### PR TITLE
Start migrating RelVal Server to the upgraded index schema.

### DIFF
--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -23,7 +23,7 @@ deploy_dqmgui_prep()
     * )
       for d in online offline caf relval dev; do
         extra="$extra $d $d/sessions $d/agents $d/data $d/uploads $d/zipped $project_logs/$d"
-	for a in clean freezer ixmerge qcontrol vcontrol register stageout verify zip; do
+	for a in clean freezer ixmerge qcontrol vcontrol register register128 stageout verify zip; do
 	  extra="$extra $d/agents/$a"
 	done
       done

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -166,8 +166,13 @@ killproc()
 
 startagent()
 {
-  local logstem=$1; shift
-  (set -x; date; exec "$@") </dev/null 2>&1 | rotatelogs $LOGDIR/$logstem-%Y%m%d.log 86400 >/dev/null 2>&1 &
+  local edition=
+  case $1 in
+    -e ) edition=$2; shift;shift
+  esac
+  local logstem=${1}; shift
+  ([ ! -z $edition ] && source $ROOT/apps/dqmgui/$edition/etc/profile.d/env.sh
+   set -x; date; exec "$@") </dev/null 2>&1 | rotatelogs $LOGDIR/$logstem-%Y%m%d.log 86400 >/dev/null 2>&1 &
 }
 
 # Start service conditionally on crond restart.
@@ -190,6 +195,9 @@ start()
       [ ! -d $STATEDIR/$cfg/ix ] && \
         (echo Creating index $STATEDIR/$cfg/ix; visDQMIndex create $STATEDIR/$cfg/ix)
       monControl start all from $CFGDIR/server-conf-$cfg.py
+      if [ ! -d $STATEDIR/$cfg/ix128 ]; then
+	(echo Creating index128 $STATEDIR/$cfg/ix128; source $ROOT/apps/dqmgui/128/etc/profile.d/env.sh; visDQMIndex create $STATEDIR/$cfg/ix128 )
+      fi
     done ;;
   esac
 
@@ -294,12 +302,23 @@ start()
         D=${D}
         CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
         DQM_DATA=$STATEDIR/$D
-        startagent $D/agent-receive \
-          visDQMReceiveDaemon \
-          $DQM_DATA/uploads \
-          $DQM_DATA/data \
-          $DQM_DATA/agents/register \
-          $DQM_DATA/agents/zip
+
+	if [ $HOST == "vocms139" ]; then
+	  startagent $D/agent-receive \
+            visDQMReceiveDaemon \
+            $DQM_DATA/uploads \
+            $DQM_DATA/data \
+            $DQM_DATA/agents/register \
+            $DQM_DATA/agents/register128 \
+            $DQM_DATA/agents/zip
+	else
+	  startagent $D/agent-receive \
+            visDQMReceiveDaemon \
+            $DQM_DATA/uploads \
+            $DQM_DATA/data \
+            $DQM_DATA/agents/register \
+            $DQM_DATA/agents/zip
+	fi
 
         startagent $D/agent-zip \
           visDQMZipDaemon \
@@ -349,6 +368,14 @@ start()
             $DQM_DATA/agents/ixmerge \
             $DQM_DATA/ix \
             $DQM_DATA/agents/register
+
+	if [ $HOST == "vocms139" ]; then
+	  startagent -e 128 $D/agent-import-128 \
+	    visDQMImportDaemon \
+	    $DQM_DATA/agents/register128 \
+	    $DQM_DATA/data \
+	    $DQM_DATA/ix128
+	fi
 
         if [ $D = offline ]; then
           startagent $D/agent-osync \


### PR DESCRIPTION
Ciao Diego, all,
I updated the deploy and manage script to be able to start migrating the RelVal Server to the upgraded index schema.
In particular the deploy script will create an additional directory (register128, for all servers) which is meant to be the entry point for all the root files that have to be registered in the upgraded index.

The manage script has been updated to:
1. create the new ix128 index directory with the upgraded schema: this is mandatory, since old and new schema are not compatible. The new directory will be created under state/dqmgui only for the relval flavor;
2. add the register128 to the list of dropboxes, so that all files that are uploaded to the RelVal server after the upgrade will be registered both in the old and in the upgraded index. This guarantees that we have perfect compatibility between the two, w/o holes in between;
3. add a new agent that will index/add the root files to the upgraded ix128 directory.

No new instance of the RelVal server will be started, i.e. the only running server will still use the old index. I do not want to have 2 servers with different configs/indexes running at the same time: once the transition is over, I'll pull another patch to move the RelVal server to the upgraded configuration.

This _must_ be used together with version 1.89 of dqmgui.spec, which:
1. pack both schemas in one unique RPM;
2. use the migrated git repo for the DQM GUI.

I'm fully available for clarifications.

Thanks a lot!
Ciao,
Marco.
