### PR TITLE
Modify tier0 manage script for wmagent/wmcore rpm merge.

### DIFF
--- a/tier0/manage
+++ b/tier0/manage
@@ -179,7 +179,10 @@ print_settings(){
 #
 . $ROOT_DIR/apps/t0/etc/profile.d/init.sh
 
-export WMCORE_ROOT
+export WMAGENT_ROOT
+# WMAGENT_ROOT == WMCORE_ROOT now but in old rpms WMCORE_ROOT was seperate,
+# if WMCORE_ROOT already set export it, else set to WMAGENT_ROOT
+export WMCORE_ROOT=${WMCORE_ROOT:-$WMAGENT_ROOT}
 export YUI_ROOT
 
 #


### PR DESCRIPTION
wmcore\* rpms will be merged into wmagent rpm. Modify tier0 manage script to work with both old and new rpm structure.
