### PR TITLE
Adding _an_reqmgr and _an_workqueue user for specific analysis services

### DIFF
--- a/an_reqmgr/ReqMgrConfig.py
+++ b/an_reqmgr/ReqMgrConfig.py
@@ -1,0 +1,59 @@
+import thread
+thread.stack_size(128*1024)
+
+import socket
+import re
+import WMCore.HTTPFrontEnd.RequestManager.ReqMgrConfiguration as ReqMgrConfig
+__all__ = []
+from WMCore.WMInit import getWMBASE
+import os.path
+INSTALL = getWMBASE()
+
+HOST = socket.getfqdn().lower()
+COUCH = "https://%s/couchdb" % HOST
+ADD_MONITOR_FLAG = False
+
+if re.match(r"^vocms(?:10[67]|13[689]|140|16[13])\.cern\.ch$", HOST):
+  COUCH = "https://cmsweb.cern.ch/couchdb"
+elif re.match(r"^vocms(?:13[23])\.cern\.ch$", HOST):
+  COUCH = "https://cmsweb-testbed.cern.ch/couchdb"
+elif re.match(r"^vocms127\.cern\.ch$", HOST):
+  COUCH = "https://cmsweb-dev.cern.ch/couchdb"
+
+config = ReqMgrConfig.reqMgrConfig(installation=INSTALL,
+                                   couchurl=COUCH,
+                                   addMonitor=ADD_MONITOR_FLAG,
+                                   port=8245,
+                                   reqMgrHost="http://%s:%d" % (socket.gethostname().lower(), 8245),
+                                   configCouchDB='analysis_reqmgr_config_cache',
+                                   workloadCouchDB='analysis_reqmgr_workload_cache',
+                                   workloadSummaryCouchDB = "analysis_workloadsummary",
+                                   wmstatCouchDB = "analysis_wmstats")
+
+TEMPLATES = os.path.normpath(os.path.join(INSTALL, '../../../data/templates/WMCore/WebTools'))
+JAVASCRIPT_PATH = os.path.normpath(os.path.join(INSTALL, '../../../data/javascript'))
+HTML_PATH = os.path.normpath(os.path.join(INSTALL, '../../../data/html'))
+
+config.webapp_("an_reqmgr")
+config.an_reqmgr.html = os.path.join(HTML_PATH, 'RequestManager')
+config.an_reqmgr.templates = os.path.join(TEMPLATES, 'RequestManager')
+
+if ADD_MONITOR_FLAG:
+    config.an_reqmgr.views.active.GlobalMonitor.templates = os.path.join(TEMPLATES, 'GlobalMonitor')
+    config.an_reqmgr.views.active.GlobalMonitor.javascript = JAVASCRIPT_PATH
+    config.an_reqmgr.views.active.GlobalMonitor.html = HTML_PATH
+    config.an_reqmgr.views.active.monitorSvc.templates = TEMPLATES
+    config.an_reqmgr.views.active.monitorSvc.serviceURL = "local"
+
+config.an_reqmgr.views.active.assign.opshold = False
+config.an_reqmgr.views.active.reqMgr.html = os.path.join(HTML_PATH, 'RequestManager')
+config.an_reqmgr.views.active.reqMgr.templates = TEMPLATES
+config.an_reqmgr.views.active.rest.templates = TEMPLATES
+config.an_reqmgr.security_roles.extend(['facops', 'FacOps'])
+
+config.component_('SecurityModule')
+config.SecurityModule.key_file = "%s/auth/wmcore-auth/header-auth-key" % __file__.rsplit('/', 3)[0]
+#config.Webtools.environment = 'development'
+config.Webtools.proxy_base = 'True'
+config.Webtools.thread_pool = 30
+config.Webtools.environment = 'production'

--- a/an_reqmgr/deploy
+++ b/an_reqmgr/deploy
@@ -1,0 +1,117 @@
+# vim: set ft=sh sw=2 ts=8 et :
+deploy_an_reqmgr_variants="default prod preprod dev offsite"
+
+deploy_an_reqmgr_deps()
+{
+  deploy backend
+  deploy wmcore-auth
+  case $variant in
+    offsite )
+      deploy couchdb offsite
+      deploy wmcore ;;
+    * )
+      deploy couchdb ;;
+  esac
+}
+
+deploy_an_reqmgr_prep()
+{
+  case $variant in offsite ) extra=install ;; * ) extra= ;; esac
+  mkproj $extra
+}
+
+deploy_an_reqmgr_sw()
+{
+  case $variant in
+    offsite )
+      deploy_pkg comp external+cherrypy
+      deploy_pkg comp external+py2-cheetah
+      deploy_pkg comp external+py2-openid
+      deploy_pkg comp external+py2-cjson
+      deploy_pkg comp cms+dls-client
+      deploy_pkg comp cms+dbs-client
+
+      local wmcore_etc=$root/current/apps/wmcore/etc
+      local couchdb_ini=$root/current/config/couchdb/local.ini
+      local mysql_config=$root/current/config/mysql/my.cnf
+
+      # get manage script from wmcore
+      cp $wmcore_etc/deploy/wmagent-manage $project_config/manage
+
+      # override the webtools couch config
+      cp $wmcore_etc/deploy/wmagent-couch.ini $couchdb_ini
+      perl -p -i -e "s{deploy_project_root}{$root/projects}g" $couchdb_ini
+
+      # grab the WMAgent MySQL config
+      cp $wmcore_etc/deploy/wmagent-mysql.cnf $mysql_config
+      ;;
+    * )
+      case $variant in prod ) secrets= ;; preprod ) secrets=Preprod ;; * ) secrets=Dev ;; esac
+      deploy_pkg \
+        -a dmwm-service-cert.pem:wmcore/dmwm-service-cert.pem \
+        -a dmwm-service-key.pem:wmcore/dmwm-service-key.pem \
+        -a ReqMgrSecrets.py:an_reqmgr/ReqMgrSecrets${secrets}.py comp cms+an_reqmgr
+
+      if grep -rq "replace me" $project_auth; then
+        note "WARNING: replace certificates in $project_auth with real ones"
+      else :; fi
+      ;;
+  esac
+}
+
+deploy_an_reqmgr_post()
+{
+  case $host in vocms13[89] ) disable ;; * ) enable ;; esac
+
+  case $variant in
+    offsite )
+      ;;
+    * )
+      # Tell couchdb to pick up reqmgr on the next restart
+      local couchdb_config=$root/current/config/couchdb
+      local couchdb_state=$root/state/couchdb
+      local reqmgrapp=$root/current/apps/an_reqmgr
+
+      for area in stagingarea replication; do
+        rm -f $couchdb_state/$area/an_reqmgr
+        touch $couchdb_state/$area/an_reqmgr
+      done
+
+      echo "couchapp push $reqmgrapp/data/couchapps/ReqMgr" \
+           "http://localhost:5984/analysis_reqmgr_workload_cache" \
+        >> $couchdb_state/stagingarea/an_reqmgr
+      echo "couchapp push $reqmgrapp/data/couchapps/ConfigCache" \
+           "http://localhost:5984/analysis_reqmgr_config_cache" \
+        >> $couchdb_state/stagingarea/an_reqmgr
+      echo "couchapp push $reqmgrapp/data/couchapps/OpsClipboard" \
+           "http://localhost:5984/analysis_ops_clipboard" \
+        >> $couchdb_state/stagingarea/an_reqmgr
+      echo "couchapp push $reqmgrapp/data/couchapps/WorkloadSummary" \
+           "http://localhost:5984/analysis_workloadsummary" \
+        >> $couchdb_state/stagingarea/an_reqmgr
+
+      # Setup ReqMgr cronjobs
+      (mkcrontab
+       sysboot
+       case $host in
+         vocms10[67] | vocms13[2689] | vocms16[13] ) ;;
+	 * )
+           local cmd="$root/current/config/an_reqmgr/manage updateversions 'I did read documentation'"
+           $nogroups || cmd="sudo -H -u _an_reqmgr bashs -l -c \"${cmd}\""
+           echo "58 * * * * $cmd" ;;
+       esac) | crontab -
+      ;;
+  esac
+}
+
+deploy_an_reqmgr_auth()
+{
+  case $1 in
+    */*-cert.pem )
+      echo "replace me with your dmwm service certificate" ;;
+    */*-key.pem )
+      echo "replace me with your dmwm service key" ;;
+    */ReqMgrSecrets*.py )
+      echo 'connectUrl = "oracle://FOO:BAR@ZOINKS"' ;;
+  esac
+}

--- a/an_reqmgr/manage
+++ b/an_reqmgr/manage
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+##H Usage: manage ACTION [SECURITY-STRING]
+##H
+##H Available actions:
+##H   help        show this help
+##H   version     get current version of the service
+##H   status      show current service's status
+##H   sysboot     start server from crond if not running
+##H   restart     (re)start the service
+##H   start       (re)start the service
+##H   stop        stop the service
+##H
+##H For more details please refer to operations page:
+##H   https://twiki.cern.ch/twiki/bin/view/CMS/ReqMgrSystemDesign
+
+if [ $(id -un)  = cmsweb ]; then
+  echo "ERROR: please use another account" 1>&2
+  exit 1
+fi
+
+echo_e=-e bsdstart=bsdstart
+case $(uname) in Darwin )
+  md5sum() { md5 -r ${1+"$@"}; }
+  echo_e= bsdstart=start
+  ;;
+esac
+
+ME=$(basename $(dirname $0))
+TOP=$(cd $(dirname $0)/../../.. && pwd)
+ROOT=$(cd $(dirname $0)/../.. && pwd)
+CFGDIR=$(dirname $0)
+LOGDIR=$TOP/logs/$ME
+STATEDIR=$TOP/state/$ME
+CFGFILE=$CFGDIR/ReqMgrConfig.py
+AUTHDIR=$TOP/current/auth/an_reqmgr
+COLOR_OK="\\033[0;32m"
+COLOR_WARN="\\033[0;31m"
+COLOR_NORMAL="\\033[0;39m"
+
+. $ROOT/apps/$ME/etc/profile.d/init.sh
+
+export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH
+export YUI_ROOT
+export WMCORE_ROOT=$AN_REQMGR_ROOT/lib/python*/site-packages
+export REQMGR_CACHE_DIR=$STATEDIR
+export WMCORE_CACHE_DIR=$STATEDIR
+if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then
+  export X509_USER_CERT=$AUTHDIR/dmwm-service-cert.pem
+  export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem
+fi
+
+# Start service conditionally on crond restart.
+sysboot()
+{
+  if [ $(pgrep -u $(id -u) -f "Root.py.*[=]$CFGFILE" | wc -l) = 0 ]; then
+    start
+  fi
+}
+
+# Start the service.
+start()
+{
+  cd $STATEDIR
+  echo "starting $ME"
+  python -u $AN_REQMGR_ROOT/lib/python*/site-packages/WMCore/WebTools/Root.py --ini=$CFGFILE \
+    </dev/null 2>&1 | rotatelogs $LOGDIR/an_reqmgr-%Y%m%d.log 86400 >/dev/null 2>&1 &
+}
+
+# Stop the service.
+stop()
+{
+  echo "stopping $ME"
+  for PID in $(pgrep -u $(id -u) -f "Root.py.*[=]$CFGFILE" | sort -rn); do
+    PSLINE=$(ps -o pid=,$bsdstart=,args= $PID |
+             perl -n -e 'print join(" ", (split)[0..6])')
+    echo "Stopping $PID ($PSLINE):"
+    kill -9 $PID
+  done
+}
+
+# Check if the server is running.
+status()
+{
+  pid=$(pgrep -u $(id -u) -f "Root.py.*[=]$CFGFILE" | sort -n)
+  if [ X"$pid" = X ]; then
+    echo $echo_e "$ME is ${COLOR_WARN}NOT RUNNING${COLOR_NORMAL}."
+  else
+    echo $echo_e "$ME is ${COLOR_OK}RUNNING${COLOR_NORMAL}, PID" $pid
+  fi
+}
+
+# Verify the security string.
+check()
+{
+  CHECK=$(echo "$1" | md5sum | awk '{print $1}')
+  if [ $CHECK != 94e261a5a70785552d34a65068819993 ]; then
+    echo "$0: cannot complete operation, please check documentation." 1>&2
+    exit 2;
+  fi
+}
+
+# make sure the CMSSW_VERSIONS are up to date
+updateversions()
+{
+  cd $STATEDIR
+  requestDbAdmin add -c $CFGFILE -v all
+}
+
+# Main routine, perform action requested on command line.
+case ${1:-status} in
+  sysboot )
+    sysboot
+    ;;
+
+  start | restart )
+    check "$2"
+    stop
+    start
+    ;;
+
+  status )
+    status
+    ;;
+
+  stop )
+    check "$2"
+    stop
+    ;;
+
+  updateversions )
+    check "$2"
+    updateversions
+    ;;
+
+  help )
+    perl -ne '/^##H/ && do { s/^##H ?//; print }' < $0
+    ;;
+
+  version )
+    echo "$AN_REQMGR_VERSION"
+    ;;
+
+  * )
+    echo "$0: unknown action '$1', please try '$0 help' or documentation." 1>&2
+    exit 1
+    ;;
+esac

--- a/an_reqmgr/monitoring.ini
+++ b/an_reqmgr/monitoring.ini
@@ -1,0 +1,11 @@
+# Glob pattern to search for log files under the svc logs directory,
+# and the regular expression to look for in those files.
+LOG_FILES='*.log'
+LOG_ERROR_REGEX='^Traceback .most recent|\] HTTP Traceback'
+
+# Perl regex to look for the service process using ps
+PS_REGEX="Root.py.*[/]ReqMgrConfig.py"
+
+# The ping test fetches the provided URL and look for the following perl regex
+PING_URL="http://localhost:8240/reqmgr/"
+PING_REGEX=".*Welcome to the DMWM web framework.*"

--- a/an_workqueue/GlobalWorkQueueConfig-default.py
+++ b/an_workqueue/GlobalWorkQueueConfig-default.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+_GlobalWorkQueueConfig_
+
+Global WorkQueue config.
+"""
+
+import socket
+import re
+import os
+
+from WMCore.Configuration import Configuration
+
+workqueueDBName = 'analysis_workqueue'
+workqueueInboxDbName = 'analysis_workqueue_inbox'
+wmstatDBName = 'analysis_wmstats'
+HOST = socket.getfqdn().lower()
+REQMGR = "https://%s/an_reqmgr/reqMgr" % HOST
+COUCH = "https://%s/couchdb" % HOST
+TEAMS = 'Analysis'
+WEBURL = "%s/%s" % (COUCH, workqueueDBName)
+
+
+root = __file__.rsplit('/', 4)[0]
+cache_dir = os.path.join(root, 'state', 'an_workqueue', 'cache')
+os.environ['WMCORE_CACHE_DIR'] = cache_dir
+
+# Nothing after this point should need to be changed.
+config = Configuration()
+
+config.section_("Agent")
+config.Agent.hostName = HOST
+config.Agent.teamName = TEAMS
+
+config.component_("WorkQueueManager")
+config.WorkQueueManager.namespace = "WMComponent.WorkQueueManager.WorkQueueManager"
+config.WorkQueueManager.couchurl = COUCH
+config.WorkQueueManager.dbname = workqueueDBName
+config.WorkQueueManager.inboxDatabase = workqueueInboxDbName
+config.WorkQueueManager.wmstatDBName = wmstatDBName
+config.WorkQueueManager.level = "GlobalQueue"
+config.WorkQueueManager.queueParams = {'WMStatsCouchUrl': "%s/%s" % (COUCH, wmstatDBName)}
+config.WorkQueueManager.queueParams['QueueURL'] = WEBURL
+config.WorkQueueManager.reqMgrConfig = {}
+config.WorkQueueManager.reqMgrConfig['endpoint'] = REQMGR

--- a/an_workqueue/GlobalWorkQueueConfig-dev.py
+++ b/an_workqueue/GlobalWorkQueueConfig-dev.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+_GlobalWorkQueueConfig_
+
+Global cmsweb-dev WorkQueue config.
+"""
+
+import socket
+import re
+import os
+
+from WMCore.Configuration import Configuration
+
+workqueueDBName = 'analysis_workqueue'
+workqueueInboxDbName = 'analysis_workqueue_inbox'
+wmstatDBName = 'analysis_wmstats'
+HOST = "cmsweb-dev.cern.ch"
+REQMGR = "https://cmsweb-dev.cern.ch/an_reqmgr/reqMgr"
+COUCH = "https://cmsweb-dev.cern.ch/couchdb"
+TEAMS = 'Analysis'
+WEBURL = "%s/%s" % (COUCH, workqueueDBName)
+
+
+root = __file__.rsplit('/', 4)[0]
+cache_dir = os.path.join(root, 'state', 'an_workqueue', 'cache')
+os.environ['WMCORE_CACHE_DIR'] = cache_dir
+
+# Nothing after this point should need to be changed.
+config = Configuration()
+
+config.section_("Agent")
+config.Agent.hostName = HOST
+config.Agent.teamName = TEAMS
+
+config.component_("WorkQueueManager")
+config.WorkQueueManager.namespace = "WMComponent.WorkQueueManager.WorkQueueManager"
+config.WorkQueueManager.couchurl = COUCH
+config.WorkQueueManager.dbname = workqueueDBName
+config.WorkQueueManager.inboxDatabase = workqueueInboxDbName
+config.WorkQueueManager.wmstatDBName = wmstatDBName
+config.WorkQueueManager.level = "GlobalQueue"
+config.WorkQueueManager.queueParams = {'WMStatsCouchUrl': "%s/%s" % (COUCH, wmstatDBName)}
+config.WorkQueueManager.queueParams['QueueURL'] = WEBURL
+config.WorkQueueManager.reqMgrConfig = {}
+config.WorkQueueManager.reqMgrConfig['endpoint'] = REQMGR

--- a/an_workqueue/GlobalWorkQueueConfig-preprod.py
+++ b/an_workqueue/GlobalWorkQueueConfig-preprod.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""
+_GlobalWorkQueueConfig_
+
+Global cmsweb-testbed WorkQueue config.
+"""
+
+import socket
+import re
+import os
+
+from WMCore.Configuration import Configuration
+
+workqueueDBName = 'analysis_workqueue'
+workqueueInboxDbName = 'analysis_workqueue_inbox'
+wmstatDBName = 'analysis_wmstats'
+HOST = "cmsweb-testbed.cern.ch"
+REQMGR = "https://cmsweb-testbed.cern.ch/an_reqmgr/reqMgr"
+COUCH = "https://cmsweb-testbed.cern.ch/couchdb"
+#TODO bettere understand how to handle teams for testbed in the analysis use case
+#TEAMS = 'testbed-dataops,testbed-dmwm,testbed-integration,testbed-processing,testbed-production,testbed-relval,testbed-analysis,testbed-t1,testbed-t1_highprio,testbed-mc,testbed-mc_highprio'
+WEBURL = "%s/%s" % (COUCH, workqueueDBName)
+PHEDEX = "https://cmsweb-testbed.cern.ch/phedex/datasvc/json/prod/"
+
+root = __file__.rsplit('/', 4)[0]
+cache_dir = os.path.join(root, 'state', 'an_workqueue', 'cache')
+os.environ['WMCORE_CACHE_DIR'] = cache_dir
+
+# Nothing after this point should need to be changed.
+config = Configuration()
+
+config.section_("Agent")
+config.Agent.hostName = HOST
+config.Agent.teamName = TEAMS
+
+config.component_("WorkQueueManager")
+config.WorkQueueManager.namespace = "WMComponent.WorkQueueManager.WorkQueueManager"
+config.WorkQueueManager.couchurl = COUCH
+config.WorkQueueManager.dbname = workqueueDBName
+config.WorkQueueManager.inboxDatabase = workqueueInboxDbName
+config.WorkQueueManager.wmstatDBName = wmstatDBName
+config.WorkQueueManager.level = "GlobalQueue"
+config.WorkQueueManager.queueParams = {'WMStatsCouchUrl': "%s/%s" % (COUCH, wmstatDBName)}
+config.WorkQueueManager.queueParams['PhEDExEndpoint'] = PHEDEX
+config.WorkQueueManager.queueParams['QueueURL'] = WEBURL
+config.WorkQueueManager.reqMgrConfig = {}
+config.WorkQueueManager.reqMgrConfig['endpoint'] = REQMGR

--- a/an_workqueue/GlobalWorkQueueConfig-prod.py
+++ b/an_workqueue/GlobalWorkQueueConfig-prod.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""
+_GlobalWorkQueueConfig_
+
+Global cmsweb WorkQueue config.
+"""
+
+import socket
+import re
+import os
+
+from WMCore.Configuration import Configuration
+
+workqueueDBName = 'analysis_workqueue'
+workqueueInboxDbName = 'analysis_workqueue_inbox'
+wmstatDBName = 'analysis_wmstats'
+HOST = "cmsweb.cern.ch"
+REQMGR = "https://cmsweb.cern.ch/an_reqmgr/reqMgr"
+COUCH = "https://cmsweb.cern.ch/couchdb"
+TEAMS = 'Analysis'
+#TODO need to bettere understand how to handle teams for the analysis use case
+#dataops,dmwm,integration,processing,production,relval,analysis,t1,t1_highprio,mc,mc_highprio'
+WEBURL = "%s/%s" % (COUCH, workqueueDBName)
+
+
+root = __file__.rsplit('/', 4)[0]
+cache_dir = os.path.join(root, 'state', 'an_workqueue', 'cache')
+os.environ['WMCORE_CACHE_DIR'] = cache_dir
+
+# Nothing after this point should need to be changed.
+config = Configuration()
+
+config.section_("Agent")
+config.Agent.hostName = HOST
+config.Agent.teamName = TEAMS
+
+config.component_("WorkQueueManager")
+config.WorkQueueManager.namespace = "WMComponent.WorkQueueManager.WorkQueueManager"
+config.WorkQueueManager.couchurl = COUCH
+config.WorkQueueManager.dbname = workqueueDBName
+config.WorkQueueManager.wmstatDBName = wmstatDBName
+config.WorkQueueManager.inboxDatabase = workqueueInboxDbName
+config.WorkQueueManager.level = "GlobalQueue"
+config.WorkQueueManager.queueParams = {'WMStatsCouchUrl': "%s/%s" % (COUCH, wmstatDBName)}
+config.WorkQueueManager.queueParams['QueueURL'] = WEBURL
+config.WorkQueueManager.reqMgrConfig = {}
+config.WorkQueueManager.reqMgrConfig['endpoint'] = REQMGR

--- a/an_workqueue/an_workqueue_task
+++ b/an_workqueue/an_workqueue_task
@@ -1,0 +1,120 @@
+#!/bin/sh
+
+##H Usage: manage ACTION [SECURITY-STRING]
+##H
+##H Available actions:
+##H   help                       show this help
+##H   version                    get current version of the service
+##H   location_refresh           refresh location info for input data
+##H   reqmgr_sync                sync with RequsetManager (get requests & report back)
+##H   housekeep                  perform internal housekeeping actions
+##H   pushcouchapp <couchdb url> push workqueue couchapp to couchdb
+##H
+##H For more details please refer to operations page:
+##H   https://twiki.cern.ch/twiki/bin/view/CMS/GlobalWorkQueue
+
+if [ $(id -un)  = cmsweb ]; then
+  echo "ERROR: please use another account" 1>&2
+  exit 1
+fi
+
+ME=$(basename $(dirname $0))
+TOP=$(cd $(dirname $0)/../../.. && pwd)
+ROOT=$(cd $(dirname $0)/../.. && pwd)
+CFGDIR=$(dirname $0)
+LOGDIR=$TOP/logs/$ME
+STATEDIR=$TOP/state/$ME
+CFGFILE=$CFGDIR/GlobalWorkQueueConfig.py
+AUTHDIR=$TOP/current/auth/an_workqueue
+
+. $ROOT/apps/$ME/etc/profile.d/init.sh
+export AN_WORKQUEUE_ROOT
+export WMCORE_ROOT=$AN_WORKQUEUE_ROOT
+export YUI_ROOT
+export WMAGENT_CONFIG=${CFGFILE}
+export WQ_CLI="${AN_WORKQUEUE_ROOT}/bin/wmagent-workqueue"
+logcmd="rotatelogs $LOGDIR/an_workqueue-%Y%m%d.log 86400 2>&1"
+
+# Verify the security string.
+check()
+{
+  CHECK=$(echo "$1" | md5sum | awk '{print $1}')
+  if [ $CHECK != 94e261a5a70785552d34a65068819993 ]; then
+    echo "$0: cannot complete operation, please check documentation." 1>&2
+    exit 2;
+  fi
+}
+
+# check for a service certificate to use
+add_cert()
+{
+  if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then
+    export X509_USER_CERT=$AUTHDIR/dmwm-service-cert.pem
+    export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem
+  fi
+}
+
+run()
+{
+  if [ $(pgrep -u $(id -u) -f "${WQ_CLI} $1" | wc -l) = 0 ]; then
+    cd $STATEDIR
+    ${WQ_CLI} $@
+  else
+    echo "Another process of ${WQ_CLI} is still running. Skipping."
+    exit 4
+  fi
+}
+
+# Main routine, perform action requested on command line.
+case ${1:-status} in
+  help )
+    perl -ne '/^##H/ && do { s/^##H ?//; print }' < $0
+    ;;
+
+  version )
+    echo ${WORKQUEUE_VERSION:-unknown}
+    ;;
+
+  location_refresh )
+    # PHEDEX cant handle proxy certs yet...
+    add_cert
+    run --locations 2>&1 | $logcmd
+    ;;
+
+  reqmgr_sync )
+    cd $STATEDIR
+    add_cert
+    run --reqmgr 2>&1 | $logcmd
+    ;;
+
+  housekeep )
+    cd $STATEDIR
+    add_cert
+    run --clean 2>&1 | $logcmd
+    ;;
+
+  interactive )
+    cd $STATEDIR
+    add_cert
+    ${WQ_CLI} -i
+    ;;
+
+  pushcouchapp )
+    url=$2
+    [ -n "$url" ] ||
+    { echo "You must specify the couchdb url"; exit 1; }
+
+    # need to use localhost interface to get admin role to allow push
+    file=$(python -c 'import tempfile as t; print t.mkstemp(suffix = ".py")[1]')
+    cat ${WMAGENT_CONFIG} > ${file}
+    perl -p -i -e "s{config.WorkQueueManager.couchurl.*}{config.WorkQueueManager.couchurl = \"$url\"}g" ${file}
+    WMAGENT_CONFIG=${file}
+    wmagent-couchapp-init --skip-cron
+    rm -f ${file}
+    ;;
+
+  * )
+    echo "$0: unknown action '$1', please try '$0 help' or documentation." 1>&2
+    exit 1
+    ;;
+esac

--- a/an_workqueue/deploy
+++ b/an_workqueue/deploy
@@ -1,0 +1,89 @@
+# vim: set ft=sh sw=2 ts=8 et :
+deploy_an_workqueue_variants="default prod preprod dev"
+
+deploy_an_workqueue_deps()
+{
+  deploy couchdb
+}
+
+deploy_an_workqueue_prep()
+{
+  mkproj cache
+}
+
+deploy_an_workqueue_sw()
+{
+  deploy_pkg \
+    -a dmwm-service-cert.pem:wmcore/dmwm-service-cert.pem \
+    -a dmwm-service-key.pem:wmcore/dmwm-service-key.pem \
+    comp cms+an_workqueue
+
+  if grep -rq "replace me" $project_auth; then
+    note "WARNING: replace certificates in $project_auth with real ones"
+  else :; fi
+
+  cp -p $project_config/GlobalWorkQueueConfig-${variant}.py $project_config/GlobalWorkQueueConfig.py
+}
+
+deploy_an_workqueue_post()
+{
+  # Do cache cleanup
+  local cmd="rm -rf $root/state/an_workqueue/cache/*"
+  $nogroups || cmd="sudo -H -u _an_workqueue bashs -l -c \"${cmd}\""
+  eval $cmd
+
+  # Tell couchdb to push an_workqueue apps on the next restart
+  local manage=$root/current/config/an_workqueue/an_workqueue_task
+  local couchdb_config=$root/current/config/couchdb
+  local couchdb_state=$root/state/couchdb
+  local couch_url="http://localhost:5984"
+
+  for area in stagingarea replication; do
+    rm -f $couchdb_state/$area/an_workqueue
+    touch $couchdb_state/$area/an_workqueue
+  done
+
+  # push app
+  echo "$project_config/an_workqueue_task pushcouchapp $couch_url" \
+      >> $couchdb_state/stagingarea/an_workqueue
+
+  for db in analysis_workqueue analysis_workqueue_inbox; do
+    # clean views on startup
+    echo "$couchdb_config/manage cleanviews $db 'I did read documentation'" \
+      >> $couchdb_state/stagingarea/an_workqueue
+  done
+
+  # Setup an_workqueue cronjobs
+  local cmd="$manage reqmgr_sync"
+  $nogroups || cmd="sudo -H -u _an_workqueue bashs -l -c \"${cmd}\""
+  local req_sync="5-45/20 * * * * $cmd"
+
+  local cmd="$manage location_refresh"
+  $nogroups || cmd="sudo -H -u _an_workqueue bashs -l -c \"${cmd}\""
+  local locations="30 * * * * $cmd"
+
+  local cmd="$manage housekeep"
+  $nogroups || cmd="sudo -H -u _an_workqueue bashs -l -c \"${cmd}\""
+  local housekeep="15-55/20 * * * * $cmd"
+
+  (mkcrontab;
+   case $host in
+     vocms10[67] | vocms13[2689] | vocms16[13])
+       ;;
+     * )
+       echo "${req_sync}"
+       echo "${locations}"
+       echo "${housekeep}"
+       ;;
+   esac) | crontab -
+}
+
+deploy_an_workqueue_auth()
+{
+  case $1 in
+    */*-cert.pem )
+      echo "replace me with your dmwm service certificate" ;;
+    */*-key.pem )
+      echo "replace me with your dmwm service key" ;;
+  esac
+}

--- a/an_workqueue/monitoring.ini
+++ b/an_workqueue/monitoring.ini
@@ -1,0 +1,12 @@
+ENABLE_IF='is_enabled("couchdb")'
+
+# Glob pattern to search for log files under the svc logs directory,
+# and the regular expression to look for in those files.
+LOG_FILES='*.log'
+
+LOG_ERROR_REGEX='(Traceback|Exception|Backtrace|CRITICAL|PostMortem|ERROR)'
+
+# The ping test fetches the provided URL and look for the following perl regex
+PING_URL="http://localhost:5984/workqueue/_design/WorkQueue/_rewrite/_show/status/task_activity"
+# If no task reports an error everything is ok (assumes dot matches newline)
+PING_REGEX="\A(?!.*ERROR).*\Z"

--- a/crabserver/config.py
+++ b/crabserver/config.py
@@ -47,8 +47,8 @@ else:
     data.reqmgrurl = 'https://%s/couchdb' % HOST
 data.monname = 'analysis_wmstats'
 data.asomonname = 'user_monitoring_asynctransfer'
-data.configcachename = 'reqmgr_config_cache'
-data.reqmgrname = 'reqmgr_workload_cache'
+data.configcachename = 'analysis_reqmgr_config_cache'
+data.reqmgrname = 'analysis_reqmgr_workload_cache'
 data.phedexurl = 'https://cmsweb.cern.ch/phedex/datasvc/xml/prod/'
 data.dbsurl = 'http://cmsdbsprod.cern.ch/cms_dbs_prod_global/servlet/DBSServlet'
 

--- a/frontend/app_an_reqmgr_nossl.conf
+++ b/frontend/app_an_reqmgr_nossl.conf
@@ -1,0 +1,1 @@
+RewriteRule ^(/an_reqmgr(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]

--- a/frontend/app_an_reqmgr_ssl.conf
+++ b/frontend/app_an_reqmgr_ssl.conf
@@ -1,0 +1,2 @@
+RewriteRule ^(/an_reqmgr(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
+RewriteRule ^/auth/complete(/an_reqmgr(/.*)?)$ http://%{ENV:BACKEND}:8245${escape:$1} [QSA,P,L,NE]

--- a/frontend/app_an_workqueue_nossl.conf
+++ b/frontend/app_an_workqueue_nossl.conf
@@ -1,0 +1,1 @@
+RewriteRule ^(/an_workqueue(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]

--- a/frontend/app_an_workqueue_ssl.conf
+++ b/frontend/app_an_workqueue_ssl.conf
@@ -1,0 +1,2 @@
+RewriteRule ^(/an_workqueue(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
+RewriteRule ^/auth/complete/an_workqueue(/.*)?$ http://%{ENV:BACKEND}:5984/an_workqueue/_design/WorkQueue/_rewrite${escape:$1} [QSA,P,L,NE]

--- a/system/deploy
+++ b/system/deploy
@@ -106,7 +106,7 @@ system_groups_and_accounts()
             T:100031:_t0mon     T:100032:_mongodb     T:100033:_reqmgr     \
             T:100034:_workqueue T:100035:_configcache T:100037:_t0datasvc  \
             T:100038:_reqmon    T:100039:_crabserver  T:100040:_crabcache  \
-            T:100041:_dmwmmon; do
+            T:100041:_dmwmmon   T:100042:_an_reqmgr   T:100043:_an_workqueue; do
     add_local_group $(echo $ng | tr : " ")
   done
 
@@ -135,6 +135,8 @@ system_groups_and_accounts()
   add_local_user 100039 _crabserver  ,_config "CRABServer App"
   add_local_user 100040 _crabcache   ,_config "CRABCache App"
   add_local_user 100041 _dmwmmon     ,_config "DMWMMon App"
+  add_local_user 100042 _an_reqmgr   ,_config "ReqMgr App for Analysis"
+  add_local_user 100043 _an_workqueue ,_config "WorkQueue App for Analysis"
 
   # Restart nscd to flush account changes. Current account will _not_
   # see these changes before logout/login however, so commands below
@@ -289,7 +291,7 @@ deploy_system_post()
       for g in _config _sw _auth _frontend _admin _base _couchdb _das _dbs \
                _dqmgui _filemover _overview _phedex _sitedb _t0mon \
                _mongodb _reqmgr _workqueue _configcache _t0datasvc _reqmon \
-               _crabserver _crabcache _dmwmmon; do
+               _crabserver _crabcache _dmwmmon _an_reqmgr _an_workqueue; do
         case " $G " in *" $g "* ) ;; * ) note "ERROR: no $g group"; exit 1;; esac
       done
 


### PR DESCRIPTION
Signed-off-by: cinquo m.cinquilli@gmail.com

Hi Diego

This includes the dedicated an_reqmgr and an_workqueue.
I've chosen the prefix 'an_' in order to not have too long names for system's users and groups (I remember this comment in the past done by lassi when I was creating crab's users), and also for the service's names.

Before going to merge this to deployment I believe also Zdenek would like to have a look. I'll send more details to the webtool list.
