### PR TITLE
Adding COUCH_HOST_NAME option to WMAgent.secrets

### DIFF
--- a/wmagent/manage
+++ b/wmagent/manage
@@ -142,6 +142,7 @@ load_secrets_file(){
     local MATCH_COUCH_USER=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_USER | sed s/COUCH_USER=//`
     local MATCH_COUCH_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PASS | sed s/COUCH_PASS=//`
     local MATCH_COUCH_HOST=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_HOST | sed s/COUCH_HOST=//`
+    local MATCH_COUCH_HOST_NAME=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_HOST_NAME | sed s/COUCH_HOST_NAME=//`
     local MATCH_COUCH_PORT=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PORT | sed s/COUCH_PORT=//`
     local MATCH_COUCH_CERT_FILE=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_CERT_FILE | sed s/COUCH_CERT_FILE=//`
     local MATCH_COUCH_KEY_FILE=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_KEY_FILE | sed s/COUCH_KEY_FILE=//`
@@ -187,6 +188,7 @@ load_secrets_file(){
     fi
     COUCH_PORT=${MATCH_COUCH_PORT:-$COUCH_PORT};
     COUCH_HOST=${MATCH_COUCH_HOST:-$COUCH_HOST};
+    COUCH_HOST_NAME=${MATCH_COUCH_HOST_NAME:-$COUCH_HOST_NAME}
 
     # if couch ssl certificate not specified check X509_USER_CERT and X509_USER_PROXY
     COUCH_CERT_FILE=${MATCH_COUCH_CERT_FILE:-${X509_USER_CERT:-$X509_USER_PROXY}};
@@ -248,6 +250,7 @@ print_settings(){
     echo "COUCH_USER=                $COUCH_USER                "
     echo "COUCH_PASS=                $COUCH_PASS                "
     echo "COUCH_HOST=                $COUCH_HOST                "
+    echo "COUCH_HOST_NAME=           $COUCH_HOST_NAME           "
     echo "COUCH_PORT=                $COUCH_PORT                "
     echo "COUCH_CERT_FILE=           $COUCH_CERT_FILE           "
     echo "COUCH_KEY_FILE=            $COUCH_KEY_FILE            "


### PR DESCRIPTION
The wmagent/manage script sets COUCH_HOST_NAME to `hostname`
On a multihomed system with the full frontend deployed, this
can cause authentication errors because local processes
will try to connect via non-loopback IPs.

This change lets the admin change COUCH_HOST_NAME to
something sensible
