### PR TITLE
Prevent frontend from spuriously starting

### DIFF
--- a/frontend/update-keys
+++ b/frontend/update-keys
@@ -99,7 +99,14 @@ sub sync_keys()
 # Restart all web servers.
 sub restart_servers()
 {
-  system("sudo $srvdir/etc/httpd graceful");
+  # make sure server is running before we restart it
+  # this script is called from CRON, so it can be unexpected
+  # for the frontend to start when you turned it off
+  if (system("sudo $srvdir/etc/httpd status") == 0)
+  {
+    system("sudo $srvdir/etc/httpd graceful");
+  }
+
   foreach my $host (@hosts)
   {
     system("ssh $host sudo $srvdir/etc/httpd graceful");


### PR DESCRIPTION
The update-keys script (which is called from a cronjob) will
execute an httpd graceful to reload the keys. This is cool
except for when you actually wanted the frontend to stay off
and httpd graceful will cause httpd to start :/

This patch simply makes sure that httpd is running (via
checking httpd status) before executing the graceful. If the
server isn't started, the graceful doesn't run
