### PR TITLE
absolute-pathizing couchdb config dir

### DIFF
--- a/couchdb/manage
+++ b/couchdb/manage
@@ -32,7 +32,7 @@ esac
 ME=$(basename $(dirname $0))
 TOP=$(cd $(dirname $0)/../../.. && pwd)
 ROOT=$(cd $(dirname $0)/../.. && pwd)
-CFGDIR=$(dirname $0)
+CFGDIR=$(cd $(dirname $0) && pwd)
 LOGDIR=$TOP/logs/$ME
 STATEDIR=$TOP/state/$ME
 KEYFILE=$ROOT/auth/$ME/hmackey.ini


### PR DESCRIPTION
For some reason this didn't work when /data was a symlink
(my /data is on a bunch of fast SSDs, not on the root path)
