### PR TITLE
Request Manager 2 deployment

### DIFF
--- a/frontend/app_reqmgr2_nossl.conf
+++ b/frontend/app_reqmgr2_nossl.conf
@@ -1,0 +1,1 @@
+RewriteRule ^(/reqmgr2(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]

--- a/frontend/app_reqmgr2_ssl.conf
+++ b/frontend/app_reqmgr2_ssl.conf
@@ -1,0 +1,2 @@
+RewriteRule ^(/reqmgr2(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
+RewriteRule ^/auth/complete(/reqmgr2(/.*)?)$ http://%{ENV:BACKEND}:8246${escape:$1} [QSA,P,L,NE]

--- a/frontend/htdocs/index.html
+++ b/frontend/htdocs/index.html
@@ -25,6 +25,7 @@
             <a href="https://cms-popularity.cern.ch/">Data Popularity</a>,
             <a href="/overview/">Overview</a>,<br />
             <a href="/reqmgr/">Request Manager</a>,
+            <a href="/reqmgr2/">Request Manager 2</a>,
             <a href="/wmstats/">Request Monitor</a>,
             <a href="/workqueue/">Work Queue</a>
           </li>

--- a/reqmgr2/config-localhost.py
+++ b/reqmgr2/config-localhost.py
@@ -1,0 +1,31 @@
+"""
+deployment repository ReqMgr configuration file for localhost.
+
+Running ReqMgr2:
+run with absolute paths (DIR), problems e.g. creating PID file otherwise
+cd WMCore
+source ./setup.sh
+# repeated running restarts the server
+# state is work directory
+bin/wmc-httpd -r -d DIR -l DIR/reqmgr.log ../deployment/reqmgr2/config-localhost.py
+    
+"""
+
+import os
+
+# load main production ReqMgr2 configuration file
+deployment_dir = __file__.rsplit('/', 1)[0]
+execfile(os.path.join(deployment_dir, "config.py"))
+
+# localhost running additions, no authentication
+config.main.section_("tools")
+config.main.tools.section_("cms_auth")
+config.main.server.socket_host = "127.0.0.1"
+config.main.server.environment = "staging" # must not be "production"
+config.main.tools.cms_auth.policy = "dangerously_insecure"
+
+# go up /deployment/reqmgr2/__file__
+first_part = os.path.abspath(__file__.rsplit('/', 3)[0])
+config.views.ui.static_content_dir = os.path.join(first_part, "WMCore/src/data")
+
+config.views.resthub.couch_host = os.getenv("COUCHURL", None)

--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -1,0 +1,89 @@
+"""
+ReqMgr only configuration file.
+Everything configurable in ReqMgr is defined here.
+
+Running the ReqMgr service:
+    - run always with absolute paths, problems e.g. creating PID file otherwise
+        (relative paths did have issues when running multiple services)
+    - work directory passed to wmc-httpd script
+    - the command below can either be run on localhost manually
+        with deployment/reqmgr2/config-localhost.py passed or is run on VM
+        from the application manage script
+    bin/wmc-httpd -r -d state_dir -l log_dir/reqmgr.log DEPLOYMENT/reqmgr2/config.py
+    
+"""
+
+import re
+import socket
+
+from WMCore.Configuration import Configuration
+
+# on localhost, this value is later set in config-localhost.py
+# on VM and CMS web deployments, this value is set from the deploy
+# script. Do not fill in anything manually here.
+# The motivation is to have all vocms machine references at 1 place
+# which is in the deploy script
+COUCH_HOST = "COUCH_HOST_VALUE_PLACEHOLDER"
+
+
+config = Configuration()
+ 
+main = config.section_("main")
+srv = main.section_("server")
+srv.thread_pool = 30
+# this is a bit shady, since this name is later in WMCore.REST.Main
+# cfg.main.application.lower() L:491 and has to agree with 
+# app = config.section_("reqmgr2"), otherwise configuration validation fails
+main.application = "reqmgr2"
+# main application port it listens on
+main.port = 8246
+main.index = "resthub"
+
+# TODO/NOTE:
+# defined in the ReqMgr1 configuration, HTTPFrontEnd/RequestManager/ReqMgrConfiguration.py
+# probably not necessary, to be fetched from SiteDB
+# config.reqmgr.security_roles = ['Admin', 'Developer', 'Data Manager', 'developer', 'admin', 'data-manager']        
+main.authz_defaults = {"role": None, "group": None, "site": None}
+sec = main.section_("tools").section_("cms_auth")
+sec.key_file = "%s/auth/wmcore-auth/header-auth-key" % __file__.rsplit('/', 3)[0]
+
+# this is where the application will be mounted, where the REST API
+# is reachable and this features in CMS web frontend rewrite rules
+app = config.section_(main.application) # string containing "reqmgr2"
+#app.admin = "cms-service-webtools@cern.ch"
+app.admin = "zdenek.maxa@cern.ch"
+app.description = "CMS data operations Request Manager."
+app.title = "CMS Request Manager (ReqMgr)"        
+
+views = config.section_("views")
+
+# redirector for the REST API implemented handlers
+resthub = views.section_("resthub")
+resthub.object = "WMCore.ReqMgr.service.hub.Hub"
+resthub.couch_host = COUCH_HOST
+# practical to have this kind of configuration values not in
+# service related RPM (difficult/impossible to change in CMS web
+# deployment) but in the deployment configuration for the service 
+resthub.sitedb_url = "https://cmsweb.cern.ch/sitedb/json/index/CEtoCMSName?name"
+# main ReqMgr CouchDB database containing all requests with spec files attached
+resthub.couch_reqmgr_db = "reqmgr_workload_cache"
+# ConfigCache - database with configuration documents
+resthub.couch_config_cache_db = "reqmgr_config_cache"
+resthub.couch_workload_summary_db = "workloadsummary"
+resthub.couch_wmstats_db = "wmstats" 
+# number of past days since when to display requests in the default view
+resthub.default_view_requests_since_num_days = 30 # days
+"""
+TODO:
+- add info on meta-data database in couch (request states, teams, etc)
+- add url to fetch users, roles, groups from sitedb (if necessary)
+- add information about caching and page expiration
+- active.create.cmsswDefaultVersion = 'CMSSW_5_2_5' should be configurable this way?
+    (it's indeed used on the web GUI request create page)
+"""
+resthub.tag_collector_url = "https://cmstags.cern.ch/tc/ReleasesXML/?anytype=1"
+
+# web user interface
+ui = views.section_("ui")
+ui.object = "WMCore.ReqMgr.webgui.frontpage.FrontPage"
+ui.static_content_dir = "/data/current/apps/%s/data" % main.application

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -1,0 +1,142 @@
+# vim: set ft=sh sw=2 ts=8 et :
+deploy_reqmgr2_variants="default prod preprod dev"
+
+
+# this function overwrites line
+# COUCH_HOST = "COUCH_HOST_VALUE_PLACEHOLDER"
+# in the configuration file config.py
+set_couch_host_value()
+{
+	case $variant in
+		prod )
+			couch_host="https://cmsweb.cern.ch/couchdb"
+		;;
+		preprod )
+			couch_host="https://cmsweb-testbed.cern.ch/couchdb"
+		;;
+		dev )
+			couch_host="https://cmsweb-dev.cern.ch/couchdb"
+		;;
+		* )
+			# e.g. VM installation
+			couch_host="https://`hostname -f`/couchdb"
+		;;
+	esac
+	
+	config_file="$root/current/config/reqmgr2/config.py"
+	perl -p -i -e "s{COUCH_HOST_VALUE_PLACEHOLDER}{$couch_host}g" $config_file
+}
+
+
+deploy_reqmgr2_deps()
+{
+	set_couch_host_value
+	# backend is light stuff that sets up wmcore hmac key for authentication
+  	deploy backend
+  	deploy wmcore-auth
+	deploy couchdb
+	deploy reqmon
+	# Always deploy ReqMgr1 along with ReqMgr2. ReqMgr1 will take care of
+    # creating CouchDB databases and pushing couchapps. Have to make sure
+    # during deployment that ReqMgr1 and ReqMgr2 are using the same tag,
+    # otherwise the ReqMgr2 couchapps (which are also shared) would be pulled
+  	# from ReqMgr1 tag.
+  	# This means that couchapps installation is not present here and during
+  	# migration to ReqMgr2 only will be taken from ReqMgr1 deploy script.
+  	deploy reqmgr
+}
+
+deploy_reqmgr2_prep()
+{
+  	mkproj
+}
+
+deploy_reqmgr2_sw()
+{
+	case $variant in
+    	* )
+      		case $variant in 
+      			prod ) 
+      				secrets=
+      			;; 
+      			preprod )
+      				secrets=Preprod
+      			;;
+      			* )
+      			 	secrets=Dev
+      			;;
+      		esac
+      		deploy_pkg \
+        		-a dmwm-service-cert.pem:wmcore/dmwm-service-cert.pem \
+        		-a dmwm-service-key.pem:wmcore/dmwm-service-key.pem \
+        	comp cms+reqmgr2
+
+      		if grep -rq "replace me" $project_auth; then
+        		note "WARNING: replace certificates in $project_auth with real ones"
+      		else :; fi
+    	;;
+  	esac
+}
+
+deploy_reqmgr2_post()
+{
+	case $host in
+   		vocms13[89] )
+   			disable
+   		;;
+   		* ) 
+   			enable 
+   		;;
+   	esac
+   		
+	# Start of the CouchDB deployment settings 
+    # Tell couchdb to pick up reqmgr on the next restart
+	# All below present in the ReqMgr1 deploy script
+	#local couchdb_config=$root/current/config/couchdb
+	#local couchdb_state=$root/state/couchdb
+	#local reqmgr2app=$root/current/apps/reqmgr2
+
+  	#for area in stagingarea replication; do
+    #  rm -f $couchdb_state/$area/reqmgr2
+    #  touch $couchdb_state/$area/reqmgr2
+	#done
+
+	#echo "couchapp push $reqmgr2app/data/couchapps/ReqMgr" \
+	#     "http://localhost:5984/reqmgr_workload_cache" \
+	#  >> $couchdb_state/stagingarea/reqmgr2
+	#echo "couchapp push $reqmgr2app/data/couchapps/ConfigCache" \
+	#     "http://localhost:5984/reqmgr_config_cache" \
+	#  >> $couchdb_state/stagingarea/reqmgr2
+	# End of the CouchDB deployment settings
+
+ 	# Setup reqmgr2 cronjobs
+  	(mkcrontab
+  		sysboot
+  		case $host in 
+  			vocms10[67] | vocms13[2689] | vocms16[13] )
+  			;;
+  			* )
+   				# TODO
+			   	# currently no cronjobs for ReqMgr2
+			   	# this is placeholder
+			   	# this command is from ReqMgr2
+			   	#local cmd="$project_config/manage updateversions 'I did read documentation'"
+			   	local cmd="ls -l /tmp"
+			   	$nogroups || cmd="sudo -H -u _reqmgr2 bashs -l -c \"${cmd}\""
+			   	echo "58 * * * * $cmd"
+			;;
+		esac) | crontab -
+}
+
+
+deploy_reqmgr2_auth()
+{
+	case $1 in
+		*/*-cert.pem )
+			echo "replace me with your dmwm service certificate"
+		;;
+    	*/*-key.pem )
+    		echo "replace me with your dmwm service key"
+    	;;
+  	esac
+}

--- a/reqmgr2/manage
+++ b/reqmgr2/manage
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+##H Usage: manage ACTION [SECURITY-STRING]
+##H
+##H Available actions:
+##H   help        show this help
+##H   version     get current version of the service
+##H   status      show current service's status
+##H   sysboot     start server from crond if not running
+##H   restart     (re)start the service
+##H   start       (re)start the service
+##H   stop        stop the service
+##H
+##H For more details please refer to operations page:
+##H   https://twiki.cern.ch/twiki/bin/view/CMS/ReqMgrSystemDesign
+##H [nice, obsolete twiki, leave for reference and example ...]
+
+if [ $(id -un)  = cmsweb ]; then
+	echo "ERROR: please use another account" 1>&2
+	exit 1
+fi
+
+echo_e=-e bsdstart=bsdstart
+case $(uname) in 
+	Darwin )
+		md5sum() { md5 -r ${1+"$@"}; }
+  		echo_e= bsdstart=start
+  	;;
+esac
+
+ME=$(basename $(dirname $0))
+TOP=$(cd $(dirname $0)/../../.. && pwd)
+ROOT=$(cd $(dirname $0)/../.. && pwd)
+CFGDIR=$(dirname $0)
+LOGDIR=$TOP/logs/$ME
+STATEDIR=$TOP/state/$ME
+CFGFILE=$CFGDIR/config.py
+AUTHDIR=$TOP/current/auth/reqmgr2
+COLOR_OK="\\033[0;32m"
+COLOR_WARN="\\033[0;31m"
+COLOR_NORMAL="\\033[0;39m"
+
+. $ROOT/apps/$ME/etc/profile.d/init.sh
+
+export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH
+export WMCORE_ROOT=$REQMGR_ROOT/lib/python*/site-packages
+export REQMGR_CACHE_DIR=$STATEDIR
+export WMCORE_CACHE_DIR=$STATEDIR
+if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then
+	export X509_USER_CERT=$AUTHDIR/dmwm-service-cert.pem
+	export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem
+fi
+
+
+# Start service conditionally on crond restart.
+sysboot()
+{
+	wmc-httpd -v -d $STATEDIR -l "|rotatelogs $LOGDIR/reqmgr2-%Y%m%d.log 86400" $CFGFILE
+}
+
+
+# Start the service.
+start()
+{
+	echo "starting $ME"
+  	wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/reqmgr2-%Y%m%d.log 86400" $CFGFILE
+}
+
+
+# Stop the service.
+stop()
+{
+	echo "stopping $ME"
+  	wmc-httpd -k -d $STATEDIR $CFGFILE
+}
+
+
+# Check if the server is running.
+status()
+{
+  	wmc-httpd -s -d $STATEDIR $CFGFILE
+}
+
+
+# Verify the security string.
+check()
+{
+	CHECK=$(echo "$1" | md5sum | awk '{print $1}')
+	if [ $CHECK != 94e261a5a70785552d34a65068819993 ]; then
+		echo "$0: cannot complete operation, please check documentation." 1>&2
+    	exit 2;
+  	fi
+}
+
+
+# TODO
+# make sure the CMSSW_VERSIONS are up to date
+# just a placeholder now
+# this is how ReqMgr1 retrived CMSSW versions and ScramArchs from CMS tag
+# collector, Diego says asynchronous communication with tag collector should
+# be preserved and info retrieved into private DB (due TC instability)
+# was run as a cron job
+#updateversions()
+#{
+#	cd $STATEDIR
+#  	requestDbAdmin add -c $CFGFILE -v all
+#}
+
+
+# Main routine, perform action requested on command line.
+case ${1:-status} in
+	sysboot )
+		sysboot
+    ;;
+
+  	start | restart )
+    	check "$2"
+    	stop
+    	start
+    ;;
+
+  	status )
+    	status
+    ;;
+
+  	stop )
+    	check "$2"
+    	stop
+    ;;
+
+  	#updateversions )
+  	#	check "$2"
+  	#  	updateversions
+  	#;;
+
+  	help )
+  		perl -ne '/^##H/ && do { s/^##H ?//; print }' < $0
+    ;;
+
+  	version )
+  		echo "$REQMGR_VERSION"
+    ;;
+
+  	* )
+  		echo "$0: unknown action '$1', please try '$0 help' or documentation." 1>&2
+    	exit 1
+    ;;
+esac

--- a/reqmgr2/monitoring.ini
+++ b/reqmgr2/monitoring.ini
@@ -1,0 +1,2 @@
+# Glob pattern to search for log files under the svc logs directory,
+# and the regular expression to look for in those files.

--- a/system/deploy
+++ b/system/deploy
@@ -108,7 +108,7 @@ system_groups_and_accounts()
             T:100038:_reqmon    T:100039:_crabserver  T:100040:_crabcache  \
             T:100041:_dmwmmon   T:100042:_an_reqmgr   T:100043:_an_workqueue\
             T:100044:_an_reqmon T:100045:_t0wmadatasvc T:100046:_dbsmigration\
-            T:100047:_t0_reqmon; do
+            T:100047:_t0_reqmon T:100048:_reqmgr2 ; do
     add_local_group $(echo $ng | tr : " ")
   done
 
@@ -143,6 +143,8 @@ system_groups_and_accounts()
   add_local_user 100045 _t0wmadatasvc ,_config "T0 WMAgent Data Service App"
   add_local_user 100046 _dbsmigration ,_config "DBS Migration Server"
   add_local_user 100047 _t0_reqmon    ,_config "ReqMon App for T0"
+  add_local_user 100048 _reqmgr2      ,_config "ReqMgr2 App"
+
 
   # Restart nscd to flush account changes. Current account will _not_
   # see these changes before logout/login however, so commands below
@@ -297,7 +299,7 @@ deploy_system_post()
                _dqmgui _filemover _overview _phedex _sitedb _t0mon \
                _mongodb _reqmgr _workqueue _configcache _t0datasvc _reqmon \
                _crabserver _crabcache _dmwmmon _an_reqmgr _an_workqueue \
-               _an_reqmon _t0wmadatasvc _dbsmigration _t0_reqmon; do
+               _an_reqmon _t0wmadatasvc _dbsmigration _t0_reqmon _reqmgr2 ; do
         case " $G " in *" $g "* ) ;; * ) note "ERROR: no $g group"; exit 1;; esac
       done
 


### PR DESCRIPTION
All points discussed yesterday implemented:

-checking env. var COUCHURL is moved into config-localhost.py
-COUCH_HOST is figured out in the deploy script and config.py overwritten, there are no other references to vocms names except from the deploy script
-offsite variant removed and redundant case cases cleaned up
-config.py is the only configuration file for ReqMgr2, there is no another one under WMCore.ReqMgr
-ReqMgr2 made dependent on ReqMgr1 (because of shared couchapps push), while deploying it's necessary to make sure both use the same WMCore tag

@geneguvo, please review. 

I will be great if you could please upgrade test-bed with reqmgr.spec 1.85, reqmgr2.spec 1.2. Thanks!
