### PR TITLE
Add mixing dash to production operator roles

### DIFF
--- a/dbs/DBS-dev.py
+++ b/dbs/DBS-dev.py
@@ -91,7 +91,7 @@ db_integration_global.engineParameters = { 'pool_size' : 15, 'max_overflow' : 10
 active.DBSWriter.section_('security')
 security_instances = active.DBSWriter.security.section_('instances')
 security_production_global = security_instances.section_('prod/global')
-security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production operator'}
+security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production-operator'}
 security_development_global = security_instances.section_('dev/global')
 security_development_global.params = {}
 security_integration_global = security_instances.section_('int/global')
@@ -127,7 +127,7 @@ db_integration_global.engineParameters = { 'pool_size' : 15, 'max_overflow' : 10
 active.DBSMigrate.section_('security')
 security_instances = active.DBSMigrate.security.section_('instances')
 security_production_global = security_instances.section_('prod/global')
-security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production operator'}
+security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production-operator'}
 security_development_global = security_instances.section_('dev/global')
 security_development_global.params = {}
 security_integration_global = security_instances.section_('int/global')

--- a/dbs/DBS-preprod.py
+++ b/dbs/DBS-preprod.py
@@ -91,7 +91,7 @@ db_integration_global.engineParameters = { 'pool_size' : 15, 'max_overflow' : 10
 active.DBSWriter.section_('security')
 security_instances = active.DBSWriter.security.section_('instances')
 security_production_global = security_instances.section_('prod/global')
-security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production operator'}
+security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production-operator'}
 security_development_global = security_instances.section_('dev/global')
 security_development_global.params = {}
 security_integration_global = security_instances.section_('int/global')
@@ -127,7 +127,7 @@ db_integration_global.engineParameters = { 'pool_size' : 15, 'max_overflow' : 10
 active.DBSMigrate.section_('security')
 security_instances = active.DBSMigrate.security.section_('instances')
 security_production_global = security_instances.section_('prod/global')
-security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production operator'}
+security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production-operator'}
 security_development_global = security_instances.section_('dev/global')
 security_development_global.params = {}
 security_integration_global = security_instances.section_('int/global')

--- a/dbs/DBS-prod.py
+++ b/dbs/DBS-prod.py
@@ -91,7 +91,7 @@ db_integration_global.engineParameters = { 'pool_size' : 15, 'max_overflow' : 10
 active.DBSWriter.section_('security')
 security_instances = active.DBSWriter.security.section_('instances')
 security_production_global = security_instances.section_('prod/global')
-security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production operator'}
+security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production-operator'}
 security_development_global = security_instances.section_('dev/global')
 security_development_global.params = {}
 security_integration_global = security_instances.section_('int/global')
@@ -127,7 +127,7 @@ db_integration_global.engineParameters = { 'pool_size' : 15, 'max_overflow' : 10
 active.DBSMigrate.section_('security')
 security_instances = active.DBSMigrate.security.section_('instances')
 security_production_global = security_instances.section_('prod/global')
-security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production operator'}
+security_production_global.params = {'dbs' : 'operator', 'dataops' : 'production-operator'}
 security_development_global = security_instances.section_('dev/global')
 security_development_global.params = {}
 security_integration_global = security_instances.section_('int/global')


### PR DESCRIPTION
Hi Diego,

the authorization with sitedb DataOps:Production Operator role is currently not working, since space are translated into dashes by https://github.com/dmwm/deployment/blob/master/frontend/mkauthmap#L127. Could you include the fixed dbs configuration for the next deployment to cmsweb/cmsweb-testbed, please?

Thanks,
Manuel
