### PR TITLE
Offline index-schema migration

### DIFF
--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -396,6 +396,7 @@ start()
 	  $DQM_DATA/uploads \
 	  $DQM_DATA/data \
 	  $DQM_DATA/agents/register \
+	  $DQM_DATA/agents/register128 \
 	  $DQM_DATA/agents/zip
 
         startagent $D/agent-zip \
@@ -428,6 +429,20 @@ start()
           $DQM_DATA/ix \
           $DQM_DATA/agents/qcontrol \
           $DQM_DATA/agents/vcontrol
+
+        startagent -e 128 $D/agent-import-128 \
+          visDQMImportDaemon \
+          $DQM_DATA/agents/register128 \
+          $DQM_DATA/data \
+          $DQM_DATA/ix128
+
+	startagent $D/agent-export \
+	  visDQMExportDaemon \
+	  $DQM_DATA/ix \
+	  $DQM_DATA/agents/export \
+	  $DQM_DATA/data \
+	  "numObjects > 0 and runNumber >= 190389" \
+	  $DQM_DATA/agents/register128
 
         startagent $D/agent-qcontrol \
           visDQMRootFileQuotaControl \
@@ -521,7 +536,7 @@ start()
           $DQM_DATA/agents/qcontrol \
           $DQM_DATA/agents/vcontrol
 
-        startagent $D/agent-qcontrol \
+	startagent $D/agent-qcontrol \
           visDQMRootFileQuotaControl \
           $DQM_DATA/agents/qcontrol \
           $DQM_DATA/agents/register \

--- a/dqmgui/quota-rfqc-caf.py
+++ b/dqmgui/quota-rfqc-caf.py
@@ -2,6 +2,8 @@
  'offline_data':5 * 1024 ** 3,
  'relval_data':5 * 1024 ** 3,
  'relval_mc':5 * 1024 ** 3,
+ 'relval_rundepmc':5 * 1024 ** 3,
+ 'simulated_rundep':5 * 1024 ** 3,
  'simulated':5 * 1024 ** 3
 }
 

--- a/dqmgui/quota-rfqc-dev.py
+++ b/dqmgui/quota-rfqc-dev.py
@@ -2,6 +2,8 @@
  'offline_data':5 * 1024 ** 3,
  'relval_data':5 * 1024 ** 3,
  'relval_mc':5 * 1024 ** 3,
+ 'relval_rundepmc':5 * 1024 ** 3,
+ 'simulated_rundep':5 * 1024 ** 3,
  'simulated':5 * 1024 ** 3
 }
 

--- a/dqmgui/quota-rfqc-offline.py
+++ b/dqmgui/quota-rfqc-offline.py
@@ -2,6 +2,8 @@
  'offline_data':2500 * 1024 ** 3,
  'relval_data':100 * 1024 ** 3,
  'relval_mc':70 * 1024 ** 3,
- 'simulated':10 * 1024 ** 3
+ 'relval_rundepmc':70 * 1024 ** 3,
+ 'simulated':10 * 1024 ** 3,
+ 'simulated_rundep':10 * 1024 ** 3
 }
 

--- a/dqmgui/quota-rfqc-relval.py
+++ b/dqmgui/quota-rfqc-relval.py
@@ -2,6 +2,8 @@
  'offline_data':50 * 1024 ** 3,
  'relval_data':2000 * 1024 ** 3,
  'relval_mc':1000 * 1024 ** 3,
- 'simulated':1000 * 1024 ** 3
+ 'relval_rundepmc':1000 * 1024 ** 3,
+ 'simulated':1000 * 1024 ** 3,
+ 'simulated_rundep':1000 * 1024 ** 3
 }
 


### PR DESCRIPTION
Ciao Diego,
this pull will start the migration of the offline index for >2012 data. It also contains few changes to the quota files to properly handle the new run-dependent MonteCarlo and RelVal samples.

This pull request should be bundled together with version 7.4.0 of DQMGUI that I'll submit via another pull request to the comp branch of cmsdist git repo.

As usual ping me in case of doubts/problems/questions.

Thanks for this extra work from your side.

Marco.
