### PR TITLE
Add single-user support for frontends

### DIFF
--- a/frontend/deploy
+++ b/frontend/deploy
@@ -56,8 +56,27 @@ deploy_frontend_sw()
 
   rm -f $PWD/etc/keys/authz-headers
   ln $root/current/auth/wmcore-auth/header-auth-key $PWD/etc/keys/authz-headers
-  setgroup ugo+r,go-w _config $PWD/{*.conf,etc/{httpd,options.txt}}
-  setgroup -R ugo+r,go-w _config $PWD/{etc/env.d,htdocs}
+  $nogroups || setgroup ugo+r,go-w _config $PWD/{*.conf,etc/{httpd,options.txt}}
+  $nogroups || setgroup -R ugo+r,go-w _config $PWD/{etc/env.d,htdocs}
+  # Further munge the server config for single-user mode
+  if [ $nogroups ]; then
+    perl -p -i -e 's/^User/#User/' $PWD/server.conf
+    perl -p -i -e 's/^Group/#Group/' $PWD/server.conf
+        
+    # non-privileged port
+    perl -p -i -e 's/Listen 80/Listen 8080/' $PWD/server.conf
+    perl -p -i -e 's/\*:80/\*:8080/' $PWD/server.conf
+        
+    perl -p -i -e 's/Listen 443/Listen 8443/' $PWD/server.conf
+    perl -p -i -e 's/\*:443/\*:8443/' $PWD/server.conf
+    
+    # non-rootowned key if we can't read it in /etc
+    if [ ! -r /etc/grid-security/hostkey.pem ]; then
+      perl -p -i -e "s#SSLCertificateFile.*#SSLCertificateFile $root/certs/hostcert.pem#" $PWD/server.conf
+      perl -p -i -e "s#SSLCertificateKeyFile.*#SSLCertificateKeyFile $root/certs/hostkey.pem#" $PWD/server.conf
+    fi
+  fi
+
 }
 
 deploy_frontend_post()
@@ -71,8 +90,8 @@ deploy_frontend_post()
     note "ERROR: cannot find hostcert to use"
     exit 1
   fi
-
-  case $host in * ) enable ;; esac
+  
+   case $host in * ) enable ;; esac
   (mkcrontab | { egrep -v -e '^(PATH|X509_[A-Z_]*)=' || true; }
    echo "13 */6 * * * $project_config/mkvomsmap --key $certs/hostkey.pem" \
         "--cert $certs/hostcert.pem -c $project_config/mkgridmap.conf" \
@@ -91,21 +110,21 @@ deploy_frontend_post()
   (crontab -l | grep -e '^[A-Z0-9_]*=' -e $project_config/ |
    perl -pe 's|^[/*0-9 ]* ||; s|(^[A-Z0-9_]+=)|export $1|') | sh -x
 
-  sudo rm -f $PWD/etc/httpd.plist
+  $nogroups || sudo rm -f $PWD/etc/httpd.plist
   perl -p -i -e "s|\@STATEDIR\@|$PWD|g" \
     < $project_config/httpd.plist.in \
     > $PWD/etc/httpd.plist
   chmod 644 $PWD/etc/httpd.plist
-  sudo chown root:$(id -gn) $PWD/etc/httpd.plist
+  $nogroups || sudo chown root:$(id -gn) $PWD/etc/httpd.plist
 
   if [ -d /etc/rc.d/init.d ]; then
-    sudo rm -f /etc/rc.d/init.d/httpd
-    sudo ln -s $PWD/etc/httpd /etc/rc.d/init.d/httpd
-    sudo /sbin/chkconfig --add httpd
-    sudo /sbin/chkconfig --levels 2345 httpd on
+    $nogroups || sudo rm -f /etc/rc.d/init.d/httpd
+    $nogroups || sudo ln -s $PWD/etc/httpd /etc/rc.d/init.d/httpd
+    $nogroups || sudo /sbin/chkconfig --add httpd
+    $nogroups || sudo /sbin/chkconfig --levels 2345 httpd on
   elif [ -d /Library/LaunchDaemons ]; then
-    sudo rm -f /Library/LaunchDaemons/ch.cern.cms.httpd.plist
-    sudo ln -s $PWD/etc/httpd.plist /Library/LaunchDaemons/ch.cern.cms.httpd.plist
+    $nogroups || sudo rm -f /Library/LaunchDaemons/ch.cern.cms.httpd.plist
+    $nogroups || sudo ln -s $PWD/etc/httpd.plist /Library/LaunchDaemons/ch.cern.cms.httpd.plist
   else
     note "ERROR: how do you install a httpd service on this system?"
     exit 1
@@ -179,5 +198,5 @@ deploy_frontend_fakeauth()
    echo "insert into role values (1, 'bar');"
    echo "insert into site_responsibility values (1, 1, 1);"
    echo "insert into group_responsibility values (1, 1, 1);") | sqlite3 $1
-  setgroup ugo+r,go-wx _config $project_auth/users.db
+  $nogroups || setgroup ugo+r,go-wx _config $project_auth/users.db
 }

--- a/frontend/manage
+++ b/frontend/manage
@@ -14,26 +14,46 @@
 ##H For more details please refer to operations page:
 ##H   https://twiki.cern.ch/twiki/bin/view/CMS/ServiceApache
 
+# Detect if we're in single user mode
+ME=$(basename $(dirname $0))
+TOP=$(cd $(dirname $0)/../../.. && pwd)
+STATEDIR=$TOP/state/$ME
+
+nogroups=false
+case $(uname) in
+    Linux )
+        [ "X$(readlink -f /etc/rc.d/init.d/httpd)" = "X$(readlink -f $STATEDIR/etc/httpd)" ] || nogroups=true ;;
+    Darwin )
+        [ "X$(readlink -f /Library/LaunchDaemons/ch.cern.cms.httpd.plist)" = "X$(readlink -f $STATEDIR/etc/httpd.plist)" ] || nogroups=true ;;
+esac
+
 case ${1:-status} in
   status | graceful | stop | configtest )
-    case $(uname) in
-      Linux )
-        sudo /sbin/service httpd $1 ;;
-      Darwin )
-        ME=$(basename $(dirname $0))
-        TOP=$(cd $(dirname $0)/../../.. && pwd)
-        sudo $TOP/state/$ME/etc/httpd $1 ;;
-    esac
+    if [ $nogroups ]; then
+        $STATEDIR/etc/httpd $1
+    else
+        case $(uname) in
+          Linux )
+            sudo /sbin/service httpd $1 ;;
+          Darwin )
+            sudo $TOP/state/$ME/etc/httpd $1 ;;
+        esac
+    fi
     ;;
 
   start | restart )
-    case $(uname) in
-      Linux )
-        sudo /sbin/service httpd restart ;;
-      Darwin )
-        sudo launchctl unload -w /Library/LaunchDaemons/ch.cern.cms.httpd.plist
-        sudo launchctl load -w /Library/LaunchDaemons/ch.cern.cms.httpd.plist ;;
-    esac
+    if [ $nogroups ]; then
+        $STATEDIR/etc/httpd restart
+    else
+        case $(uname) in
+          Linux )
+            sudo /sbin/service httpd restart 
+            ;;
+          Darwin )
+            sudo launchctl unload -w /Library/LaunchDaemons/ch.cern.cms.httpd.plist
+            sudo launchctl load -w /Library/LaunchDaemons/ch.cern.cms.httpd.plist ;;
+        esac
+    fi
     ;;
 
   help )


### PR DESCRIPTION
Adds support for the -a Deploy option to the frontend, to prevent
the CMS-installed apache service from conflicting with system-wide
HTTP services and to ease automated integration testing

Here's a dump of it working:

```
+ set -e
+ su vagrant -c /vagrant/scripts/install-frontend.sh
++ set -e
++ export http_proxy=http://fs1.accre.vanderbilt.edu:3128
++ http_proxy=http://fs1.accre.vanderbilt.edu:3128
++ REPO_DEPLOYMENT_PATH=/vagrant/repos/deployment
++ INSTALL_PWD=/data
++ FRONTEND_EXTRA_CERTIFICATES=/vagrant/misc/extra-certificates.txt
++ FRONTEND_SITEDB_MAPPING=
++ FRONTEND_HOSTCERT=/vagrant/certs/hostcert.pem
++ FRONTEND_HOSTKEY=/vagrant/certs/hostkey.pem
++ WMAGENT_INSTALL_POSTFIX=wmagent-install
++ CMSWEB_INSTALL_POSTFIX=cmsweb-install
++ WMAGENT_INSTALL_LOCATION=/data/wmagent-install
++ CMSWEB_INSTALL_LOCATION=/data/cmsweb-install
++ WMCORE_SOURCE_TREE=/home/meloam/analysis/WMCore
++ WMCORE_TAG=0.9.26
++ CMSWEB_TAG=HG1303a
+++ hostname -f
++ MY_HOSTNAME=localhost
++ REPO='-r comp=comp.pre'
++ export SCRAM_ARCH=slc6_amd64_gcc461
++ SCRAM_ARCH=slc6_amd64_gcc461
++ '[' '!' -e /data/cfg ']'
++ '[' -e /data/cmsweb-install/current ']'
++ pkill -9 -f /data/cmsweb-install
++ true
++ mkdir -p /data/cmsweb-install
++ cd /data/cmsweb-install
++ '[' '!' -e certs ']'
++ mkdir -p certs
++ '[' '!' -r /vagrant/certs/hostcert.pem ']'
++ '[' -e certs/hostcert.pem ']'
+++ sudo cp /vagrant/certs/hostcert.pem certs/hostcert.pem
++ '[' -e certs/hostkey.pem ']'
+++ sudo cp /vagrant/certs/hostkey.pem certs/hostkey.pem
+++ id -un
+++ id -gn
++ sudo chown vagrant:vagrant certs/hostcert.pem certs/hostkey.pem
++ chmod 600 certs/hostcert.pem certs/hostkey.pem
++ export X509_USER_CERT=/data/cmsweb-install/certs/hostcert.pem
++ X509_USER_CERT=/data/cmsweb-install/certs/hostcert.pem
++ export X509_USER_KEY=/data/cmsweb-install/certs/hostkey.pem
++ X509_USER_KEY=/data/cmsweb-install/certs/hostkey.pem
++ /data/cfg/Deploy -R cmsweb@HG1303a -t install -r comp=comp.pre -A slc6_amd64_gcc461 -s 'prep sw' /data/cmsweb-install admin frontend
/data/cfg/Deploy: line 45: lsb_release: command not found
INFO: 20130531020224: starting deployment of: admin frontend
INFO: deploying backend - variant: default, version: default
INFO: bootstrapping comp.pre software area in /data/cmsweb-install/install/sw.pre
INFO: bootstrap successful
INFO: deploying admin - variant: default, version: default
INFO: deploying wmcore-auth - variant: default, version: default
INFO: deploying frontend - variant: default, version: default
INFO: generating fake login with user vagrant password hXGQULqIOjFroMt dn ''
INFO: installation log can be found in /data/cmsweb-install/.deploy/20130531-020224-6768-prepsw.log
INFO: installation completed sucessfully
++ '[' /home/meloam/analysis/WMCore -a -e /home/meloam/analysis/WMCore ']'
++ /data/cfg/Deploy -R cmsweb@HG1303a -t install -r comp=comp.pre -A slc6_amd64_gcc461 -s post /data/cmsweb-install admin frontend
/data/cfg/Deploy: line 45: lsb_release: command not found
INFO: 20130531020627: starting deployment of: admin frontend
INFO: deploying backend - variant: default, version: default
INFO: deploying admin - variant: default, version: default
INFO: deploying wmcore-auth - variant: default, version: default
INFO: deploying frontend - variant: default, version: default
INFO: installation log can be found in /data/cmsweb-install/.deploy/20130531-020627-8276-post.log
INFO: installation completed sucessfully

++ '[' -e /home/vagrant/.globus/usercert.pem ']'
++ set +x
Starting frontend..
++ set +x
+++ cut -f2- '-d '
+++ openssl x509 -noout -subject -in /data/cmsweb-install/certs/hostcert.pem
++ dn='/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=brazil.accre.vanderbilt.edu'
++ echo '"/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=brazil.accre.vanderbilt.edu" cms'
++ '[' -e /home/vagrant/.globus/usercert.pem ']'
+ exit 0
```
