### PR TITLE
add optional database connection details for dataservice backend

### DIFF
--- a/tier0/manage
+++ b/tier0/manage
@@ -47,6 +47,7 @@ DQM_URL=
 CONFDB_URL=
 SMDB_URL=
 POPCONLOGDB_URL=
+T0DATASVCDB_URL=
 
 #
 # Init checks
@@ -108,6 +109,7 @@ load_secrets_file(){
     local MATCH_CONFDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep CONFDB_URL | sed s/CONFDB_URL=//`
     local MATCH_SMDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep SMDB_URL | sed s/SMDB_URL=//`
     local MATCH_POPCONLOGDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep POPCONLOGDB_URL | sed s/POPCONLOGDB_URL=//`
+    local MATCH_T0DATASVCDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep T0DATASVCDB_URL | sed s/T0DATASVCDB_URL=//`
 
     # oracle settings
     ORACLE_USER=$MATCH_ORACLE_USER;
@@ -156,6 +158,7 @@ load_secrets_file(){
     CONFDB_URL=$MATCH_CONFDB_URL;
     SMDB_URL=$MATCH_SMDB_URL;
     POPCONLOGDB_URL=$MATCH_POPCONLOGDB_URL;
+    T0DATASVCDB_URL=$MATCH_T0DATASVCDB_URL;
 }
 
 print_settings(){
@@ -182,6 +185,7 @@ print_settings(){
     echo "CONFDB_URL=                $CONFDB_URL                "
     echo "SMDB_URL=                  $SMDB_URL                  "
     echo "POPCONLOGDB_URL=           $POPCONLOGDB_URL           "
+    echo "T0DATASVCDB_URL=           $T0DATASVCDB_URL           "
 }
 
 
@@ -335,6 +339,9 @@ initialize_tier0(){
     fi
     if [ "x$POPCONLOGDB_URL" != "x" ]; then
 	optargs="$optargs --popconlogdb_url=$POPCONLOGDB_URL"
+    fi
+    if [ "x$T0DATASVCDB_URL" != "x" ]; then
+	optargs="$optargs --t0datasvcdb_url=$T0DATASVCDB_URL"
     fi
     tier0-mod-config --input=$CONFIG_TIER0/config-agent.py \
 	             --output=$CONFIG_TIER0/config.py \


### PR DESCRIPTION
The Tier0 dataservice will move to it's own persistent database and no longer be run against the t0ast database. That persistent database will be populated from the Tier0, but this is optional. Add forwarding
of the database connection details from the secret file to the Tier0 configuration.
