### PR TITLE
changing the databases behind t0wmadatasvc

### DIFF
--- a/t0wmadatasvc/deploy
+++ b/t0wmadatasvc/deploy
@@ -31,33 +31,47 @@ import socket
 
 fqdn = socket.getfqdn().lower()
 dbparam = {
-     'prod': { '.title': 'Production',
-               '.order': 0,
+            'prod': { '.title': 'Production',
+                      '.order': 0,
 
-		    '*': { 'type': DB,
-		             'trace': False,
-		             'schema': "cms_t0wmadatasvc",
-		             'clientid': "t0wmadatasvc-web@%s" % fqdn,
-		             'liveness': "select sysdate from dual",
-		             'user': "cms_t0wmadatasvc_reader_fixme",
-                   'password': "FIXME",
-                   'dsn': "cmsr_fixme",
-                   'timeout': 300 }
-             },
+                      '*': { 'type': DB,
+                             'trace': False,
+                             'schema': "cms_t0datasvc_prod",
+                             'clientid': "t0wmadatasvc-web@%s" % fqdn,
+                             'liveness': "select sysdate from dual",
+                             'user': "cms_t0datasvc_prod",
+                             'password': "FIXME",
+                             'dsn': "cmsr",
+                             'timeout': 300 }
+                    },
 
-     'replay':  { '.title': 'Dev',
-               '.order': 1,
+            'replay1':  { '.title': 'Replay1',
+                          '.order': 1,
 
-          '*': { 'type': DB,
-                   'trace': True,
-                   'schema': "cms_t0wmadatasvc",
-                   'clientid': "t0wmadatasvc-web@%s" % fqdn,
-                   'liveness': "select sysdate from dual",
-                   'user': "cms_t0wmadatasvc_reader_fixme",
-                   'password': "FIXME",
-                   'dsn': "devdb11_fixme",
-                   'timeout': 300 }
-             }
+                          '*': { 'type': DB,
+                                 'trace': False,
+                                 'schema': "cms_t0datasvc_replay1",
+                                 'clientid': "t0wmadatasvc-web@%s" % fqdn,
+                                 'liveness': "select sysdate from dual",
+                                 'user': "cms_t0datasvc_replay1",
+                                 'password': "FIXME",
+                                 'dsn': "int2r",
+                                 'timeout': 300 }
+                        },
+
+            'replay2':  { '.title': 'Replay2',
+                          '.order': 2,
+
+                          '*': { 'type': DB,
+                                 'trace': False,
+                                 'schema': "cms_t0datasvc_replay2",
+                                 'clientid': "t0wmadatasvc-web@%s" % fqdn,
+                                 'liveness': "select sysdate from dual",
+                                 'user': "cms_t0datasvc_replay2",
+                                 'password': "FIXME",
+                                 'dsn': "int2r",
+                                 'timeout': 300 }
+                        }
 }
 EOF
     ;;

--- a/t0wmadatasvc/monitoring.ini
+++ b/t0wmadatasvc/monitoring.ini
@@ -7,6 +7,6 @@ LOG_ERROR_REGEX='error:'
 PS_REGEX="wmc-httpd.*[/]t0wmadatasvc[/]config.py"
 
 # The ping test fetches the provided URL and look for the following perl regex
-PING_URL="http://localhost:8308/t0wmadatasvc/replay/hello"
+PING_URL="http://localhost:8308/t0wmadatasvc/prod/hello"
 PING_HEADER="Accept: application/json"
 PING_REGEX="world"


### PR DESCRIPTION
This will change the t0wmadatasvc to not just support prod and replay, but prod, replay1 and replay2. Not sure how this interferes with the request to update t0wmadatasvc to 0.0.2, in principle this should be orthogonal (we can live with the current prod and replay for a while longer).
