### PR TITLE
fix a bug in naming of instances

### DIFF
--- a/t0wmadatasvc/deploy
+++ b/t0wmadatasvc/deploy
@@ -45,33 +45,33 @@ dbparam = {
                              'timeout': 300 }
                     },
 
-            'replay1':  { '.title': 'Replay1',
-                          '.order': 1,
+            'replayone':  { '.title': 'ReplayOne',
+                            '.order': 1,
 
-                          '*': { 'type': DB,
-                                 'trace': False,
-                                 'schema': "cms_t0datasvc_replay1",
-                                 'clientid': "t0wmadatasvc-web@%s" % fqdn,
-                                 'liveness': "select sysdate from dual",
-                                 'user': "cms_t0datasvc_replay1_fixme",
-                                 'password': "FIXME",
-                                 'dsn': "int2r_fixme",
-                                 'timeout': 300 }
-                        },
+                            '*': { 'type': DB,
+                                   'trace': False,
+                                   'schema': "cms_t0datasvc_replay1",
+                                   'clientid': "t0wmadatasvc-web@%s" % fqdn,
+                                   'liveness': "select sysdate from dual",
+                                   'user': "cms_t0datasvc_replay1_fixme",
+                                   'password': "FIXME",
+                                   'dsn': "int2r_fixme",
+                                   'timeout': 300 }
+                          },
 
-            'replay2':  { '.title': 'Replay2',
-                          '.order': 2,
+            'replaytwo':  { '.title': 'ReplayTwo',
+                            '.order': 2,
 
-                          '*': { 'type': DB,
-                                 'trace': False,
-                                 'schema': "cms_t0datasvc_replay2",
-                                 'clientid': "t0wmadatasvc-web@%s" % fqdn,
-                                 'liveness': "select sysdate from dual",
-                                 'user': "cms_t0datasvc_replay2_fixme",
-                                 'password': "FIXME",
-                                 'dsn': "int2r_fixme",
-                                 'timeout': 300 }
-                        }
+                            '*': { 'type': DB,
+                                   'trace': False,
+                                   'schema': "cms_t0datasvc_replay2",
+                                   'clientid': "t0wmadatasvc-web@%s" % fqdn,
+                                   'liveness': "select sysdate from dual",
+                                   'user': "cms_t0datasvc_replay2_fixme",
+                                   'password': "FIXME",
+                                   'dsn': "int2r_fixme",
+                                   'timeout': 300 }
+                          }
 }
 EOF
     ;;


### PR DESCRIPTION
Unfortunately instance names don't appear to allow numbers, therefore I had to make a small fix. The prod instance works in the version you just merged, which is what matters most (and where the selfcheck runs), so there is no hurry to get this merged as well.

I updated the secret, it's in same place as before, same password. That is the actual file I use for deployment on my private instance now (and there prod, replayone and replaytwo all work).
