### PR TITLE
ix to ix128 migration is implemented in the server conf files.

### DIFF
--- a/dqmgui/server-conf-caf.py
+++ b/dqmgui/server-conf-caf.py
@@ -36,7 +36,7 @@ server.extend('DQMLayoutAccess', None, STATEDIR,
 server.source('DQMUnknown')
 server.source('DQMOverlay')
 server.source('DQMStripChart')
-server.source('DQMArchive', "%s/ix" % STATEDIR, '^/Global/')
+server.source('DQMArchive', "%s/ix128" % STATEDIR, '^/Global/')
 server.source('DQMLayout')
 
 execfile(CONFIGDIR + "/dqm-services.py")

--- a/dqmgui/server-conf-dev.py
+++ b/dqmgui/server-conf-dev.py
@@ -40,7 +40,7 @@ server.source('DQMOverlay')
 server.source('DQMStripChart')
 server.source('DQMCertification')
 server.source('DQMLive', "localhost:8061")
-server.source('DQMArchive', "%s/ix" % STATEDIR, '^/Global/')
+server.source('DQMArchive', "%s/ix128" % STATEDIR, '^/Global/')
 server.source('DQMLayout')
 
 execfile(CONFIGDIR + "/dqm-services.py")

--- a/dqmgui/server-conf-offline.py
+++ b/dqmgui/server-conf-offline.py
@@ -37,7 +37,7 @@ server.source('DQMUnknown')
 server.source('DQMOverlay')
 server.source('DQMStripChart')
 server.source('DQMCertification')
-server.source('DQMArchive', "%s/ix" % STATEDIR, '^/Global/')
+server.source('DQMArchive', "%s/ix128" % STATEDIR, '^/Global/')
 server.source('DQMLayout')
 
 execfile(CONFIGDIR + "/dqm-services.py")


### PR DESCRIPTION
This PR should be merged to github but it should NOT be deployed to the production offline and relval dqm GUIs.
