### PR TITLE
Added bbesien to contacts visDQMZipCastorVerifier

### DIFF
--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -312,7 +312,7 @@ start()
         startagent $D/agent-zverifier \
           visDQMZipCastorVerifier \
           $DQM_DATA/agents/verify \
-          marco.rovere@cern.ch,atanas.batinkov@cern.ch \
+          marco.rovere@cern.ch,atanas.batinkov@cern.ch,broen.van.besien@cern.ch \
           $DQM_DATA/zipped \
           $CASTORDIR \
           24 \


### PR DESCRIPTION
Added broen.van.besien@cern.ch to the list of emergency contacts for the agent visDQMZipCastorVerifier.
We are currently reviewing the Permanent Storage chain. Step one is to add myself to the people that get warned when something goes wrong.