### PR TITLE
Changed root file quota for dev server

### DIFF
--- a/dqmgui/quota-rfqc-dev.py
+++ b/dqmgui/quota-rfqc-dev.py
@@ -1,8 +1,8 @@
-{'online_data':1 * 1024 ** 3,
- 'offline_data':5 * 1024 ** 3,
- 'relval_data':5 * 1024 ** 3,
- 'relval_mc':5 * 1024 ** 3,
- 'relval_rundepmc':5 * 1024 ** 3,
+{'online_data':20 * 1024 ** 3,
+ 'offline_data':200 * 1024 ** 3,
+ 'relval_data':20 * 1024 ** 3,
+ 'relval_mc':20 * 1024 ** 3,
+ 'relval_rundepmc':20 * 1024 ** 3,
  'simulated_rundep':5 * 1024 ** 3,
  'simulated':5 * 1024 ** 3
 }


### PR DESCRIPTION
I pushed it to 200G for the offline.

In theory all the categories combined could run up to 290G, but this is definitely not something that could happen on the short term.
In fact it will also take a while before the 200G for offline is filled.

In the meanwhile, we can assign more space to the /data mount on vocms0133.