### PR TITLE
Updated manage and deploy scripts for CastorVerifier

### DIFF
--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -71,30 +71,42 @@ deploy_dqmgui_post()
      esac
    }) | crontab -
 
-  # BEWARE!!!: For the slc6 servers, backups only turned on for the DQMGUI dev server (on pre-prod)!!!
   case $host:$root in
-    vocms13[389]:/data/srv | vocms0133:/data/srv | broen* )
+    vocms13[389]:/data/srv | vocms013[389]:/data/srv | broen* )
       klist -s # must have afs kerberos token
       (acrontab -l | { egrep -v -e " $host.*$project_config/" || true; }
 
        # Enable the afs-sync only on vocms138
+       # Remains only on SLC5. Will not be migrated to SLC6.
        case $host in
          vocms138 )
            echo "6 */3 * * * $host $project_config/manage -q xstart afs-sync 'I did read documentation'" ;;
        esac
 
        # Set the backup of the index files to castor
+       # During the parallel run period, should only run on SLC5
+       # after that, should swith to SLC6
        case $host in
-         vocms13[89] | vocms013[89] )
+         vocms13[89] )
            echo "30 3 * * 0 $host [ \$(date +\\%e) -le 7 ] &&" \
                             "$project_config/manage backup" \
                             "/castor/cern.ch/cms/archive/cmsweb/backups 'I did read documentation'" ;;
        esac
 
-       # Set the backup of the root files (castor stageout) on slc6 (pre)prod machines only
+       # Set the backup of the zipped root files (castor stageout)
+       # Currently only on SLC6 dev machine
+       # After the parallel run this must be switched on on the prod machines
        case $host in
-         vocms013[389] | broen* )
-           echo "*/15 * * * * $host $project_config/manage rootfilesbackup 'I did read documentation'" ;;
+         vocms0133 | broen* )
+           echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'" ;;
+       esac
+
+       # Set the check/verification of the backup of the zipped root files
+       # Currently only on SLC6 dev machine
+       # After the parallel run this must be switched on on the prod machines
+       case $host in
+         vocms0133 | broen* )
+           echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'" ;;
        esac
       ) | acrontab
       ;;

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -3,23 +3,24 @@
 ##H Usage 1: manage [options] ACTION [ARG] [SECURITY-STRING]
 ##H
 ##H Available actions:
-##H   help              show this help
-##H   version           get current version of the service
-##H   status            show current service's status
-##H   dstatus            show current service's detailed status
-##H   sysboot           start server from crond if not running
-##H   restart           (re)start the service
-##H   start             (re)start the service
-##H   stop              stop the service
-##H   compile           refresh render plugins
-##H   backup            backup the current service state by archiving it to ARG area in castor
-##H   rootfilesbackup   backup new root files to castor
+##H   help            show this help
+##H   version         get current version of the service
+##H   status          show current service's status
+##H   dstatus         show current service's detailed status
+##H   sysboot         start server from crond if not running
+##H   restart         (re)start the service
+##H   start           (re)start the service
+##H   stop            stop the service
+##H   compile         refresh render plugins
+##H   backup          backup the current service state by archiving it to ARG area in castor
+##H   zipbackup       backup new root files to castor
+##H   zipbackupcheck  check if the backup of the root files to castor was successful
 ##H
 ##H Usage 2: manage [options] ACTION COMPONENTs [SECURITY-STRING]
 ##H COMPONENTs: webserver collector renderer logger agents afs-sync migration
 ##H
 ##H   xstatus     show status for COMPONENTs
-##H   xdstatus     show detailed status for COMPONENTs
+##H   xdstatus    show detailed status for COMPONENTs
 ##H   xstart      (re)start COMPONENTs
 ##H   xrestart    (re)start COMPONENTs
 ##H   xstop       stop COMPONENTs
@@ -242,6 +243,7 @@ start()
         $DQM_DATA/repository/original \
         $STATEDIR/online/ix128
       ;;
+
     dqm-c2d07-11:*agents* ) # dqm-integration
       refuseproc "file agents" "visDQMIndex" "refusing to restart"
 
@@ -272,44 +274,19 @@ start()
         $STATEDIR/online/ix128
       ;;
 
-    vocms13[89]:*agents* | vocms013[89]:*agents* ) # relval/offline/caf server
+    vocms13[89]:*agents* ) # SLC5 relval/offline/caf server
       refuseproc "file agents" "visDQMIndex|[^/]zip +|OnlineSync|visDQMCreateInfo" "refusing to restart"
 
-      # standard lot of agents
       for D in $CONFIGS; do
         D=${D}
-        CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
         DQM_DATA=$STATEDIR/$D
 
-	startagent $D/agent-receive \
-	  visDQMReceiveDaemon \
-	  $DQM_DATA/uploads \
-	  $DQM_DATA/data \
-	  $DQM_DATA/agents/register \
-	  $DQM_DATA/agents/zip
-
-        startagent $D/agent-zip \
-          visDQMZipDaemon \
-          $DQM_DATA/agents/zip \
+        startagent $D/agent-receive \
+          visDQMReceiveDaemon \
+          $DQM_DATA/uploads \
           $DQM_DATA/data \
-          $DQM_DATA/zipped \
-          $DQM_DATA/agents/freezer
-
-        startagent $D/agent-zfreeze \
-          visDQMZipFreezeDaemon \
-          $DQM_DATA/agents/freezer \
-          $DQM_DATA/zipped \
-          7 \
-          $DQM_DATA/agents/stageout
-
-        startagent $D/agent-zverifier \
-          visDQMZipCastorVerifier \
-          $DQM_DATA/agents/verify \
-          marco.rovere@cern.ch,atanas.batinkov@cern.ch \
-          $DQM_DATA/zipped \
-          $CASTORDIR \
-          24 \
-          $DQM_DATA/agents/clean
+          $DQM_DATA/agents/register \
+          $DQM_DATA/agents/zip
 
         startagent $D/agent-import-128 \
           visDQMImportDaemon \
@@ -336,6 +313,78 @@ start()
             $DQM_DATA/agents/ixmerge \
             $DQM_DATA/ix128 \
             $DQM_DATA/agents/register
+
+        # When the period of parallel running is finished,
+        # the zip and zipfreeze below should be removed
+
+        startagent $D/agent-zip \
+          visDQMZipDaemon \
+          $DQM_DATA/agents/zip \
+          $DQM_DATA/data \
+          $DQM_DATA/zipped \
+          $DQM_DATA/agents/freezer
+
+        startagent $D/agent-zfreeze \
+          visDQMZipFreezeDaemon \
+          $DQM_DATA/agents/freezer \
+          $DQM_DATA/zipped \
+          7 \
+          $DQM_DATA/agents/stageout
+
+        if [ $D = offline ]; then
+          startagent $D/agent-osync \
+            visDQMOnlineSyncDaemon \
+            -s https://cmsweb.cern.ch/dqm/online/data/browse/Original \
+            -d 14400 \
+            -n 50 \
+            /dev/null \
+            $DQM_DATA/data/OnlineData/original
+
+          startagent $D/agent-coinfo \
+            visDQMCreateInfoDaemon \
+            $DQM_DATA/data/OnlineData \
+            $DQM_DATA/agents/zip
+        fi
+
+      done
+      ;;
+
+    vocms013[89]:*agents* ) # SLC6 relval/offline/caf server
+      refuseproc "file agents" "visDQMIndex|[^/]zip +|OnlineSync|visDQMCreateInfo" "refusing to restart"
+
+      for D in $CONFIGS; do
+        D=${D}
+        DQM_DATA=$STATEDIR/$D
+
+        startagent $D/agent-receive \
+          visDQMReceiveDaemon \
+          $DQM_DATA/uploads \
+          $DQM_DATA/data \
+          $DQM_DATA/agents/register \
+          $DQM_DATA/agents/zip
+
+        startagent $D/agent-import-128 \
+          visDQMImportDaemon \
+          $DQM_DATA/agents/register \
+          $DQM_DATA/data \
+          $DQM_DATA/ix128 \
+          $DQM_DATA/agents/qcontrol \
+          $DQM_DATA/agents/vcontrol
+
+        startagent $D/agent-qcontrol \
+          visDQMRootFileQuotaControl \
+          $DQM_DATA/agents/qcontrol \
+          $DQM_DATA/agents/register \
+          $DQM_DATA/data \
+          $CFGDIR/quota-rfqc-${D}.py
+
+        startagent $D/agent-vcontrol \
+          visDQMVerControlDaemon \
+          $DQM_DATA/agents/vcontrol \
+          $DQM_DATA/data
+
+        # When the period of parallel running is finished,
+        # zip and zipfreeze should be added here
 
         if [ $D = offline ]; then
           startagent $D/agent-osync \
@@ -356,47 +405,20 @@ start()
       ;;
 
     # Special setup for the vocms0133 test server. (In the past this didn't run the Castor agent chain)
-    # This runs the agents to backup the zipped root files to caster, but in a "faster" way
+    # This runs the agents to backup the zipped root files to Castor, but in a "faster" way
     vocms0133:*agents* )
       refuseproc "file agents" "visDQMIndex|[^/]zip +|OnlineSync|visDQMCreateInfo" "refusing to restart"
 
-      # standard lot of agents
       for D in $CONFIGS; do
         D=${D}
-        CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
         DQM_DATA=$STATEDIR/$D
 
         startagent $D/agent-receive \
-	  visDQMReceiveDaemon \
-	  $DQM_DATA/uploads \
-	  $DQM_DATA/data \
-	  $DQM_DATA/agents/register \
-	  $DQM_DATA/agents/zip
-
-        startagent $D/agent-zip \
-          visDQMZipDaemon \
-          $DQM_DATA/agents/zip \
+          visDQMReceiveDaemon \
+          $DQM_DATA/uploads \
           $DQM_DATA/data \
-          $DQM_DATA/zipped \
-          $DQM_DATA/agents/freezer
-
-	# BVB: We freeze zip files faster (1 days instead of 7)
-        startagent $D/agent-zfreeze \
-          visDQMZipFreezeDaemon \
-          $DQM_DATA/agents/freezer \
-          $DQM_DATA/zipped \
-          1 \
-          $DQM_DATA/agents/stageout
-
-	# BVB: We verify zip files faster (12 hours instead of 24)
-        startagent $D/agent-zverifier \
-          visDQMZipCastorVerifier \
-          $DQM_DATA/agents/verify \
-          marco.rovere@cern.ch,atanas.batinkov@cern.ch,broen.vanbesien@cern.ch \
-          $DQM_DATA/zipped \
-          $CASTORDIR \
-          12 \
-          $DQM_DATA/agents/clean
+          $DQM_DATA/agents/register \
+          $DQM_DATA/agents/zip
 
         startagent $D/agent-import-128 \
           visDQMImportDaemon \
@@ -418,11 +440,20 @@ start()
           $DQM_DATA/agents/vcontrol \
           $DQM_DATA/data
 
-        startagent $D/agent-ixmerge \
-            visDQMIndexMergeDaemon \
-            $DQM_DATA/agents/ixmerge \
-            $DQM_DATA/ix128 \
-            $DQM_DATA/agents/register
+        startagent $D/agent-zip \
+          visDQMZipDaemon \
+          $DQM_DATA/agents/zip \
+          $DQM_DATA/data \
+          $DQM_DATA/zipped \
+          $DQM_DATA/agents/freezer
+
+        # BVB: We freeze zip files faster (1 days instead of 7)
+        startagent $D/agent-zfreeze \
+          visDQMZipFreezeDaemon \
+          $DQM_DATA/agents/freezer \
+          $DQM_DATA/zipped \
+          1 \
+          $DQM_DATA/agents/stageout
       done
       ;;
 
@@ -430,43 +461,16 @@ start()
     broen*:*agents* ) # Broens test system (basically doing what offline does)
       refuseproc "file agents" "visDQMIndex|[^/]zip +|OnlineSync|visDQMCreateInfo" "refusing to restart"
 
-      # standard lot of agents
       for D in $CONFIGS; do
         D=${D}
-        CASTORDIR=/castor/cern.ch/cms/store/dqm/logarchive/test/dqmguidata/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
         DQM_DATA=$STATEDIR/$D
 
         startagent $D/agent-receive \
-	  visDQMReceiveDaemon \
-	  $DQM_DATA/uploads \
-	  $DQM_DATA/data \
-	  $DQM_DATA/agents/register \
-	  $DQM_DATA/agents/zip
-
-        startagent $D/agent-zip \
-          visDQMZipDaemon \
-          $DQM_DATA/agents/zip \
+          visDQMReceiveDaemon \
+          $DQM_DATA/uploads \
           $DQM_DATA/data \
-          $DQM_DATA/zipped \
-          $DQM_DATA/agents/freezer
-
-	# BVB: We freeze zip files immediately (0 days instead of 7)
-        startagent $D/agent-zfreeze \
-          visDQMZipFreezeDaemon \
-          $DQM_DATA/agents/freezer \
-          $DQM_DATA/zipped \
-          0 \
-          $DQM_DATA/agents/stageout
-
-	# BVB: We verify zip files immediately (0 hours instead of 24)
-        startagent $D/agent-zverifier \
-          visDQMZipCastorVerifier \
-          $DQM_DATA/agents/verify \
-          marco.rovere@cern.ch,atanas.batinkov@cern.ch,broen.vanbesien@cern.ch \
-          $DQM_DATA/zipped \
-          $CASTORDIR \
-          0 \
-          $DQM_DATA/agents/clean
+          $DQM_DATA/agents/register \
+          $DQM_DATA/agents/zip
 
         startagent $D/agent-import-128 \
           visDQMImportDaemon \
@@ -488,15 +492,24 @@ start()
           $DQM_DATA/agents/vcontrol \
           $DQM_DATA/data
 
-        startagent $D/agent-ixmerge \
-            visDQMIndexMergeDaemon \
-            $DQM_DATA/agents/ixmerge \
-            $DQM_DATA/ix128 \
-            $DQM_DATA/agents/register
+        startagent $D/agent-zip \
+          visDQMZipDaemon \
+          $DQM_DATA/agents/zip \
+          $DQM_DATA/data \
+          $DQM_DATA/zipped \
+          $DQM_DATA/agents/freezer
+
+        # BVB: We freeze zip files immediately (0 days instead of 7)
+        startagent $D/agent-zfreeze \
+          visDQMZipFreezeDaemon \
+          $DQM_DATA/agents/freezer \
+          $DQM_DATA/zipped \
+          0 \
+          $DQM_DATA/agents/stageout
       done
       ;;
 
-    vocms138:*afs-sync* | vocms0138:*afs-sync* )
+    vocms138:*afs-sync* ) # afs-sync only started on SLC5, stopped when migrating to SLC6
       refuseproc "afs sync" "visDQMAfsSync"
 
       DIRS=OnlineData,OfflineData/HIRun2011/StreamHIExpress
@@ -519,7 +532,6 @@ start()
     *:*agents* )
       refuseproc "file agents" "visDQMIndex|[^/]zip +" "refusing to restart"
 
-      # standard lot of agents
       for D in $FLAVOR; do
         DQM_DATA=$STATEDIR/$D
         startagent $D/agent-receive \
@@ -536,7 +548,7 @@ start()
           $DQM_DATA/agents/qcontrol \
           $DQM_DATA/agents/vcontrol
 
-	startagent $D/agent-qcontrol \
+        startagent $D/agent-qcontrol \
           visDQMRootFileQuotaControl \
           $DQM_DATA/agents/qcontrol \
           $DQM_DATA/agents/register \
@@ -706,36 +718,6 @@ compile()
   done
 }
 
-# Backup new root files (zipped) to castor
-rootfilesbackup()
-{
-  refuseproc "castor root file backup" "visDQMZipCastorStager"
-
-  for D in $CONFIGS; do
-    D=${D}
-    # Modify Castor dir for specific local test server, so that this can be tested by the cmsdqm account
-    case $HOST in
-      vocms013[389] )
-        CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
-        ;;
-      * )
-        CASTORDIR=/castor/cern.ch/cms/store/dqm/logarchive/test/dqmguidata/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
-        ;; 
-    esac
-    DQM_DATA=$STATEDIR/$D
-    LOGSTEM=$D/agent-castorrootfilebackup
-    # Start the original agent process, however, not as an agent, but directly in the current thread.
-    # The agent was modified in such a way that it exits after each cycle.
-    # It is supposed to be started from/by acrontab.
-    visDQMZipCastorStager \
-      $DQM_DATA/agents/stageout \
-      $DQM_DATA/zipped \
-      $CASTORDIR \
-      $DQM_DATA/agents/verify \
-      </dev/null 2>&1 | rotatelogs $LOGDIR/$LOGSTEM-%Y%m%d.log 86400 >/dev/null 2>&1
-  done
-}
-
 # Backups dqmgui by archiving its state to castor
 # This is the backup of the index
 backup()
@@ -831,6 +813,68 @@ backup()
   echo "Backup completed."
 }
 
+# Backup new root files (zipped) to castor
+zipbackup()
+{
+  refuseproc "castor root file backup" "visDQMZipCastorStager"
+
+  for D in $CONFIGS; do
+    D=${D}
+    # Modify Castor dir for specific local test server, so that this can be tested by the cmsdqm account
+    case $HOST in
+      vocms013[389] )
+        CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
+        ;;
+      * )
+        CASTORDIR=/castor/cern.ch/cms/store/dqm/logarchive/test/dqmguidata/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
+        ;; 
+    esac
+    DQM_DATA=$STATEDIR/$D
+    LOGSTEM=$D/agent-castorzipbackup
+    # Start the original agent process, however, not as an agent, but directly in the current thread.
+    # The agent was modified in such a way that it exits after each cycle.
+    # It is supposed to be started from/by acrontab.
+    visDQMZipCastorStager \
+      $DQM_DATA/agents/stageout \
+      $DQM_DATA/zipped \
+      $CASTORDIR \
+      $DQM_DATA/agents/verify \
+      </dev/null 2>&1 | rotatelogs $LOGDIR/$LOGSTEM-%Y%m%d.log 86400 >/dev/null 2>&1
+  done
+}
+
+# Check / verify the backup of the zipped root files to castor
+zipbackupcheck()
+{
+  refuseproc "castor root file backup check" "visDQMZipCastorVerifier"
+
+  for D in $CONFIGS; do
+    D=${D}
+    # Modify Castor dir for specific local test server, so that this can be tested by the cmsdqm account
+    case $HOST in
+      vocms013[389] )
+        CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
+        ;;
+      * )
+        CASTORDIR=/castor/cern.ch/cms/store/dqm/logarchive/test/dqmguidata/$(echo $D | sed -r 's/(offline|relval)/dqmdata/')
+        ;; 
+    esac
+    DQM_DATA=$STATEDIR/$D
+    LOGSTEM=$D/agent-castorzipbackupcheck
+    # Start the original agent process, however, not as an agent, but directly in the current thread.
+    # The agent was modified in such a way that it exits after each cycle.
+    # It is supposed to be started from/by acrontab.
+    visDQMZipCastorVerifier \
+      $DQM_DATA/agents/verify \
+      marco.rovere@cern.ch,broen.van.besien@cern.ch \
+      $DQM_DATA/zipped \
+      $CASTORDIR \
+      24 \
+      $DQM_DATA/agents/clean \
+      </dev/null 2>&1 | rotatelogs $LOGDIR/$LOGSTEM-%Y%m%d.log 86400 >/dev/null 2>&1
+  done
+}
+
 # Verify the security string.
 check()
 {
@@ -855,18 +899,19 @@ done
 newline=""
 getconfigs
 
-# Check user name. Everything except afs-sync, backup (of index) and
-# rootfilesbackup must run as non-$ALTERNATIVE_USER account, afs-sync, backup
-# and rootfilesbackup must be under $ALTERNATIVE_USER, refuse to run otherwise.
+# Check user name. Everything except afs-sync, backup (of index),zipbackup and
+# zipbackupcheck must run as non-$ALTERNATIVE_USER account, afs-sync, backup,
+# zipbackup and zipbackupcheck must be under $ALTERNATIVE_USER, refuse to run
+# otherwise.
 case $FLAVOR:$(id -un):$1:$2 in
-  *:$ALTERNATIVE_USER:*:afs-sync | *:$ALTERNATIVE_USER:rootfilesbackup:* | *:$ALTERNATIVE_USER:backup:* )
+  *:$ALTERNATIVE_USER:*:afs-sync | *:$ALTERNATIVE_USER:backup:* | *:$ALTERNATIVE_USER:zipbackup:* | *:$ALTERNATIVE_USER:zipbackupcheck:* )
     ;;
 
-  offline-caf:$ALTERNATIVE_USER:*:* | offline-caf:*:*:afs-sync | relval:*:rootfilesbackup:* | offline-caf:*:backup:* )
+  offline-caf:$ALTERNATIVE_USER:*:* | offline-caf:*:*:afs-sync | offline-caf:*:backup:* | offline-caf:*:zipbackup:* | offline-caf:*:zipbackupcheck:* )
     echo "ERROR: please use another account" 1>&2
     exit 1 ;;
 
-  relval:$ALTERNATIVE_USER:*:* | relval:*:*:afs-sync | relval:*:rootfilesbackup:* | relval:*:backup:* )
+  relval:$ALTERNATIVE_USER:*:* | relval:*:*:afs-sync | relval:*:backup:* | relval:*:zipbackup:* | relval:*:zipbackupcheck:* )
     echo "ERROR: please use another account" 1>&2
     exit 1 ;;
 esac
@@ -918,14 +963,19 @@ case ${1:-status} in
     stop "$2"
     ;;
 
-  rootfilesbackup )
-    check "$2"
-    rootfilesbackup
-    ;;
-
   backup )
     check "$3"
     backup "$2"
+    ;;
+
+  zipbackup )
+    check "$2"
+    zipbackup
+    ;;
+
+  zipbackupcheck )
+    check "$2"
+    zipbackupcheck
     ;;
 
   help )


### PR DESCRIPTION
These changes should come together with a new release of the dqmgui that Marco will prepare very soon.

To explain the changes:
- In the manage script:
    Added the "zipbackupcheck" operation, that will be used to start the CastorVerifier by acron
    For the starting and stopping of the agents: did a further split of the servers, making it more explicit what is started and where. This will be the situation during the parallel run:
      - 133: the default
      - 138 and 139:  the default + the zip backup chain + the online to offline + afs sync
      - 0133: the default + the zip backup chain
      - 0138 and 0139: the default + the online to offline

- In the deploy script:
    Added the CastorVerifier so that it is also to the acrontab
    Cleaned and updated what is installed when and where. This will be the situation during the parallel run:
      - afssync: only on the 139
      - backup (of the index): only 133, 138, 139
      - zipbackup (CastorStager): only 0133
      - zipbackupcheck (CastorVerifier): only 0133