### PR TITLE
Updating manage script for vis dqm sound alarm daemon

### DIFF
--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -231,7 +231,7 @@ start()
         http://localhost:8030/dqm/online \
         cmsdaqweb.cms \
         50555 600 2 \
-	cms-dqm-oncall@cern.ch
+        cms-dqm-oncall@cern.ch
       ;;
 
     dqm-c2d07-02:*agents* ) # dqm-prod-offsite

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -230,7 +230,8 @@ start()
         visDQMSoundAlarmDaemon \
         http://localhost:8030/dqm/online \
         cmsdaqweb.cms \
-        50555 600 2
+        50555 600 2 \
+	cms-dqm-oncall@cern.ch
       ;;
 
     dqm-c2d07-02:*agents* ) # dqm-prod-offsite


### PR DESCRIPTION
This is a PR quite separate from all the rest. It adds one line to the configuration of the sound daemon for the online production server. (So this has no effect whatsoever on any of the servers managed by the http group.)
I just want to add this line now, so that it's there when we can finaly migrate our Online servers to slc6 as well.
Thanks for merging this.