### PR TITLE
Add creation of agent folder ixstageout to dqmgui deploy

### DIFF
--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -30,7 +30,7 @@ deploy_dqmgui_prep()
     * )
       for d in online offline caf relval dev; do
         extra="$extra $d $d/sessions $d/agents $d/data $d/uploads $d/zipped $project_logs/$d"
-	for a in clean freezer ixmerge qcontrol vcontrol register register128 stageout verify zip; do
+	for a in clean freezer ixmerge ixstageout qcontrol vcontrol register register128 stageout verify zip; do
 	  extra="$extra $d/agents/$a"
 	done
       done


### PR DESCRIPTION
Agents were written to create this folder themselves when necessary.
And they did the job.
However, the stageout agent was the first to do this, and created the folder with such permissions that the import agent can not write to it.
The more correct way to do it in the deploy script is done in this PR.
Tested locally.
In principle, we should delete the folder /data/srv/state/dqmgui/dev/agents/ixstageout before new deployment, to test if creation happens correctly.