### PR TITLE
Prep dqmgui prod switch to slc6

### DIFF
--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -66,7 +66,7 @@ deploy_dqmgui_post()
      echo "17 2 * * * $cmd"
      # Set the castor stageout (root files backup) on slc5 machines: run by cron under cmsweb account
      case $host in
-       vocms013[89] )
+       vocms13[89] )
        echo "@reboot $project_config/manage xstart stageout 'I did read documentation'" ;;
      esac
    }) | crontab -

--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -66,7 +66,7 @@ deploy_dqmgui_post()
      echo "17 2 * * * $cmd"
      # Set the castor stageout (root files backup) on slc5 machines: run by cron under cmsweb account
      case $host in
-       vocms13[89] )
+       vocms013[89] )
        echo "@reboot $project_config/manage xstart stageout 'I did read documentation'" ;;
      esac
    }) | crontab -
@@ -84,7 +84,7 @@ deploy_dqmgui_post()
        esac
 
        # Set the backup of the index files to castor
-       # During the parallel run period, should only run on SLC5
+       # This is the old index backup. Should only run on SLC5.
        case $host in
          vocms13[89] )
            echo "30 3 * * 0 $host [ \$(date +\\%e) -le 7 ] &&" \
@@ -93,26 +93,23 @@ deploy_dqmgui_post()
        esac
 
        # Set the backup of the index (index CASTOR stageout)
-       # Currently only on SLC6 dev machine
-       # After the parallel run this must be switched on on the prod machines
+       # Only for Offline or Relval SLC6 machines
        case $host in
-         vocms0133 | broen* )
+         vocms013[389] | broen* )
            echo "*/15 * * * * $host $project_config/manage indexbackup 'I did read documentation'" ;;
        esac
-       
+
        # Set the backup of the zipped root files (zip CASTOR stageout)
-       # Currently only on SLC6 dev machine
-       # After the parallel run this must be switched on on the prod machines
+       # Only for Offline or Relval SLC6 machines
        case $host in
-         vocms0133 | broen* )
+         vocms013[389] | broen* )
            echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'" ;;
        esac
 
        # Set the check/verification of the backup of the zipped root files
-       # Currently only on SLC6 dev machine
-       # After the parallel run this must be switched on on the prod machines
+       # Only for Offline or Relval SLC6 machines
        case $host in
-         vocms0133 | broen* )
+         vocms013[389] | broen* )
            echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'" ;;
        esac
       ) | acrontab

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -316,23 +316,6 @@ start()
             $DQM_DATA/ix128 \
             $DQM_DATA/agents/register
 
-        # When the period of parallel running is finished,
-        # the zip and zipfreeze below should be removed
-
-        startagent $D/agent-zip \
-          visDQMZipDaemon \
-          $DQM_DATA/agents/zip \
-          $DQM_DATA/data \
-          $DQM_DATA/zipped \
-          $DQM_DATA/agents/freezer
-
-        startagent $D/agent-zfreeze \
-          visDQMZipFreezeDaemon \
-          $DQM_DATA/agents/freezer \
-          $DQM_DATA/zipped \
-          7 \
-          $DQM_DATA/agents/stageout
-
         if [ $D = offline ]; then
           startagent $D/agent-osync \
             visDQMOnlineSyncDaemon \
@@ -387,8 +370,19 @@ start()
           $DQM_DATA/agents/vcontrol \
           $DQM_DATA/data
 
-        # When the period of parallel running is finished,
-        # zip and zipfreeze should be added here
+        startagent $D/agent-zip \
+          visDQMZipDaemon \
+          $DQM_DATA/agents/zip \
+          $DQM_DATA/data \
+          $DQM_DATA/zipped \
+          $DQM_DATA/agents/freezer
+
+        startagent $D/agent-zfreeze \
+          visDQMZipFreezeDaemon \
+          $DQM_DATA/agents/freezer \
+          $DQM_DATA/zipped \
+          7 \
+          $DQM_DATA/agents/stageout
 
         if [ $D = offline ]; then
           startagent $D/agent-osync \
@@ -409,7 +403,7 @@ start()
       ;;
 
     # Special setup for the vocms0133 test server. (In the past this didn't run the Castor agent chain)
-    # This runs the agents to backup the zipped root files to Castor, but at a "faster" tempo for testing
+    # This runs the agents to backup the zipped root files to Castor
     vocms0133:*agents* )
       refuseproc "file agents" "visDQMIndex|[^/]zip +|OnlineSync|visDQMCreateInfo" "refusing to restart"
 
@@ -453,12 +447,11 @@ start()
           $DQM_DATA/zipped \
           $DQM_DATA/agents/freezer
 
-        # BVB: We freeze zip files faster (1 days instead of 7)
         startagent $D/agent-zfreeze \
           visDQMZipFreezeDaemon \
           $DQM_DATA/agents/freezer \
           $DQM_DATA/zipped \
-          1 \
+          7 \
           $DQM_DATA/agents/stageout
       done
       ;;


### PR DESCRIPTION
For the config script:
- turning on acrontab entries for zipbackup, zipbackupcheck and indexbackup for new SLC6 servers
- on the old SLC5 servers, the stageout will have to be turned of manually

For the manage script:
- ZipDaemon and ZipFreezeDaemon will now run on the new SLC6 servers.
- on the old SLC5 servers, both Daemons will have to be removed manually from manage
- On the test server: Changed freeze period for zip files from 1 to 7 days, like on the other servers. 