### PR TITLE
deployment script for wmstats server

### DIFF
--- a/frontend/app_reqmon_nossl.conf
+++ b/frontend/app_reqmon_nossl.conf
@@ -1,2 +1,3 @@
+RewriteRule ^(/wmstatsserver(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/c?wmstats(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/c?workloadsummary(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]

--- a/frontend/app_reqmon_ssl.conf
+++ b/frontend/app_reqmon_ssl.conf
@@ -1,3 +1,5 @@
+RewriteRule ^(/wmstatsserver(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
+RewriteRule ^/auth/complete(/wmstatsserver(/.*)?)$ http://%{ENV:BACKEND}:8299${escape:$1} [QSA,P,L,NE]
 RewriteRule ^(/c?wmstats(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
 RewriteRule ^/auth/complete/wmstats(/.*)?$ http://%{ENV:BACKEND}:5984/wmstats/_design/WMStats/_rewrite${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete/cwmstats(/.*)?$ http://%{ENV:BACKEND}:5985/wmstats/_design/WMStats/_rewrite${escape:$1} [QSA,P,L,NE]

--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -135,15 +135,6 @@ if  HOST.startswith("vocms0307") or HOST.startswith("vocms0133"):
     couchCleanup.workqueueCleanDuration = 60 * 60 * 12 # every 12 hours
     couchCleanup.log_file = '%s/logs/reqmgr2/couchCleanup-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
     
-    # LogDB task (update and clean up)
-    logDBTasks = extentions.section_("logDBTasks")
-    logDBTasks.object = "WMCore.ReqMgr.CherryPyThreads.LogDBTasks.LogDBTasks"
-    logDBTasks.central_logdb_url = data.central_logdb_url
-    logDBTasks.log_reporter = data.log_reporter
-    logDBTasks.logDBCleanDuration = 60 * 60 * 24 * 7 # 7 days
-    logDBTasks.logDBUpdateDuration = 60 * 10 # every 10 min
-    logDBTasks.log_file = '%s/logs/reqmgr2/logDBTasks-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
-    
     # status change task 
     statusChangeTasks = extentions.section_("statusChangeTasks")
     statusChangeTasks.object = "WMCore.ReqMgr.CherryPyThreads.StatusChangeTasks.StatusChangeTasks"

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -6,7 +6,6 @@ deploy_reqmgr2_deps()
   deploy backend
   deploy wmcore-auth
   deploy couchdb
-  deploy bigcouch
   deploy reqmon
   deploy acdcserver $variant
 

--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -1,0 +1,96 @@
+"""
+ReqMgr only configuration file.
+Everything configurable in ReqMgr is defined here.
+
+"""
+
+import socket
+import time
+from WMCore.Configuration import Configuration
+from os import path
+
+HOST = socket.gethostname().lower()
+BASE_URL = "@@BASE_URL@@"
+DBS_INS = "@@DBS_INS@@"
+COUCH_URL = "%s/couchdb" % BASE_URL
+LOG_DB_URL = "%s/wmstats_logdb" % COUCH_URL
+
+ROOTDIR = __file__.rsplit('/', 3)[0]
+config = Configuration()
+
+main = config.section_("main")
+srv = main.section_("server")
+srv.thread_pool = 30
+main.application = "wmstatsserver"
+main.application_dir = "reqmon"
+main.port = 8299 # main application port it listens on
+main.index = "ui"
+# Defaults to allow any CMS authenticated user. Write APIs should require
+# additional roles in SiteDB (i.e. "Admin" role for the "ReqMgr" group)
+main.authz_defaults = {"role": None, "group": None, "site": None}
+
+sec = main.section_("tools").section_("cms_auth")
+sec.key_file = "%s/auth/wmcore-auth/header-auth-key" % ROOTDIR
+
+# this is where the application will be mounted, where the REST API
+# is reachable and this features in CMS web frontend rewrite rules
+app = config.section_(main.application) # string containing "wmstats"
+app.admin = "cms-service-webtools@cern.ch"
+app.description = "CMS data operations Request Manager."
+app.title = "CMS WMStats (ReqMon)"
+
+views = config.section_("views")
+
+# practical to have this kind of configuration values not in
+# service related RPM (difficult/impossible to change in CMS web
+# deployment) but in the deployment configuration for the service
+
+# redirector for the REST API implemented handlers
+data = views.section_("data")
+data.object = "WMCore.WMStats.Service.RestApiHub.RestApiHub"
+# The couch host is defined during deployment time.
+data.couch_host = COUCH_URL
+# main ReqMgr CouchDB database containing all requests with spec files attached
+data.couch_reqmgr_db = "reqmgr_workload_cache"
+# ReqMgr database containing groups, teams, software, etc
+data.couch_config_cache_db = "reqmgr_config_cache"
+data.couch_workload_summary_db = "workloadsummary"
+data.couch_wmstats_db = "wmstats"
+data.central_logdb_url = LOG_DB_URL
+data.log_reporter = "wmstats"
+
+if DBS_INS == "private_vm":
+    data.dbs_url = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
+else:
+    data.dbs_url = "%s/dbs/%s/global/DBSReader" % (BASE_URL, DBS_INS)
+
+# web user interface
+ui = views.section_("ui")
+ui.object = "WMCore.WMStats.WebGui.FrontPage.FrontPage"
+ui.static_content_dir = path.join(path.abspath(ROOTDIR),
+                                 "apps",
+                                 main.application_dir,
+                                 "data")
+
+extentions = config.section_("extensions")
+
+# wmstats data cache update (This need to be updated for all backend since this is memory cache)
+dataCacheTasks = extentions.section_("dataCacheTasks")
+dataCacheTasks.object = "WMCore.WMStats.CherryPyThreads.DataCacheUpdate.DataCacheUpdate"
+dataCacheTasks.wmstats_url = "%s/%s" % (data.couch_host, data.couch_wmstats_db)
+dataCacheTasks.reqmgrdb_url = "%s/%s" % (data.couch_host, data.couch_reqmgr_db)
+dataCacheTasks.dataCacheUpdateDuration = 60 * 5 # every 5 min
+dataCacheTasks.log_file = '%s/logs/reqmon/dataCacheTasks-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
+
+# Production instance of wmdatamining, must be a production back-end
+if  HOST.startswith("vocms0307") or HOST.startswith("vocms0133"):
+    
+    # LogDB task (update and clean up)
+    logDBTasks = extentions.section_("logDBTasks")
+    logDBTasks.object = "WMCore.WMStats.CherryPyThreads.LogDBTasks.LogDBTasks"
+    logDBTasks.central_logdb_url = data.central_logdb_url
+    logDBTasks.log_reporter = data.log_reporter
+    logDBTasks.logDBCleanDuration = 60 * 60 * 24 * 1 # 1 day
+    logDBTasks.logDBUpdateDuration = 60 * 10 # every 10 min
+    logDBTasks.log_file = '%s/logs/reqmon/logDBTasks-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
+    

--- a/reqmon/deploy
+++ b/reqmon/deploy
@@ -1,8 +1,9 @@
 # vim: set ft=sh sw=2 ts=8 et :
 deploy_reqmon_deps()
-{
+{ 
+  deploy backend
+  deploy wmcore-auth
   deploy couchdb
-  deploy bigcouch
 }
 
 deploy_reqmon_prep()
@@ -12,12 +13,30 @@ deploy_reqmon_prep()
 
 deploy_reqmon_sw()
 {
-  deploy_pkg comp cms+reqmon
-  perl -p -i -e 's/__fill_dbname_here__/wmstats/g' $root/current/apps/reqmon/data/couchapps/WMStats/_attachments/js/loader.js
+  deploy_pkg \
+    -a dmwm-service-cert.pem:wmcore/dmwm-service-cert.pem \
+    -a dmwm-service-key.pem:wmcore/dmwm-service-key.pem \
+    comp cms+reqmon
+
+  if grep -rq "replace me" $project_auth; then
+    note "WARNING: replace certificates in $project_auth with real ones"
+  else :; fi
+
+  case $variant in
+    prod )    base_url="https://cmsweb.cern.ch"         dbs_ins="prod";;
+    preprod ) base_url="https://cmsweb-testbed.cern.ch" dbs_ins="int";;
+    dev )     base_url="https://cmsweb-dev.cern.ch"     dbs_ins="dev";;
+    * )       base_url="https://`hostname -f`"          dbs_ins="private_vm";;
+  esac
+  perl -p -i -e "s{\"\@\@BASE_URL\@\@\"}{\"$base_url\"}g; \
+                 s{\"\@\@DBS_INS\@\@\"}{\"$dbs_ins\"}g"   \
+       $project_config/config.py
 }
 
 deploy_reqmon_post()
 {
+  case $host in vocms13[89] | vocms013[89] ) disable;;  * ) enable;; esac
+  
   # Tell couch to push the reqmon app on the next restart
   for couch in couchdb:5984 bigcouch:5985; do
     echo "couchapp push $root/current/apps/reqmon/data/couchapps/WMStats" \
@@ -29,4 +48,12 @@ deploy_reqmon_post()
     echo "couchapp push $root/current/apps/reqmon/data/couchapps/LogDB" \
          "http://localhost:${couch##*:}/wmstats_logdb" >> $root/state/${couch%%:*}/stagingarea/reqmon  
   done
+}
+
+deploy_reqmon_auth()
+{
+  case $1 in
+    */*-cert.pem ) echo "replace me with your dmwm service certificate" ;;
+    */*-key.pem )  echo "replace me with your dmwm service key" ;;
+  esac
 }

--- a/reqmon/manage
+++ b/reqmon/manage
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+##H Usage: manage ACTION [SECURITY-STRING]
+##H
+##H Available actions:
+##H   help              show this help
+##H   version           get current version of the service
+##H   status            show current service's status
+##H   sysboot           start server from crond if not running
+##H   restart           (re)start the service
+##H   updateversions    update database with ScramArchs/CMSSW releases
+##H   start             (re)start the service
+##H   stop              stop the service
+##H
+##H For more details please refer to operations page:
+##H   https://twiki.cern.ch/twiki/bin/view/CMS/ReqMgrSystemDesign
+##H [nice, obsolete twiki, leave for reference and example ...]
+
+if [ $(id -un)  = cmsweb ]; then
+  echo "ERROR: please use another account" 1>&2
+  exit 1
+fi
+
+echo_e=-e bsdstart=bsdstart
+case $(uname) in
+  Darwin )
+    md5sum() { md5 -r ${1+"$@"}; }
+    echo_e= bsdstart=start
+    ;;
+esac
+
+ME=$(basename $(dirname $0))
+TOP=$(cd $(dirname $0)/../../.. && pwd)
+ROOT=$(cd $(dirname $0)/../.. && pwd)
+CFGDIR=$(dirname $0)
+LOGDIR=$TOP/logs/$ME
+STATEDIR=$TOP/state/$ME
+CFGFILE=$CFGDIR/config.py
+AUTHDIR=$TOP/current/auth/reqmon
+COLOR_OK="\\033[0;32m"
+COLOR_WARN="\\033[0;31m"
+COLOR_NORMAL="\\033[0;39m"
+
+. $ROOT/apps/$ME/etc/profile.d/init.sh
+
+export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH
+export WMCORE_ROOT=$REQMON_ROOT/lib/python*/site-packages
+if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then
+  export X509_USER_CERT=$AUTHDIR/dmwm-service-cert.pem
+  export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem
+fi
+
+
+# Start service conditionally on crond restart.
+sysboot()
+{
+  wmc-httpd -v -d $STATEDIR -l "|rotatelogs $LOGDIR/reqmon-%Y%m%d.log 86400" $CFGFILE
+}
+
+
+# Start the service.
+start()
+{
+  echo "starting $ME"
+  wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/reqmon-%Y%m%d.log 86400" $CFGFILE
+}
+
+
+# Stop the service.
+stop()
+{
+  echo "stopping $ME"
+  wmc-httpd -k -d $STATEDIR $CFGFILE
+}
+
+
+# Check if the server is running.
+status()
+{
+  wmc-httpd -s -d $STATEDIR $CFGFILE
+}
+
+
+# Verify the security string.
+check()
+{
+  CHECK=$(echo "$1" | md5sum | awk '{print $1}')
+  if [ $CHECK != 94e261a5a70785552d34a65068819993 ]; then
+    echo "$0: cannot complete operation, please check documentation." 1>&2
+    exit 2;
+  fi
+}
+
+
+# Main routine, perform action requested on command line.
+case ${1:-status} in
+  sysboot )
+    sysboot
+    ;;
+
+  start | restart )
+    check "$2"
+    stop
+    start
+    ;;
+
+  status )
+    status
+    ;;
+
+  stop )
+    check "$2"
+    stop
+    ;;
+
+
+  help )
+    perl -ne '/^##H/ && do { s/^##H ?//; print }' < $0
+    ;;
+
+  version )
+    echo "$REQMON_VERSION"
+    ;;
+
+  * )
+    echo "$0: unknown action '$1', please try '$0 help' or documentation." 1>&2
+    exit 1
+    ;;
+esac

--- a/reqmon/monitoring.ini
+++ b/reqmon/monitoring.ini
@@ -1,0 +1,17 @@
+# Glob pattern to search for log files under the svc logs directory,
+# and the regular expression to look for in those files.
+LOG_FILES='*.log'
+LOG_ERROR_REGEX='ERROR'
+
+# Perl regex to look for the service process using ps
+PS_REGEX="wmc-httpd.*[/]reqmon/config.py"
+
+# The ping test fetches the provided URL and look for the following perl regex
+PING_URL="http://localhost:8299/wmstatserver/data/info"
+PING_HEADER="Accept: application/json"
+PING_REGEX="wmcore_reqmon_version"
+
+# Monitor process activity
+PROCESS_OWNER="_reqmon"
+PROCESS_REGEX_NAME="wmc-httpd.*[/]reqmon/config.py"
+PROCESS_ACTIVITY="cpu,mem,threads,user,system,rss,vms"


### PR DESCRIPTION
@geneguvo, Diego, could you review the code?

This change include REST server (cherrypy) for wmstats which includes server side data cache and moved logDB thread from reqmgr2.
This is still initial version so there will be additional features to be added.
DataCache addition will use additional ~30MB of server side memory.

/wmstatsserver/data is the server uri for data service but will move to /wmstats/data when we relocate the wmstats source code from couchapp to html directly in WMCore/src. (we need to do some refactoring so it won't be this deployment)

Thanks  