### PR TITLE
Fix CERN CA url to request host certificate

### DIFF
--- a/system/careq-cern-ch
+++ b/system/careq-cern-ch
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     exit(1)
 
   # Authenticate to CERN SSO.
-  ca_url = "https://gridca.cern.ch/gridca/host/HostSelection.aspx?template=EE2Host&instructions=openssl"
+  ca_url = "https://ca.cern.ch/ca/host/HostSelection.aspx?template=ee2host&instructions=openssl"
   url, form_data, initial_page = sso_auth(ca_url)
 
   # Unfortunately, gridca.cern.ca returns /gridca as initial page, so


### PR DESCRIPTION
It was failing to automatically renew my host certificate, with [1]. I changed the url and it works ok now.
@geneguvo @BrunoCoimbra please merge

[1]
WARNING: it will use your kerberos credentials for the Single Sign On.
Using SSL X509 key /afs/cern.ch/user/a/amaltaro/.globus/userkey.pem certificate /afs/cern.ch/user/a/amaltaro/.globus/usercert.pem
Traceback (most recent call last):
  File "/tmp/foo/cfg/system/careq-cern-ch", line 134, in <module>
    url, form_data, initial_page = sso_auth(ca_url)
  File "/tmp/foo/cfg/system/careq-cern-ch", line 64, in sso_auth
    assert m, "No cert login link at <%s>" % login.geturl()
AssertionError: No cert login link at <https://ca.cern.ch/ca/?template=EE2Host&instructions=openssl>