### PR TITLE
Removed Castor from the shift layouts

### DIFF
--- a/dqmgui/layouts/castor-layouts.py
+++ b/dqmgui/layouts/castor-layouts.py
@@ -1,4 +1,10 @@
-def castorlayout(i, p, *rows): i["Castor/Layouts/" + p] = DQMItem(layout=rows)
+def castorlayout(i, p, *rows):
+    i["Castor/Layouts/" + p] = DQMItem(layout=rows)
+
+# BVB 20160316: Removed Castor from the shift layouts (there are no instructions
+#               and as far as we know Castor will not be in before the HI run at
+#               the end of the year). We leave the expert workspace for what it
+#               is.
 
 castorlayout(dqmitems, "01 - Map of frontend and readout errors",
            [{ 'path': "Castor/CastorDigiMonitor/QIE_capID+er+dv",

--- a/dqmgui/layouts/castor_T0_layouts.py
+++ b/dqmgui/layouts/castor_T0_layouts.py
@@ -1,4 +1,10 @@
-def castorlayout(i, p, *rows): i["Castor/Layouts/" + p] = DQMItem(layout=rows)
+def castorlayout(i, p, *rows):
+    i["Castor/Layouts/" + p] = DQMItem(layout=rows)
+
+# BVB 20160316: Removed Castor from the shift layouts (there are no instructions
+#               and as far as we know Castor will not be in before the HI run at
+#               the end of the year). We leave the expert workspace for what it
+#               is.
 
 castorlayout(dqmitems, "01 - Map of frontend and readout errors",
            [{ 'path': "Castor/CastorDigiMonitor/QIE_capID+er+dv",

--- a/dqmgui/layouts/shift_castor_T0_layout.py
+++ b/dqmgui/layouts/shift_castor_T0_layout.py
@@ -1,16 +1,22 @@
-def shiftcastorlayout(i, p, *rows): i["00 Shift/Castor/" + p] = DQMItem(layout=rows)
+def shiftcastorlayout(i, p, *rows):
+    i["00 Shift/Castor/" + p] = DQMItem(layout=rows)
 
-shiftcastorlayout(dqmitems, "01 - Map of frontend and readout errors",
-           [{ 'path': "Castor/CastorDigiMonitor/QIE_capID+er+dv",
-             'description':"Frontend and readout errors"}]
-           )
+# BVB 20160316: Removed Castor from the shift layouts (there are no instructions
+#               and as far as we know Castor will not be in before the HI run at
+#               the end of the year). We leave the expert workspace for what it
+#               is.
 
-shiftcastorlayout(dqmitems, "02 - Channel-wise timing",
-           [{ 'path': "Castor/CastorDigiMonitor/QfC=f(Tile TS) (cumulative)",
-             'description':"Channel-wise timing"}]
-           )
-
-shiftcastorlayout(dqmitems, "03 - Map of rechit occupancies",
-           [{ 'path': "Castor/CastorRecHitMonitor/CastorRecHitOccMap",
-             'description':"Map of rechit occupancies"}]
-           )
+##shiftcastorlayout(dqmitems, "01 - Map of frontend and readout errors",
+##           [{ 'path': "Castor/CastorDigiMonitor/QIE_capID+er+dv",
+##             'description':"Frontend and readout errors"}]
+##           )
+##
+##shiftcastorlayout(dqmitems, "02 - Channel-wise timing",
+##           [{ 'path': "Castor/CastorDigiMonitor/QfC=f(Tile TS) (cumulative)",
+##             'description':"Channel-wise timing"}]
+##           )
+##
+##shiftcastorlayout(dqmitems, "03 - Map of rechit occupancies",
+##           [{ 'path': "Castor/CastorRecHitMonitor/CastorRecHitOccMap",
+##             'description':"Map of rechit occupancies"}]
+##           )

--- a/dqmgui/layouts/shift_castor_layout.py
+++ b/dqmgui/layouts/shift_castor_layout.py
@@ -1,16 +1,22 @@
-def shiftcastorlayout(i, p, *rows): i["00 Shift/Castor/" + p] = DQMItem(layout=rows)
+def shiftcastorlayout(i, p, *rows):
+    i["00 Shift/Castor/" + p] = DQMItem(layout=rows)
 
-shiftcastorlayout(dqmitems, "01 - Map of frontend and readout errors",
-           [{ 'path': "Castor/CastorDigiMonitor/QIE_capID+er+dv",
-             'description':"Frontend and readout errors"}]
-           )
+# BVB 20160316: Removed Castor from the shift layouts (there are no instructions
+#               and as far as we know Castor will not be in before the HI run at
+#               the end of the year). We leave the expert workspace for what it
+#               is.
 
-shiftcastorlayout(dqmitems, "02 - Channel-wise timing",
-           [{ 'path': "Castor/CastorDigiMonitor/QfC=f(Tile TS) (cumulative)",
-             'description':"Channel-wise timing"}]
-           )
-
-shiftcastorlayout(dqmitems, "03 - Map of rechit occupancies",
-           [{ 'path': "Castor/CastorRecHitMonitor/CastorRecHitOccMap",
-             'description':"Map of rechit occupancies"}]
-           )
+##shiftcastorlayout(dqmitems, "01 - Map of frontend and readout errors",
+##           [{ 'path': "Castor/CastorDigiMonitor/QIE_capID+er+dv",
+##             'description':"Frontend and readout errors"}]
+##           )
+##
+##shiftcastorlayout(dqmitems, "02 - Channel-wise timing",
+##           [{ 'path': "Castor/CastorDigiMonitor/QfC=f(Tile TS) (cumulative)",
+##             'description':"Channel-wise timing"}]
+##           )
+##
+##shiftcastorlayout(dqmitems, "03 - Map of rechit occupancies",
+##           [{ 'path': "Castor/CastorRecHitMonitor/CastorRecHitOccMap",
+##             'description':"Map of rechit occupancies"}]
+##           )


### PR DESCRIPTION
There are no instructions and as far as we know Castor will not be
in before the HI run at the end of the year. We leave the expert
workspace for what it is.