### PR TITLE
Update of config.py with the new URL for external REST configuration …

### DIFF
--- a/crabserver/config.py
+++ b/crabserver/config.py
@@ -37,7 +37,7 @@ data.db = 'CRABServerAuth.dbconfig'
 data.backend = 'oracle'
 data.workflowManager = 'HTCondorDataWorkflow'
 
-data.extconfigurl = 'http://git.cern.ch/pubweb/?p=CRAB3ServerConfig.git;a=blob_plain;f=cmsweb-rest-config.json'
+data.extconfigurl = 'http://gitlab.cern.ch/crab3/CRAB3ServerConfig/raw/master/cmsweb-rest-config.json'
 
 data.loggingLevel = 10
 data.loggingFile = '%s/logs/crabserver/CRAB-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))


### PR DESCRIPTION
I moved crab3 configs from git to gitlab and now we need this PR to updated config files on cmsweb.