### PR TITLE
Fixed the rainbow palette problem

### DIFF
--- a/dqmgui/style/DQMInfoRenderPlugin.cc
+++ b/dqmgui/style/DQMInfoRenderPlugin.cc
@@ -316,24 +316,7 @@ private:
       gPad->SetLeftMargin(0.12);
       obj->SetStats( kFALSE );
 
-      int pcol[2];
-      float rgb[2][2];
-      rgb[0][0] = 0.80;
-      rgb[0][1] = 0.00;
-      rgb[1][0] = 0.00;
-      rgb[1][1] = 0.80;
-
-      for( int i=0; i<2; i++ )
-      {
-        pcol[i] = 801+i;
-        TColor* color2 = gROOT->GetColor( 801+i );
-        if( ! color2 ) color2 = new TColor( 801+i, 0, 0, 0, "" );
-        color2->SetRGB( rgb[i][0], rgb[i][1], 0. );
-      }
-
-      gStyle->SetPalette(2, pcol);
-      obj->SetMinimum(-1.e-15);
-      obj->SetMaximum(1.0);
+      dqm::utils::reportSummaryMapPalette(obj);
       obj->SetOption("col");
 
       return;

--- a/dqmgui/style/ESRenderPlugin.cc
+++ b/dqmgui/style/ESRenderPlugin.cc
@@ -32,19 +32,19 @@ class ESRenderPlugin : public DQMRenderPlugin {
 
   virtual void initialise( int, char ** ) {
     float rgb[10][3] = {{0.87, 0.00, 0.00}, {0.91, 0.27, 0.00},
-			{0.95, 0.54, 0.00}, {1.00, 0.81, 0.00},
-			{0.56, 0.91, 0.00}, {0.12, 1.00, 0.00},
-			{0.06, 0.60, 0.50}, {0.00, 0.20, 1.00},
-			{0.00, 0.10, 0.94}, {0.00, 0.00, 0.87}};
+                        {0.95, 0.54, 0.00}, {1.00, 0.81, 0.00},
+                        {0.56, 0.91, 0.00}, {0.12, 1.00, 0.00},
+                        {0.06, 0.60, 0.50}, {0.00, 0.20, 1.00},
+                        {0.00, 0.10, 0.94}, {0.00, 0.00, 0.87}};
+
 
     for (int i=0; i<10; ++i) {
-      TColor* color = gROOT->GetColor( 951+i );
-      if ( ! color ) color = new TColor( 951+i, 0, 0, 0, "");
-      color->SetRGB( rgb[i][0], rgb[i][1], rgb[i][2] );
+      colorbar1[i] = TColor::GetColor(rgb[i][0], rgb[i][1], rgb[i][2]);
     }
 
-    for (int i=0; i<10; ++i) colorbar1[i] = i+951;
-    for (int i=0; i<8; ++i) colorbar2[i] = i+1;
+    for (int i=0; i<8; ++i) {
+      colorbar2[i] = i+1;
+    }
     colorbar2[0] = 0;
     colorbar2[7] = 800;
   }

--- a/dqmgui/style/JetMETRenderPlugin.cc
+++ b/dqmgui/style/JetMETRenderPlugin.cc
@@ -52,49 +52,45 @@ public:
     for(int i=0; i<22; i++)
       {
         for(int j=0; j<18; j++)
-	  {
-	    dummybox->Fill(i,j,0.1);
-	  }
+          {
+            dummybox->Fill(i,j,0.1);
+          }
       }
 
     for( int i=0; i<60; i++ ){
 
       if ( i < 15 ){
-	l1t_rgb[i][0] = 1.00;
-	l1t_rgb[i][1] = 1.00;
-	l1t_rgb[i][2] = 1.00;
+        l1t_rgb[i][0] = 1.00;
+        l1t_rgb[i][1] = 1.00;
+        l1t_rgb[i][2] = 1.00;
       }
       else if ( i < 30 ){
-	l1t_rgb[i][0] = 0.50;
-	l1t_rgb[i][1] = 0.80;
-	l1t_rgb[i][2] = 1.00;
+        l1t_rgb[i][0] = 0.50;
+        l1t_rgb[i][1] = 0.80;
+        l1t_rgb[i][2] = 1.00;
       }
       else if ( i < 40 ){
-	l1t_rgb[i][0] = 1.00;
-	l1t_rgb[i][1] = 1.00;
-	l1t_rgb[i][2] = 1.00;
+        l1t_rgb[i][0] = 1.00;
+        l1t_rgb[i][1] = 1.00;
+        l1t_rgb[i][2] = 1.00;
       }
       else if ( i < 57 ){
-	l1t_rgb[i][0] = 0.80+0.01*(i-40);
-	l1t_rgb[i][1] = 0.00+0.03*(i-40);
-	l1t_rgb[i][2] = 0.00;
+        l1t_rgb[i][0] = 0.80+0.01*(i-40);
+        l1t_rgb[i][1] = 0.00+0.03*(i-40);
+        l1t_rgb[i][2] = 0.00;
       }
       else if ( i < 59 ){
-	l1t_rgb[i][0] = 0.80+0.01*(i-40);
-	l1t_rgb[i][1] = 0.00+0.03*(i-40)+0.15+0.10*(i-17-40);
-	l1t_rgb[i][2] = 0.00;
+        l1t_rgb[i][0] = 0.80+0.01*(i-40);
+        l1t_rgb[i][1] = 0.00+0.03*(i-40)+0.15+0.10*(i-17-40);
+        l1t_rgb[i][2] = 0.00;
       }
       else if ( i == 59 ){
-	l1t_rgb[i][0] = 0.00;
-	l1t_rgb[i][1] = 0.80;
-	l1t_rgb[i][2] = 0.00;
+        l1t_rgb[i][0] = 0.00;
+        l1t_rgb[i][1] = 0.80;
+        l1t_rgb[i][2] = 0.00;
       }
 
-      l1t_pcol[i] = 1901+i;
-
-      TColor* color = gROOT->GetColor( 1901+i );
-      if( ! color ) color = new TColor( 1901+i, 0, 0, 0, "" );
-      color->SetRGB( l1t_rgb[i][0], l1t_rgb[i][1], l1t_rgb[i][2] );
+      l1t_pcol[i] = TColor::GetColor(l1t_rgb[i][0], l1t_rgb[i][1], l1t_rgb[i][2]);
     }
 
     b_box_w = new TBox();
@@ -103,11 +99,11 @@ public:
     b_box_g = new TBox();
     b_box_b = new TBox();
 
-    b_box_g->SetFillColor(1960);
-    b_box_y->SetFillColor(1959);
-    b_box_r->SetFillColor(1941);
+    b_box_g->SetFillColor(l1t_pcol[59]);
+    b_box_y->SetFillColor(l1t_pcol[58]);
+    b_box_r->SetFillColor(l1t_pcol[40]);
     b_box_w->SetFillColor(0);
-    b_box_b->SetFillColor(1923);
+    b_box_b->SetFillColor(l1t_pcol[22]);
 
   }
 

--- a/dqmgui/style/QualityTestStatusRenderPlugin.cc
+++ b/dqmgui/style/QualityTestStatusRenderPlugin.cc
@@ -112,14 +112,7 @@ void dqm::QualityTestStatusRenderPlugin::reportSummaryMapPalette(TH2* obj) {
                 // do nothing, it should not arrive here
             }
 
-            pallete[i] = 9001 + i;
-            TColor* color = gROOT->GetColor(9001 + i);
-
-            if (!color) {
-                color = new TColor(9001 + i, 0, 0, 0, "");
-            }
-
-            color->SetRGB(rgb[i][0], rgb[i][1], rgb[i][2]);
+            pallete[i] = TColor::GetColor(rgb[i][0], rgb[i][1], rgb[i][2]);
         }
     }
 

--- a/dqmgui/style/utils.cc
+++ b/dqmgui/style/utils.cc
@@ -45,10 +45,7 @@ void utils::reportSummaryMapPalette(TH2* obj)
         rgb[i][1] = 0.80;
         rgb[i][2] = 0.00;
       }
-      pcol[i] = 901+i;
-      TColor* color = gROOT->GetColor( 901+i );
-      if( ! color ) color = new TColor( 901+i, 0, 0, 0, "" );
-      color->SetRGB( rgb[i][0], rgb[i][1], rgb[i][2] );
+      pcol[i] = TColor::GetColor(rgb[i][0], rgb[i][1], rgb[i][2]);
     }
   }
 


### PR DESCRIPTION
Previously pre-defined colors would be selected by their index and then
the color would be overwritten by SetRGB. People were using random high
numbers like 950 or 2000 as their start indexes.
However with the newest root updates, they actually started to overwrite
existing colors.
We replaced those methods to use GetColor(r,g,b) witch will create the
new color _outside_ of the range if it does not exist yet.