### PR TITLE
Filter timing and exit status from DQMGUI indexing

### DIFF
--- a/dqmgui/monitoring-dqm-dev-agents.ini
+++ b/dqmgui/monitoring-dqm-dev-agents.ini
@@ -6,5 +6,6 @@ LOG_ERROR_REGEX='Traceback \(most recent|cherrypy\.error|File ".*", line \d+, in
 
 REPORT_FILES='dev/agent-*.log'
 REPORT_REGEX='\[(?P<AGENT>[A-Za-z0-9]+)/\d+\] found (?P<QUEUE>\d+) new files'
+REPORT_REGEX='\[(?P<AGENT>[A-Za-z0-9]+)/\d+\] imported .* with status (?P<STATUS>\d+) in (?P<ELAPSED>\d+.\d+)s'
 
 PS_REGEX='[/]dqmgui/[-a-z0-9.]+(/128)?/bin/visDQM[A-Za-z0-9]+(Daemon|Stager|Verifier|QuotaControl) .*/state/dqmgui/dev/agents'

--- a/dqmgui/monitoring-dqm-dev-web.ini
+++ b/dqmgui/monitoring-dqm-dev-web.ini
@@ -12,3 +12,7 @@ PS_REGEX='[/]monGui .*/server-conf-dev.py'
 
 PING_URL='http://localhost:8060/dqm/dev/digest'
 PING_REGEX='__main__\s+monGui'
+
+REPORT_FILES='dev/[w]*.log'
+REPORT_REGEX='.*INFO: saved file.*size\s+(?P<UPLOADSIZE>\d+)'
+REPORT_REGEX='.*POST /dqm/[a-zA-Z]+/data/put HTTP/\d+.\d+" 200\s+\[data:.*out\s+(?P<UPLOADELAPSED>\d+)\s+us'

--- a/dqmgui/monitoring-dqm-offline-agents.ini
+++ b/dqmgui/monitoring-dqm-offline-agents.ini
@@ -6,5 +6,6 @@ LOG_ERROR_REGEX='Traceback \(most recent|cherrypy\.error|File ".*", line \d+, in
 
 REPORT_FILES='offline/agent-*.log'
 REPORT_REGEX='\[(?P<AGENT>[A-Za-z0-9]+)/\d+\] found (?P<QUEUE>\d+) new files'
+REPORT_REGEX='\[(?P<AGENT>[A-Za-z0-9]+)/\d+\] imported .* with status (?P<STATUS>\d+) in (?P<ELAPSED>\d+.\d+)s'
 
 PS_REGEX='[/]dqmgui/[-a-z0-9.]+(/128)?/bin/visDQM[A-Za-z0-9]+(Daemon|Stager|Verifier|QuotaControl) .*/state/dqmgui/offline/agents'

--- a/dqmgui/monitoring-dqm-offline-web.ini
+++ b/dqmgui/monitoring-dqm-offline-web.ini
@@ -12,3 +12,7 @@ PS_REGEX='[/]monGui .*/server-conf-offline.py'
 
 PING_URL='http://localhost:8080/dqm/offline/digest'
 PING_REGEX='__main__\s+monGui'
+
+REPORT_FILES='offline/[w]*.log'
+REPORT_REGEX='.*INFO: saved file.*size\s+(?P<UPLOADSIZE>\d+)'
+REPORT_REGEX='.*POST /dqm/[a-zA-Z]+/data/put HTTP/\d+.\d+" 200\s+\[data:.*out\s+(?P<UPLOADELAPSED>\d+)\s+us'

--- a/dqmgui/monitoring-dqm-relval-agents.ini
+++ b/dqmgui/monitoring-dqm-relval-agents.ini
@@ -6,5 +6,6 @@ LOG_ERROR_REGEX='Traceback \(most recent|cherrypy\.error|File ".*", line \d+, in
 
 REPORT_FILES='relval/agent-*.log'
 REPORT_REGEX='\[(?P<AGENT>[A-Za-z0-9]+)/\d+\] found (?P<QUEUE>\d+) new files'
+REPORT_REGEX='\[(?P<AGENT>[A-Za-z0-9]+)/\d+\] imported .* with status (?P<STATUS>\d+) in (?P<ELAPSED>\d+.\d+)s'
 
 PS_REGEX='[/]dqmgui/[-a-z0-9.]+(/128)?/bin/visDQM[A-Za-z0-9]+(Daemon|Stager|Verifier|QuotaControl) .*/state/dqmgui/relval/agents'

--- a/dqmgui/monitoring-dqm-relval-web.ini
+++ b/dqmgui/monitoring-dqm-relval-web.ini
@@ -12,3 +12,7 @@ PS_REGEX='[/]monGui .*/server-conf-relval.py'
 
 PING_URL='http://localhost:8081/dqm/relval/digest'
 PING_REGEX='__main__\s+monGui'
+
+REPORT_FILES='relval/[w]*.log'
+REPORT_REGEX='.*INFO: saved file.*size\s+(?P<UPLOADSIZE>\d+)'
+REPORT_REGEX='.*POST /dqm/[a-zA-Z]+/data/put HTTP/\d+.\d+" 200\s+\[data:.*out\s+(?P<UPLOADELAPSED>\d+)\s+us'


### PR DESCRIPTION
Every time a file is indexed by the DQMGUI, the time spent
in the process and the exit status of the process itself are
logged. This PR updates the monitoring system to be able to
extract these informations and make them available later in
the chain.