### PR TITLE
CSC layouts and render plugins update

### DIFF
--- a/dqmgui/layouts/csc_T0_layouts.py
+++ b/dqmgui/layouts/csc_T0_layouts.py
@@ -719,12 +719,22 @@ csclayout(dqmitems,"CSC DQM Shifter/04 Timing/06 Anode RecHit Timing ME+",
          None])
 
 csclayout(dqmitems,"CSC DQM Shifter/04 Timing/07 Segments Timing",
-    [{'path': "CSC/CSCOfflineMonitor/Segments/hSTimeCathode", 'description': "Histogram shows segment time distribution. Any significant deviation from Gaussian should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+    [{'path': "CSC/CSCOfflineMonitor/Segments/hSTimeCathode", 'description': "Histogram shows cathode only segment time distribution. Any significant deviation from Gaussian should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+  {'path': "CSC/CSCOfflineMonitor/Segments/hSTimeAnode", 'description': "Histogram shows anode only segment time distribution. Any significant deviation from Gaussian should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
   {'path': "CSC/CSCOfflineMonitor/Segments/hSTimeVsTOF", 'description': "Histogram shows combined segment time distribution (average of cathode times and pruned anode times). Any significant deviation from Gaussian should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}],
   [{'path': "CSC/CSCOfflineMonitor/Segments/hSTimeCombined", 'description': "Histogram shows combined segment time vs the distance from IP. Any significant fraction of out of zero events should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+  {'path': "CSC/CSCOfflineMonitor/Segments/hSTimeDiff", 'description': "Histogram shows difference between anode and cathode segment time distribution. Any significant deviation from Gaussian should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
   {'path': "CSC/CSCOfflineMonitor/Segments/hSTimeVsZ", 'description': "Histogram shows combined segment time vs Z axis. Any significant fraction of out of zero events should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}
   ]
   )
+
+csclayout(dqmitems,"CSC DQM Shifter/04 Timing/08 Segments Timing (Serial)",
+    [{'path': "CSC/CSCOfflineMonitor/Segments/hSTimeAnodeSerial", 'description': "Histogram shows anode only segment time vs chamber ID. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/Segments/hSTimeCathodeSerial", 'description': "Histogram shows cathode only segment time distribution vs chamber ID. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}],
+    [{'path': "CSC/CSCOfflineMonitor/Segments/hSTimeCombinedSerial", 'description': "Histogram shows combined (anode + cathode) segment time vs chamber ID. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/Segments/hSTimeDiffSerial", 'description': "Histogram shows difference between anode and cathode segment time vs chamber ID.For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}
+    ]
+    )
 
 csclayout(dqmitems,"CSC DQM Shifter/05 Gains/01 Sum 3x3 RecHit Charge ME-",
         [None,

--- a/dqmgui/layouts/shift_csc_T0_layout.py
+++ b/dqmgui/layouts/shift_csc_T0_layout.py
@@ -17,3 +17,16 @@ csclayout(dqmitems,"03 Chambers without Data (Statistically Significant)",
      {'path': "CSC/Summary/CSC_STATS_wo_clct", 'description': "For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftCSC#CSC_STATS_wo_clct\">here</a>."}],
     [{'path': "CSC/Summary/CSC_STATS_wo_cfeb", 'description': "For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftCSC#CSC_STATS_wo_cfeb\">here</a>."},
      {'path': "CSC/Summary/CSC_STATS_cfeb_bwords", 'description': "For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftCSC#CSC_STATS_cfeb_bwords\">here</a>."}])
+
+csclayout(dqmitems,"04 Physics Efficiency - RecHits Minus",
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm1", 'description': "Histogram shows 2D RecHits distribution in ME-1. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm2", 'description': "Histogram shows 2D RecHits distribution in ME-2. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}],
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm3", 'description': "Histogram shows 2D RecHits distribution in ME-3. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm4", 'description': "Histogram shows 2D RecHits distribution in ME-4. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}])
+
+csclayout(dqmitems,"05 Physics Efficiency - RecHits Plus",
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp1", 'description': "Histogram shows 2D RecHits distribution in ME+1. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp2", 'description': "Histogram shows 2D RecHits distribution in ME+2. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}],
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp3", 'description': "Histogram shows 2D RecHits distribution in ME+3. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp4", 'description': "Histogram shows 2D RecHits distribution in ME+4. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}])
+

--- a/dqmgui/layouts/shift_csc_layout.py
+++ b/dqmgui/layouts/shift_csc_layout.py
@@ -17,3 +17,16 @@ csclayout(dqmitems,"03 Chambers without Data (Statistically Significant)",
      {'path': "CSC/Summary/CSC_STATS_wo_clct", 'description': "For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftCSC#CSC_STATS_wo_clct\">here</a>."}],
     [{'path': "CSC/Summary/CSC_STATS_wo_cfeb", 'description': "For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftCSC#CSC_STATS_wo_cfeb\">here</a>."},
      {'path': "CSC/Summary/CSC_STATS_cfeb_bwords", 'description': "For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftCSC#CSC_STATS_cfeb_bwords\">here</a>."}])
+
+csclayout(dqmitems,"04 Physics Efficiency - RecHits Minus",
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm1", 'description': "Histogram shows 2D RecHits distribution in ME-1. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm2", 'description': "Histogram shows 2D RecHits distribution in ME-2. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}],
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm3", 'description': "Histogram shows 2D RecHits distribution in ME-3. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalm4", 'description': "Histogram shows 2D RecHits distribution in ME-4. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}])
+
+csclayout(dqmitems,"05 Physics Efficiency - RecHits Plus",
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp1", 'description': "Histogram shows 2D RecHits distribution in ME+1. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp2", 'description': "Histogram shows 2D RecHits distribution in ME+2. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}],
+    [{'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp3", 'description': "Histogram shows 2D RecHits distribution in ME+3. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."},
+     {'path': "CSC/CSCOfflineMonitor/recHits/hRHGlobalp4", 'description': "Histogram shows 2D RecHits distribution in ME+4. Any unusual inhomogeneity should be reported. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/viewauth/CMS/CSCDPGDataMonitorShiftInstructions\">here</a>."}])
+

--- a/dqmgui/style/CSCRenderPlugin.cc
+++ b/dqmgui/style/CSCRenderPlugin.cc
@@ -2706,7 +2706,10 @@ public:
   reMatch(".*/CSCOfflineMonitor/recHits/hRHTiming.*", o.name) ||
   reMatch(".*/CSCOfflineMonitor/recHits/hRHstpos.*", o.name) ||
         reMatch(".*/CSCOfflineMonitor/Segments/hSTimeCathode$", o.name) ||
-        reMatch(".*/CSCOfflineMonitor/Segments/hSTimeCombined$", o.name))
+        reMatch(".*/CSCOfflineMonitor/Segments/hSTimeCombined$", o.name) ||
+        reMatch(".*/CSCOfflineMonitor/Segments/hSTimeAnode$", o.name) ||
+        reMatch(".*/CSCOfflineMonitor/Segments/hSTimeDiff$", o.name))
+        
       {
         obj->SetStats(true);
         gStyle->SetOptStat("euomr");
@@ -2755,7 +2758,11 @@ public:
       }
 
     if (reMatch(".*/CSCOfflineMonitor/Segments/hSTimeVsTOF$", o.name) ||
-  reMatch(".*/CSCOfflineMonitor/Segments/hSTimeVsZ$", o.name))
+  reMatch(".*/CSCOfflineMonitor/Segments/hSTimeVsZ$", o.name) ||
+  reMatch(".*/CSCOfflineMonitor/Segments/hSTimeAnodeSerial$", o.name) ||
+  reMatch(".*/CSCOfflineMonitor/Segments/hSTimeCathodeSerial$", o.name) ||
+  reMatch(".*/CSCOfflineMonitor/Segments/hSTimeCombinedSerial$", o.name) ||
+  reMatch(".*/CSCOfflineMonitor/Segments/hSTimeDiffSerial$", o.name))
       {
         obj->SetStats(true);
         gStyle->SetOptStat("eou");


### PR DESCRIPTION
CSC Layouts : 
- added copies of CSC recHits plots to Central Shifter layout 
- added CSC segment timing plots to CSC DQM shifter-only Offline DQM layout

CSC Render Plugins:
- added handlers for new Online and Offline CSC segment timing plots (refer to CMSSW PR #13943 and #13944)
