### PR TITLE
Enabled checkpoint for WMAgent; added replication performance tweaks

### DIFF
--- a/wmagent/local.ini
+++ b/wmagent/local.ini
@@ -48,9 +48,12 @@ ssl_certificate_max_depth = 10
 ;key_file = deploy_project_root/couchdb/certs/key.pem
 ;cacert_file = deploy_project_root/couchdb/certs/cert.pem
 ssl_certificate_max_depth = 10
-; checkpoint is introduced new in 1.6 version
-; checkpoint_interval = 5000
-; worker_batch_size = 500
-use_checkpoints = false
+; checkpoint setup: 10 minutes interval
+use_checkpoints = true
+checkpoint_interval = 600000
+; performance setup (still to be evaluated in the production nodes)
+worker_processes = 4
+http_connections = 10
+worker_batch_size = 2000
 max_replication_retry_count = infinity
 socket_options = [{keepalive, true}, {nodelay, true}]


### PR DESCRIPTION
Big thanks to @geneguvo who got this setup working!
By default, we set the checkpoint interval to 10min (600k milisecs).

The performance settings need to be carefully watched in the production nodes to make sure it won't bring bad effects.
@ticoann FYI