### PR TITLE
Bug fix for PCLPixelAlignmentRenderPlugin.cc

### DIFF
--- a/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
+++ b/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
@@ -216,7 +216,7 @@ private:
 	if (fabs(obj->GetBinContent(i)) > maxMoveCut_){
 		hitMax = true;	
 	}		
-	else if (obj->GetBinContent(i) > cut_){
+	else if (fabs(obj->GetBinContent(i)) > cut_){
 		moved = true;
 		if (obj->GetBinError(i) > maxErrorCut_){
 			hitMaxError = true;


### PR DESCRIPTION
Add a missing fabs() for correct display of movement of SiPix large structures in PCL Alignment. 