### PR TITLE
Add di-electron plot from HLT

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -432,6 +432,8 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Size',
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/16 Cluster Energy vs Seed Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/17 di-Electron Mass',
+	   [{'path': 'HLT/ObjectMonitor/MainShifter/di-Electron_Mass', 'description': 'HLT di-electron mass [from HLT DQM].'}])
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE
   for sign in ['-', '+']: # Loop over z-side

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -92,12 +92,11 @@ server.workspace('DQMContent', 30, 'Calorimeter', 'EcalPreshower', '^EcalPreshow
                  'EcalPreshower/Layouts/04-ESTimingTaskSummary-EcalPreshower',
                  'EcalPreshower/Layouts/05-ESGain-EcalPreshower',
                 )
-server.workspace('DQMContent', 30, 'Calorimeter', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd)', 'Ecal/Layouts',
+server.workspace('DQMContent', 30, 'Calorimeter', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass)', 'Ecal/Layouts',
                  'Ecal/Layouts/00 Summary',
                  'Ecal/Layouts/01 Occupancy Summary',
                  'Ecal/Layouts/02 Calibration Summary',
                 )
-# Ecal workspace modified above to include three L1 Trigger plots as requested by Ecal team
 server.workspace('DQMContent', 30, 'Calorimeter', 'HCAL', '^(Hcal|Hcal2)/', '',
                  'Hcal/Layouts/00 Current Summary',
                  'Hcal/Layouts/01 RAW Bad Quality',


### PR DESCRIPTION
**Add di-electron mass monitoring from HLT to check HLT e/gamma rates**
- ECAL was recently implicated in the problem of missing e/gamme rates in HLT which turned out to be due to a bug in the HLT code (nothing peculiar was seen in ECAL DQM)
- The di-electron mass plot is primarily fed by the e/gamma HLT path and, for future reference, ECAL would like to be able to conveniently monitor this plot as well