### PR TITLE
Add SR flag mismatch plots and fix EB label numbering

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -677,6 +677,10 @@ ecallayout(dqmitems, 'Ecal/Layouts/07 Selective Readout/16 ZS Flag Readout',
 	   [{'path': 'EcalBarrel/EBSelectiveReadoutTask/EBSRT ZS Flagged Fully Readout', 'description': 'Occurrence rate of full readout when unit is flagged as zero-suppressed.'}],
 	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT ZS Flagged Fully Readout EE -', 'description': 'Occurrence rate of full readout when unit is flagged as zero-suppressed.'},
 	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT ZS Flagged Fully Readout EE +', 'description': 'Occurrence rate of full readout when unit is flagged as zero-suppressed.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/07 Selective Readout/17 TT Flag Mismatch',
+	   [{'path': 'EcalBarrel/EBSelectiveReadoutTask/EBSRT TT flag mismatch', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'}],
+	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT flag mismatch EE +', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'},
+	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT flag mismatch EE -', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'}])
 
 #____________________ Layouts / 08 Laser ____________________
 ecallayout(dqmitems, 'Ecal/Layouts/08 Laser/00 Calibration Event Rate',

--- a/dqmgui/style/EcalRenderPlugin.cc
+++ b/dqmgui/style/EcalRenderPlugin.cc
@@ -1124,6 +1124,7 @@ EcalRenderPlugin::preDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject, 
      !fullpath.Contains("Pedestal") &&
      !fullpath.Contains("pedestal") &&
      !fullpath.Contains("event size") &&
+     !fullpath.Contains("flag mismatch") &&
      !fullpath.Contains("Trigger Primitives") &&
      !fullpath.Contains("Occupancy") &&
      !fullpath.Contains("TestPulse") &&
@@ -1164,6 +1165,15 @@ EcalRenderPlugin::preDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject, 
     obj->GetYaxis()->SetRangeUser(0.1, 0.608*68);
 
     applyDefaults = false;
+  }
+  else if(TPRegexp("E[BE]SelectiveReadoutTask/E[BE]SRT TT flag mismatch(| EE [+-])").MatchB(fullpath)){
+    const Int_t Number = 2;
+    Double_t Red[Number]    = {1.00, 1.00};
+    Double_t Green[Number]  = {0.85, 0.00};
+    Double_t Blue[Number]   = {0.85, 0.00};
+    Double_t Length[Number] = {0.00, 1.00 };
+    Int_t nb=50;
+    TColor::CreateGradientColorTable(Number,Length,Red,Green,Blue,nb);
   }
   else if( TPRegexp("E[BE]TriggerTowerTask/E[BE]TTT Real vs Emulated TP Et(| EE [+-])").MatchB(fullpath) ){
     if(obj->GetMaximum() > 0.) gPad->SetLogz(true);

--- a/dqmgui/style/EcalRenderPlugin.cc
+++ b/dqmgui/style/EcalRenderPlugin.cc
@@ -403,7 +403,7 @@ EcalRenderPlugin::initialise(int, char **)
 
   MEMLabels->SetMinimum(68.1);
 
-  for(int i = 0; i < 68; i++)
+  for(int i = 1; i < 69; i++)
     ebTTLabels->SetBinContent(i/4 + 1, i%4 + 1, i+1);
 
   // 36 entries


### PR DESCRIPTION
Added SR flag mismatch plots to online Ecal layout in Ecal/07 Selective Readout, and also modified corresponding layout plugin. Also, fixed EB TT numbering, now consistent with other plots.