### PR TITLE
Fixed broken FED error plot

### DIFF
--- a/dqmgui/layouts/rpc-layouts.py
+++ b/dqmgui/layouts/rpc-layouts.py
@@ -19,7 +19,7 @@ rpclayout(dqmitems, "00-Summary_Map",
           [{ 'path': "RPC/EventInfo/reportSummaryMap", 'description': summary + rpclink }])
 
 rpclayout(dqmitems, "01-Fatal_FED_Errors",
-          [{ 'path': "RPC/FEDIntegrity_SM/FEDFatal", 'description': fed + rpclink }])
+          [{ 'path': "RPC/FEDIntegrity_EvF/FEDFatal", 'description': fed + rpclink }])
 ##-------------------
 
 #RPC Events

--- a/dqmgui/layouts/shift_rpc_layout.py
+++ b/dqmgui/layouts/shift_rpc_layout.py
@@ -14,7 +14,7 @@ shiftrpclayout(dqmitems, "00-Summary_Map",
 
 #FED Fatal
 shiftrpclayout(dqmitems, "01-Fatal_FED_Errors",
-               [{ 'path': "RPC/FEDIntegrity_SM/FEDFatal", 'description': fed + rpclink }])
+               [{ 'path': "RPC/FEDIntegrity_EvF/FEDFatal", 'description': fed + rpclink }])
 
 #RPC Events
 shiftrpclayout(dqmitems, "02-RPC_Events",


### PR DESCRIPTION
For ages already the RPC shift and expert layouts show that the FED
error plot (01-Fatal_FED_Errors) is not available. The reason is simple:
It's linking to the wrong directory: FEDIntegrity_SM instead of
FEDIntegrity_EvF. The fix is so simple that I'm doing it myself.