### PR TITLE
Phase1 Pixel DQM Renderplugin changes

### DIFF
--- a/dqmgui/style/SiPixelRenderPlugin.cc
+++ b/dqmgui/style/SiPixelRenderPlugin.cc
@@ -304,16 +304,17 @@ private:
       if( obj->GetMinimum() > 0.) obj->SetMinimum(0.);
 
       // Ranges for specific histograms.
-      // TODO: maybe fix these in CMSSW?
-      if( o.name.find( "adcCOMB" ) != std::string::npos && obj->GetEntries() > 0. ){ gPad->SetLogy(1); gPad->SetTopMargin(0.15); }
-      if( o.name.find( "chargeCOMB" ) != std::string::npos && obj->GetEntries() > 0. ){ obj->GetXaxis()->SetRange(1,51); gPad->SetLogy(1); gPad->SetTopMargin(0.15); }
+      if( o.name.find( "adcCOMB" ) != std::string::npos && obj->GetEntries() > 0. ){ obj->SetMinimum(1.0); gPad->SetLogy(1); }
+      if( o.name.find( "chargeCOMB" ) != std::string::npos && obj->GetEntries() > 0. ){ obj->SetMinimum(1.0); obj->GetXaxis()->SetRange(1,51); gPad->SetLogy(1); }
       if( o.name.find( "OnTrack/charge_siPixelClusters" ) != std::string::npos ){ obj->GetXaxis()->SetRange(1,51); }
       if( o.name.find( "OffTrack/charge_siPixelClusters" ) != std::string::npos ){ obj->GetXaxis()->SetRange(1,51); }
       if( o.name.find( "OnTrack/size_siPixelClusters" ) != std::string::npos ){ obj->GetXaxis()->SetRange(1,41); }
       if( o.name.find( "OffTrack/size_siPixelClusters" ) != std::string::npos ){ obj->GetXaxis()->SetRange(1,41); }
+
+      // TODO: With SetLogy the minimum should always be forced non-0. Probably broken here.
       if( o.name.find( "barrelEventRate" ) != std::string::npos && obj->GetEntries() > 0. ) {gPad->SetLogx(1); gPad->SetLogy(1); gPad->SetTopMargin(0.15); gPad->SetRightMargin(0.15); }
       if( o.name.find( "endcapEventRate" ) != std::string::npos && obj->GetEntries() > 0. ) {gPad->SetLogx(1); gPad->SetLogy(1); gPad->SetTopMargin(0.15); gPad->SetRightMargin(0.15); }
-      if( o.name.find( "ALLMODS_chargeCOMB" ) != std::string::npos ) obj->GetXaxis()->SetRange(1,51);
+
       if( o.name.find( "noOccROCsBarrel" ) != std::string::npos ){ float currentX = (float) obj->GetBinCenter(obj->FindLastBinAbove(1.0))+5.; obj->GetXaxis()->SetRangeUser(0.,currentX);
         obj->GetYaxis()->SetRangeUser(250,350);}
       if( o.name.find( "noOccROCsEndcap" ) != std::string::npos ){ float currentX = (float) obj->GetBinCenter(obj->FindLastBinAbove(1.0))+5.; obj->GetXaxis()->SetRangeUser(0.,currentX);

--- a/dqmgui/style/SiPixelRenderPlugin.cc
+++ b/dqmgui/style/SiPixelRenderPlugin.cc
@@ -16,11 +16,8 @@
 #include "TColor.h"
 #include "TText.h"
 #include "TLine.h"
+#include "TGaxis.h"
 #include <cassert>
-
-#define PI_12 0.261799
-#define PI    3.141592
-#define PI_2  1.570796
 
 class SiPixelRenderPlugin : public DQMRenderPlugin
 {
@@ -81,8 +78,18 @@ private:
       gPad->SetRightMargin(0.15);
       obj->SetOption("colz");
 
+      TH1* th1 = dynamic_cast<TH1*>(obj);
+      TAxis* xa = th1->GetXaxis();
+      TAxis* ya = th1->GetYaxis();
+      xa->SetTitleSize(0.04);
+      xa->SetLabelSize(0.03);
+      ya->SetTitleSize(0.04);
+      ya->SetLabelSize(0.03);
+      TGaxis::SetMaxDigits(3);
+
+
       // TODO: content-based zooming might be useful.
-      // (maybe as a function, cud be useful for TH1 as well(
+      // (maybe as a function, could be useful for TH1 as well)
 
       // case-insensitive find is not easy...
       if (o.name.find( "sizeYvsEta" ) != std::string::npos
@@ -93,8 +100,6 @@ private:
       }
 
       if (o.name.find( "reportSummaryMap" ) == std::string::npos) {
-        TAxis* xa = obj->GetXaxis();
-        TAxis* ya = obj->GetYaxis();
         xa->SetTitleOffset(0.7);
         xa->SetTitleSize(0.065);
         xa->SetLabelSize(0.065);
@@ -175,11 +180,12 @@ private:
       TAxis* xa = obj->GetXaxis();
       TAxis* ya = obj->GetYaxis();
       xa->SetTitleOffset(0.7);
-      xa->SetTitleSize(0.065);
-      xa->SetLabelSize(0.065);
+      xa->SetTitleSize(0.04);
+      xa->SetLabelSize(0.03);
       ya->SetTitleOffset(0.75);
-      ya->SetTitleSize(0.065);
-      ya->SetLabelSize(0.065);
+      ya->SetTitleSize(0.04);
+      ya->SetLabelSize(0.03);
+      TGaxis::SetMaxDigits(3);
 
       // Always include 0.
       if( obj->GetMinimum() > 0.) obj->SetMinimum(0.);

--- a/dqmgui/style/SiPixelRenderPlugin.cc
+++ b/dqmgui/style/SiPixelRenderPlugin.cc
@@ -29,6 +29,8 @@ public:
     {
       if( o.name.find( "Pixel/" ) != std::string::npos )
         return true;
+      if( o.name.find( "PixelPhase1/" ) != std::string::npos )
+        return true;
 
       return false;
     }
@@ -61,132 +63,8 @@ public:
     }
 
 private:
-/*
-void paletteGraph(Double_t min, Double_t max){
-	gStyle->SetPalette(1);
-	gStyle->SetOptStat(0);
-	gStyle->SetNumberContours(255);
-	TCanvas* pal = new TCanvas("Palette", "Palette", 150, 600);
-	TH2F* palet = new TH2F("Palette", "Palette", 1, 0, 1, 255, min, max);
-	Double_t dc = (max - min) / 255;
-	for(Int_t i = 0; i < 255; i++)
-		palet->SetBinContent(1, i + 1, min + i * dc);
-	palet->Draw("COL");
-	gPad->SetLeftMargin(0.5);
-	palet->SetLabelSize(0.2,"Y");
-	palet->SetLabelOffset(0.05, "Y");
-	palet->SetLabelOffset(99, "X");
-	palet->SetTitle("");
-	palet->SetTickLength(0,"X");
-	palet->SetLabelSize(0,"X");
-	gPad->SetGrid(false,false);
-}
-*/
-Int_t getColor(TH2F* fH, Int_t i, Int_t j, Double_t zmin, Double_t zmax){
-	Int_t ncolors  = gStyle->GetNumberOfColors();
 
-	Double_t zc;
-    	Double_t dz = zmax - zmin;
-	if(dz <= 0)
-		return -1;
-
-	Int_t ndiv = fH->GetContour();
-	if (ndiv == 0 ) {
-		ndiv = gStyle->GetNumberContours();
-		fH->SetContour(ndiv);
-	}
-
-	Int_t ndivz  = TMath::Abs(ndiv);
-
-	if (fH->TestBit(TH1::kUserContour) == 0)
-		fH->SetContour(ndiv);
-
-	Double_t scale = ndivz/dz;
-	Int_t color;
-	const Double_t z = fH->GetBinContent(i,j);
-
-	if (z < zmin || z==0.)
-		return -1;
-	if (fH->TestBit(TH1::kUserContour)) {
-		zc = fH->GetContourLevelPad(0);
-		if (z < zc)
-			return -1;
-		color = -1;
-		for (Int_t k=0; k<ndiv; k++) {
-			zc = fH->GetContourLevelPad(k);
-			if (z < zc)
-				continue;
-			else
-				color++;
-		}
-	} else
-		color = Int_t(0.01+(z-zmin)*scale);
-
-	Int_t theColor = Int_t((color+0.99)*Double_t(ncolors)/Double_t(ndivz));
-	if (z >= zmax)
-		theColor = ncolors-1;
-	return theColor;
-}
-
-void polarGraph(TCanvas *c, TH2F* map){
-	TGraphPolar *graphs[24][7];
-	TColor *colors = new TColor();
-
-	colors->SetPalette(1, 0);
-	gStyle->SetPalette(1);
-	gStyle->SetNumberContours(255);
-
-		for(Int_t i = 0 ; i < 24; i++)
-			for(Int_t j = 0 ; j < 7; j++)
-			{
-				graphs[i][j] = makeSlice(j + 1., j + 1.9999, PI_2-(i+1)*PI_12, PI_2-(i)*PI_12,
-						colors->GetColorPalette(getColor(map,
-i + 1, j + 1, map->GetMinimum(), map->GetMaximum())), 5,
-						map->GetName());
-				graphs[i][j]->Draw("F same");
-			}
-		c->Update();
-		graphs[0][0]->GetPolargram()->SetToRadian();
-		graphs[0][0]->SetMaximum(8);
-		graphs[0][0]->GetPolargram()->SetNdivPolar(24);
-		graphs[0][0]->GetPolargram()->SetNdivRadial(8);
-
-		Int_t cnt(7);
-
-		for(Int_t i = 0 ; i < 6 ; i++)
-			graphs[0][0]->GetPolargram()->SetPolarLabel(i,Form("%d", cnt--));
-		for(Int_t i = 6 ; i < 18 ; i++)
-			graphs[0][0]->GetPolargram()->SetPolarLabel(i,Form("%d", i-5));
-		cnt = 12;
-		for(Int_t i = 19 ; i < 24 ; i++)
-			graphs[0][0]->GetPolargram()->SetPolarLabel(i,Form("%d", cnt--));
-
-}
-
-TGraphPolar* makeSlice(Double_t rA, Double_t rB, Double_t phiA, Double_t phiB, Int_t
-color, Int_t npts, std::string title){
-	Double_t *r = new Double_t[2*npts+3];
-	Double_t *th = new Double_t[2*npts+3];
-
-	r[0] = rA;
-	th[0] = phiA;
-	for(Int_t i = 0 ; i <= npts ; i++){
-		r[i + 1] = rB;
-		th[i + 1] = i * (phiB - phiA) / npts + phiA;
-		r[npts+2+i] = rA;
-		th[npts+2+i] = phiB - i * (phiB - phiA) / npts;
-	}
-
-	TGraphPolar *grP = new TGraphPolar(2*npts+3,th,r);
-
-	grP->SetTitle(title.c_str());
-	grP->SetFillColor(color);
-	grP->SetLineColor(color);
-	grP->SetLineWidth(2);
-	return grP;
-}
-
-void preDrawTH2( TCanvas *, const VisDQMObject &o )
+  void preDrawTH2( TCanvas *, const VisDQMObject &o )
     {
       TH2* obj = dynamic_cast<TH2*>( o.object );
       assert( obj );
@@ -195,16 +73,26 @@ void preDrawTH2( TCanvas *, const VisDQMObject &o )
       gStyle->SetCanvasBorderMode( 0 );
       gStyle->SetPadBorderMode( 0 );
       gStyle->SetPadBorderSize( 0 );
-      //    (data->pad)->SetLogy( 0 );;
+
       gStyle->SetOptStat( 0 );
       obj->SetStats( kFALSE );
-      if(o.name.find( "sizeYvsEta" ) != std::string::npos){
+
+      gStyle->SetPalette(1);
+      gPad->SetRightMargin(0.15);
+      obj->SetOption("colz");
+
+      // TODO: content-based zooming might be useful.
+      // (maybe as a function, cud be useful for TH1 as well(
+
+      // case-insensitive find is not easy...
+      if (o.name.find( "sizeYvsEta" ) != std::string::npos
+       || o.name.find( "sizeyvseta" ) != std::string::npos) {
         obj->SetStats( kTRUE );
-	gStyle->SetOptStat( 1111111 );
-	if(obj->GetEntries() > 0.) gPad->SetLogz(1);
+        gStyle->SetOptStat( 1111111 );
+        if(obj->GetEntries() > 0.) gPad->SetLogz(1);
       }
 
-      if( o.name.find( "reportSummaryMap" ) == std::string::npos){
+      if (o.name.find( "reportSummaryMap" ) == std::string::npos) {
         TAxis* xa = obj->GetXaxis();
         TAxis* ya = obj->GetYaxis();
         xa->SetTitleOffset(0.7);
@@ -215,91 +103,66 @@ void preDrawTH2( TCanvas *, const VisDQMObject &o )
         ya->SetLabelSize(0.065);
       }
 
+      // TODO: fix this in the right place?
       if( o.name.find( "endcapOccupancyMap" ) != std::string::npos ) obj->SetTitle("Endcap Digi Occupancy Map");
-      if( o.name.find( "hitmap" ) != std::string::npos  ||
-	  o.name.find( "rocmap" ) != std::string::npos  ||
-	  o.name.find( "zeroOccROC_map" ) != std::string::npos  ||
-          o.name.find( "Occupancy" ) != std::string::npos ||
-	  o.name.find( "position_siPixelClusters" ) != std::string::npos ||
-	  (o.name.find( "TRKMAP" ) != std::string::npos && o.name.find( "Layer" ) != std::string::npos) ||
-	  o.name.find( "sizeYvsEta" ) != std::string::npos)
-      {
-        gStyle->SetPalette(1);
-	gPad->SetRightMargin(0.15);
-        obj->SetOption("colz");
-        return;
-      }
+       
       //Separated out HitEfficiency maps to set scale
-      if( o.name.find( "HitEfficiency_L" ) != std::string::npos)
+      if( o.name.find( "fficiency" ) != std::string::npos)
         {
-          gStyle->SetPalette(1);
-          gPad->SetRightMargin(0.15);
           obj->SetOption("colz");
           obj->SetMaximum(1.0);
           obj->SetMinimum(0.95);
           return;
         }
-      if( o.name.find( "HitEfficiency_D" ) != std::string::npos)
-        {
-          gStyle->SetPalette(1);
-          gPad->SetRightMargin(0.15);
-          obj->SetOption("colz");
-          obj->SetMaximum(1.0);
-          obj->SetMinimum(0.95);
-          return;
-        }
+
+      // FED things
       if( o.name.find( "FedChLErr" ) != std::string::npos )
-      {
-        gPad->SetGrid();
-	gPad->SetRightMargin(0.15);
-        gStyle->SetPalette(1);
-	obj->SetOption("colztext");
-      }
+        {
+          gPad->SetGrid();
+          obj->SetOption("colztext");
+        }
 
       if( o.name.find( "FedETypeNErr" ) != std::string::npos )
-      {
-        gPad->SetGrid();
-	gPad->SetLeftMargin(0.3);
-	gPad->SetRightMargin(0.15);
-        gStyle->SetPalette(1);
-        obj->SetOption("colztext");
-	if( obj->GetEntries() > 0. ) gPad->SetLogz(1);
-	return;
-      }
+        {
+          gPad->SetGrid();
+          gPad->SetLeftMargin(0.3);
+          obj->SetOption("colztext");
+          if( obj->GetEntries() > 0. ) gPad->SetLogz(1);
+          return;
+        }
 
       if( o.name.find( "FedChNErr" ) != std::string::npos )
-      {
-        gPad->SetGrid();
-	gPad->SetRightMargin(0.15);
-        gStyle->SetPalette(1);
-        obj->SetOption("colztext");
-	if( obj->GetEntries() > 0. ) gPad->SetLogz(1);
-      }
-      if( o.name.find( "avgfedDigiOccvsLumi" ) != std::string::npos )
         {
+          gPad->SetGrid();
           gPad->SetRightMargin(0.15);
           gStyle->SetPalette(1);
+          obj->SetOption("colztext");
+          if( obj->GetEntries() > 0. ) gPad->SetLogz(1);
+        }
+
+      if( o.name.find( "avgfedDigiOccvsLumi" ) != std::string::npos )
+        {
           obj->SetOption("colz");
           obj->SetMinimum(0.00001);
           obj->SetMaximum(0.8);
-	  int currentX = (int) obj->FindLastBinAbove(0.001)+1;
-	  obj->GetXaxis()->SetRange(1,currentX);
+          int currentX = (int) obj->FindLastBinAbove(0.001)+1;
+          obj->GetXaxis()->SetRange(1,currentX);
           return;
         }
 
       TH2F* obj2 = dynamic_cast<TH2F*>( o.object );
 
       if( o.name.find( "reportSummaryMap" ) != std::string::npos )
-      {
-        gPad->SetGrid();
-        if(obj->GetNbinsX()==7) gPad->SetLeftMargin(0.3);
-        dqm::utils::reportSummaryMapPalette(obj2);
-	if(obj->GetNbinsX()>10){
-	  //Look at last filled bin (above -0.99) and use to zoom in on plot
-	  int currentX = (int) obj->FindLastBinAbove(-0.99)+1;
-	  obj->GetXaxis()->SetRange(1,currentX);}
-        return;
-      }
+        {
+          gPad->SetGrid();
+          if(obj->GetNbinsX()==7) gPad->SetLeftMargin(0.3);
+          dqm::utils::reportSummaryMapPalette(obj2);
+          if(obj->GetNbinsX()>10){
+            //Look at last filled bin (above -0.99) and use to zoom in on plot
+            int currentX = (int) obj->FindLastBinAbove(-0.99)+1;
+            obj->GetXaxis()->SetRange(1,currentX);}
+          return;
+        }
     }
 
   void preDrawTH1( TCanvas *, const VisDQMObject &o )
@@ -309,15 +172,6 @@ void preDrawTH2( TCanvas *, const VisDQMObject &o )
 
       // This applies to all
       gStyle->SetOptStat(111);
-//       if ( obj->GetMaximum(1.e5) > 0. )
-//       {
-//         gPad->SetLogy(1);
-//       }
-//       else
-//       {
-//         gPad->SetLogy(0);
-//       }
-
       TAxis* xa = obj->GetXaxis();
       TAxis* ya = obj->GetYaxis();
       xa->SetTitleOffset(0.7);
@@ -327,6 +181,11 @@ void preDrawTH2( TCanvas *, const VisDQMObject &o )
       ya->SetTitleSize(0.065);
       ya->SetLabelSize(0.065);
 
+      // Always include 0.
+      if( obj->GetMinimum() > 0.) obj->SetMinimum(0.);
+
+      // Ranges for specific histograms.
+      // TODO: maybe fix these in CMSSW?
       if( o.name.find( "adcCOMB" ) != std::string::npos && obj->GetEntries() > 0. ){ gPad->SetLogy(1); gPad->SetTopMargin(0.15); }
       if( o.name.find( "chargeCOMB" ) != std::string::npos && obj->GetEntries() > 0. ){ obj->GetXaxis()->SetRange(1,51); gPad->SetLogy(1); gPad->SetTopMargin(0.15); }
       if( o.name.find( "OnTrack/charge_siPixelClusters" ) != std::string::npos ){ obj->GetXaxis()->SetRange(1,51); }
@@ -366,49 +225,19 @@ void preDrawTH2( TCanvas *, const VisDQMObject &o )
       if( o.name.find( "SUMOFF_charge_OnTrack_Endcap" ) != std::string::npos ){ obj->SetMinimum(-5.); obj->SetMaximum(45.); }
       if( o.name.find( "SUMOFF_nclusters_OnTrack_Endcap" ) != std::string::npos ){ obj->SetMinimum(-0.1); obj->SetMaximum(2.5); }
       if( o.name.find( "SUMOFF_size_OnTrack_Endcap" ) != std::string::npos ){ obj->SetMinimum(-0.1); obj->SetMaximum(4.); }
-
-     // prettify for shifters:
-//       if( o.name.find( "SUMDIG_ndigis_" ) != std::string::npos ||
-//           o.name.find( "SUMCLU_nclusters_" ) != std::string::npos ||
-// 	  o.name.find( "SUMCLU_size_" ) != std::string::npos ) gPad->SetLogy(0);
-//       if( o.name.find( "SUMOFF_ndigis_" ) != std::string::npos ||
-//           o.name.find( "SUMOFF_nclusters_" ) != std::string::npos ||
-// 	  o.name.find( "SUMOFF_size_" ) != std::string::npos ) gPad->SetLogy(0);
     }
 
   void postDrawTH1( TCanvas *, const VisDQMObject &o )
     {
-      TText tt;
-      tt.SetTextSize(0.12);
       if (o.flags == 0) return;
-      else
-      {
-        /*    if (o.flags & DQMNet::DQM_PROP_REPORT_ERROR)
-              {
-              tt.SetTextColor(2);
-              tt.DrawTextNDC(0.5, 0.5, "Error");
-              }
-              else if (o.flags & DQMNet::DQM_PROP_REPORT_WARN)
-              {
-              tt.SetTextColor(5);
-              tt.DrawTextNDC(0.5, 0.5, "Warning");
-              }
-              else if (o.flags & DQMNet::DQM_PROP_REPORT_OTHER)
-              {
-              tt.SetTextColor(1);
-              tt.DrawTextNDC(0.5, 0.5, "Other ");
-              }
-              else
-              {
-              tt.SetTextColor(3);
-              tt.DrawTextNDC(0.5, 0.5, "Ok ");
-              }
-        */
-      }
-
+      
       TH1* obj = dynamic_cast<TH1*>( o.object );
       assert( obj );
 
+      // TODO: add EXTEND_* decorations for Phase1 here. 
+      // (maybe as a function, TH2 could use it as well)
+
+      // Upper/Lower limit decoration for SUMOFFs.
       if( o.name.find( "SUMOFF_adc_Barrel" ) != std::string::npos ){
         TLine tl1; tl1.SetLineColor(4); tl1.DrawLine(1.,85.,193.,85.);
         TLine tl2; tl2.SetLineColor(4); tl2.DrawLine(1.,115.,193.,115.);
@@ -507,74 +336,14 @@ void preDrawTH2( TCanvas *, const VisDQMObject &o )
         float currentX = (float) obj->GetBinCenter(obj->FindLastBinAbove(1.0))+5.;
         TLine tl; tl.SetLineColor(4); tl.SetLineStyle(2); tl.DrawLine(0.0,314.0,currentX,314.0);
       }
-//       else if( o.name.find( "OnTrack/size_siPixelClusters" ) != std::string::npos ||
-//                o.name.find( "OffTrack/size_siPixelClusters" ) != std::string::npos ){
-//         Int_t ibin = obj->GetMaximumBin();
-//         Double_t val = obj->GetBinContent(ibin);
-//         TLine tl; tl.SetLineColor(4); tl.DrawLine(10.,0.,10.,val);
-//       }
-
     }
 
-  void postDrawTH2( TCanvas *c, const VisDQMObject &o )
-{
-
+  void postDrawTH2( TCanvas * /*c*/, const VisDQMObject &o )
+    {
       TH2* obj = dynamic_cast<TH2*>( o.object );
       assert( obj );
-      if( o.name.find( "TRKMAP" ) != std::string::npos && o.name.find( "Disc" ) != std::string::npos ){
-        c->Clear();
-	polarGraph(c, dynamic_cast<TH2F*>(obj));
-      }
-
-      if( o.name.find( "reportSummaryMap" ) != std::string::npos )
-      {
-	if(obj->GetNbinsX()==40){
-	  TLine tl1; tl1.SetLineColor(4); tl1.DrawLine(32.,25.,32.,37.); //top right corner
-	  TLine tl2; tl2.SetLineColor(4); tl2.DrawLine(32.,25.,40.,25.); //top right corner
-	  //
-	  TLine tl3; tl3.SetLineColor(4); tl3.DrawLine(3.,29.,3.,31.); //little boxes
-	  TLine tl4; tl4.SetLineColor(4); tl4.DrawLine(5.,29.,5.,31.); //little boxes
-	  TLine tl5; tl5.SetLineColor(4); tl5.DrawLine(3.,29.,5.,29.); //little boxes
-	  TLine tl6; tl6.SetLineColor(4); tl6.DrawLine(3.,31.,5.,31.); //little boxes
-	  //
-	  TLine tl7; tl7.SetLineColor(4); tl7.DrawLine(11.,29.,11.,31.); //little boxes
-	  TLine tl8; tl8.SetLineColor(4); tl8.DrawLine(13.,29.,13.,31.); //little boxes
-	  TLine tl9; tl9.SetLineColor(4); tl9.DrawLine(11.,29.,13.,29.); //little boxes
-	  TLine tl10; tl10.SetLineColor(4); tl10.DrawLine(11.,31.,13.,31.); //little boxes
-	  //
-	  TLine tl11; tl11.SetLineColor(4); tl11.DrawLine(19.,29.,19.,31.); //little boxes
-	  TLine tl12; tl12.SetLineColor(4); tl12.DrawLine(21.,29.,21.,31.); //little boxes
-	  TLine tl13; tl13.SetLineColor(4); tl13.DrawLine(19.,29.,21.,29.); //little boxes
-	  TLine tl14; tl14.SetLineColor(4); tl14.DrawLine(19.,31.,21.,31.); //little boxes
-	  //
-	  TLine tl15; tl15.SetLineColor(4); tl15.DrawLine(27.,29.,27.,31.); //little boxes
-	  TLine tl16; tl16.SetLineColor(4); tl16.DrawLine(29.,29.,29.,31.); //little boxes
-	  TLine tl17; tl17.SetLineColor(4); tl17.DrawLine(27.,29.,29.,29.); //little boxes
-	  TLine tl18; tl18.SetLineColor(4); tl18.DrawLine(27.,31.,29.,31.); //little boxes
-	  //
-	  TLine tl19; tl19.SetLineColor(4); tl19.DrawLine(3.,25.,3.,27.); //little boxes
-	  TLine tl20; tl20.SetLineColor(4); tl20.DrawLine(5.,25.,5.,27.); //little boxes
-	  TLine tl21; tl21.SetLineColor(4); tl21.DrawLine(3.,25.,5.,25.); //little boxes
-	  TLine tl22; tl22.SetLineColor(4); tl22.DrawLine(3.,27.,5.,27.); //little boxes
-	  //
-	  TLine tl23; tl23.SetLineColor(4); tl23.DrawLine(11.,25.,11.,27.); //little boxes
-	  TLine tl24; tl24.SetLineColor(4); tl24.DrawLine(13.,25.,13.,27.); //little boxes
-	  TLine tl25; tl25.SetLineColor(4); tl25.DrawLine(11.,25.,13.,25.); //little boxes
-	  TLine tl26; tl26.SetLineColor(4); tl26.DrawLine(11.,27.,13.,27.); //little boxes
-	  //
-	  TLine tl27; tl27.SetLineColor(4); tl27.DrawLine(19.,25.,19.,27.); //little boxes
-	  TLine tl28; tl28.SetLineColor(4); tl28.DrawLine(21.,25.,21.,27.); //little boxes
-	  TLine tl29; tl29.SetLineColor(4); tl29.DrawLine(19.,25.,21.,25.); //little boxes
-	  TLine tl30; tl30.SetLineColor(4); tl30.DrawLine(19.,27.,21.,27.); //little boxes
-	  //
-	  TLine tl31; tl31.SetLineColor(4); tl31.DrawLine(27.,25.,27.,27.); //little boxes
-	  TLine tl32; tl32.SetLineColor(4); tl32.DrawLine(29.,25.,29.,27.); //little boxes
-	  TLine tl33; tl33.SetLineColor(4); tl33.DrawLine(27.,25.,29.,25.); //little boxes
-	  TLine tl34; tl34.SetLineColor(4); tl34.DrawLine(27.,27.,29.,27.); //little boxes
-	}
-      }
-
-}
+      // Add Th2 post-draw code here.
+    }
 
 };
 

--- a/dqmgui/style/SiPixelRenderPlugin.cc
+++ b/dqmgui/style/SiPixelRenderPlugin.cc
@@ -65,16 +65,16 @@ public:
 private:
 
   // simple recursive descent parser for the "Column(0,30,50,)/Other(0,3,5,)/Last"
-  // format used to carry the positions where histograms where concatenated by 
+  // format used to carry the positions where histograms where concatenated by
   // EXTEND to this plugin.
   template<typename Iterator>
   struct LabelMarkerParser {
-    std::vector<std::vector<int>> markers; // output 
+    std::vector<std::vector<int>> markers; // output
     std::string text; // cleaned-up label
 
     static std::pair<bool, int> parse_int(Iterator& start, Iterator end) {
       int out = 0;
-      if (start == end || !std::isdigit(*start)) return std::make_pair(false, out); 
+      if (start == end || !std::isdigit(*start)) return std::make_pair(false, out);
       while (start != end && std::isdigit(*start))
         out = out * 10 + (*start++ - '0');
       return std::make_pair(true, out);
@@ -118,7 +118,7 @@ private:
     }
   };
 
-  void putMarkers(TH1* obj) 
+  void putMarkers(TH1* obj)
     {
       // TODO: Y-Axis as well?
       TAxis* ax = obj->GetXaxis();
@@ -131,11 +131,11 @@ private:
       std::vector<std::vector<int>>& markers = res.second.markers;
 
       auto ymax = obj->GetMaximum() * 0.5;
-      auto ymin = 0; // TODO: we actually want the y axis range here. 
+      auto ymin = 0; // TODO: we actually want the y axis range here.
       auto step = (ymax-ymin)*0.5 / markers.size();
       // we only get one set of values each, but have to draw a full hierarchy
       putMarkersRecursive(markers.begin(), markers.end(), 0, ymin, ymax, step);
-      
+
       ax->SetTitle(newlabel.c_str());
     }
 
@@ -144,8 +144,8 @@ private:
     if (begin == end) return;
     for (auto mark : *begin) {
       auto pos = double(mark) + 0.5 + double(offset);
-      TLine tl; 
-      tl.SetLineColor(4); 
+      TLine tl;
+      tl.SetLineColor(4);
       tl.DrawLine(pos, ymin, pos, ymax);
       putMarkersRecursive(begin+1, end, offset + mark, ymin, ymax - step, step);
     }
@@ -192,7 +192,7 @@ private:
 
       // TODO: fix this in the right place?
       if( o.name.find( "endcapOccupancyMap" ) != std::string::npos ) obj->SetTitle("Endcap Digi Occupancy Map");
-       
+
       //Separated out HitEfficiency maps to set scale
       if( o.name.find( "fficiency" ) != std::string::npos)
         {
@@ -336,11 +336,11 @@ private:
   void postDrawTH1( TCanvas *, const VisDQMObject &o )
     {
       if (o.flags == 0) return;
-      
+
       TH1* obj = dynamic_cast<TH1*>( o.object );
       assert( obj );
-      
-      // put EXTEND marker for phase1 
+
+      // put EXTEND marker for phase1
       putMarkers(obj);
 
       // Upper/Lower limit decoration for SUMOFFs.

--- a/dqmgui/style/SiPixelRenderPlugin.cc
+++ b/dqmgui/style/SiPixelRenderPlugin.cc
@@ -51,6 +51,7 @@ public:
   virtual void postDraw( TCanvas *c, const VisDQMObject &o, const VisDQMImgInfo & )
     {
       c->cd();
+      putName(o);
 
       if( dynamic_cast<TH2*>( o.object ) )
       {
@@ -63,6 +64,18 @@ public:
     }
 
 private:
+  TText *name_text = nullptr;
+
+  void putName(VisDQMObject const& o) {
+    // we cannot delete this immediately, so wait for the next call
+    if (name_text) delete name_text;
+
+    name_text = new TText(0.05,0.01, o.name.c_str());
+    name_text->SetTextColor(kBlack);
+    name_text->SetTextSize(0.02);
+    name_text->SetNDC();
+    name_text->Draw("same");
+  }
 
   // simple recursive descent parser for the "Column(0,30,50,)/Other(0,3,5,)/Last"
   // format used to carry the positions where histograms where concatenated by


### PR DESCRIPTION
This PR prepares the SiPixel Renderplugin for Phase1,  by:

- Removing lots of code that was probably never used.
- Applying more options by default (so also for new Phase1 plots)
- Providing a way to get Layer/Shell/etc. markers on profiles. The information has to be provided in the axis label string. The code for this is not yet PR'd against CMSSW, since it makes the labels hard to read w/o this PR. This got much more complicated than expected, but the code should now be clean and even work properly.
- Some more general style changes that also apply to Phase0, related to font sizes and axis ranges.
- The renderplugin now puts the full pathname of the ME on the canvas, to prevent confusion of plots.

