### PR TITLE
Made PixelLumi plots independent of SiPixel plugin

### DIFF
--- a/dqmgui/style/BeamPixelRenderPlugin.cc
+++ b/dqmgui/style/BeamPixelRenderPlugin.cc
@@ -220,12 +220,12 @@ private:
 
     if (o.name.find("reportSummaryMap") != std::string::npos)
       {
-	c->SetGrid(false, false);
+        c->SetGrid(false, false);
         // Give the report summary map the standard CMS DQM colors:
         // (standard code, transferred from the SiPixel render plugin)
         TH2F* obj2 = dynamic_cast<TH2F*>( o.object );
         dqm::utils::reportSummaryMapPalette(obj2);
-	return;
+        return;
       }
   }
 

--- a/dqmgui/style/BeamPixelRenderPlugin.cc
+++ b/dqmgui/style/BeamPixelRenderPlugin.cc
@@ -221,7 +221,10 @@ private:
     if (o.name.find("reportSummaryMap") != std::string::npos)
       {
 	c->SetGrid(false, false);
-	
+        // Give the report summary map the standard CMS DQM colors:
+        // (standard code, transferred from the SiPixel render plugin)
+        TH2F* obj2 = dynamic_cast<TH2F*>( o.object );
+        dqm::utils::reportSummaryMapPalette(obj2);
 	return;
       }
   }


### PR DESCRIPTION
* In the past it seems that the SiPixel render plugin was
unknowingly also applied to the BeamPixel plots, since they were
filtering on "Pixel/"
* By changing the SiPixel render plugin, the BeamPixel plots were
affected as well.
* However, by not applying the SiPixel render plugins on the
BeamPixel plots, the summary plot looks different, since it was actually
relying on the SiPixel render plugin.

Action:
Copied relevant lines of the SiPixel render plugin
to the BeamPixel render plugin, so that the summary plot has the correct
palette even without the SiPixel render plugin being applied to it. For
all the other plots it seems to make no difference.