### PR TITLE
Adding plugin .h-files to list of files to compile

### DIFF
--- a/dqmgui/server-conf-dev.py
+++ b/dqmgui/server-conf-dev.py
@@ -24,7 +24,7 @@ server.baseUrl     = '/dqm/dev'
 server.title       = 'CMS data quality'
 server.serviceName = 'CERN Development'
 
-server.plugin('render', "%s/style/*.cc" % CONFIGDIR)
+server.plugin('render', "%s/style/*.cc" % CONFIGDIR, "%s/style/*.h" % CONFIGDIR)
 server.extend('DQMRenderLink', server.pathOfPlugin('render'))
 server.extend('DQMToJSON')
 server.extend('DQMFileAccess', "%s/auth/wmcore-auth/header-auth-key" % __file__.rsplit('/', 3)[0],

--- a/dqmgui/server-conf-offline.py
+++ b/dqmgui/server-conf-offline.py
@@ -34,7 +34,7 @@ else:
   server.serviceName = 'Offline Local'
   server.baseUrl     = '/dqm/offline'
 
-server.plugin('render', "%s/style/*.cc" % CONFIGDIR)
+server.plugin('render', "%s/style/*.cc" % CONFIGDIR, "%s/style/*.h" % CONFIGDIR)
 server.extend('DQMRenderLink', server.pathOfPlugin('render'))
 server.extend('DQMToJSON')
 server.extend('DQMFileAccess', "%s/auth/wmcore-auth/header-auth-key" % __file__.rsplit('/', 3)[0],

--- a/dqmgui/server-conf-online.py
+++ b/dqmgui/server-conf-online.py
@@ -92,7 +92,7 @@ server.baseUrl     = BASEURL
 server.title       = 'CMS data quality'
 server.serviceName = SERVICENAME
 
-server.plugin('render', "%s/style/*.cc" % CONFIGDIR)
+server.plugin('render', "%s/style/*.cc" % CONFIGDIR, "%s/style/*.h" % CONFIGDIR)
 server.extend('DQMRenderLink', server.pathOfPlugin('render'))
 server.extend('DQMToJSON')
 server.extend('DQMFileAccess', "%s/auth/wmcore-auth/header-auth-key" % __file__.rsplit('/', 3)[0],

--- a/dqmgui/server-conf-relval.py
+++ b/dqmgui/server-conf-relval.py
@@ -41,7 +41,7 @@ else:
   server.serviceName = 'RelVal Local'
   server.baseUrl     = '/dqm/relval'
 
-server.plugin('render', "%s/style/*.cc" % CONFIGDIR)
+server.plugin('render', "%s/style/*.cc" % CONFIGDIR, "%s/style/*.h" % CONFIGDIR)
 server.extend('DQMRenderLink', server.pathOfPlugin('render'))
 server.extend('DQMToJSON')
 server.extend('DQMFileAccess', "%s/auth/wmcore-auth/header-auth-key" % __file__.rsplit('/', 3)[0],


### PR DESCRIPTION
This is step 2 of a 2 step change:

Step1: Make sure that _if_ .h files are taken into account for the
decision on whether or not something has changed, then these .h files
are not sent as input to the make file.

Step2: Once this is done, we can add the header files to the patterns of
the files that need to be looked at for the render plugins. (This is
done in configuration, which is a different repo.)