### PR TITLE
Updated uGT DQM histogram names to align with changes in CMSSW

### DIFF
--- a/dqmgui/layouts/l1t-layouts.py
+++ b/dqmgui/layouts/l1t-layouts.py
@@ -44,22 +44,17 @@ l1t_quickCollection(dqmitems, "06 - uGMT MUON PHI ETA",
   }])
 l1t_quickCollection(dqmitems, "07 - uGT Algorithm Trigger Bits (after prescale) vs. Global BX Number",
   [{
-    'path': "L1T2016/L1TStage2uGT/algoBits_after_prescaler_bx_global",
+    'path': "L1T2016/L1TStage2uGT/algoBits_after_prescale_bx_global",
     'description': ""
   }])
 l1t_quickCollection(dqmitems, "08 - uGT Algorithm Trigger Bits (after prescale) vs. BX Number in Event",
   [{
-    'path': "L1T2016/L1TStage2uGT/algoBits_after_prescaler_bx_inEvt",
+    'path': "L1T2016/L1TStage2uGT/algoBits_after_prescale_bx_inEvt",
     'description': ""
   }])
 l1t_quickCollection(dqmitems, "09 - uGT Algorithm Trigger Bits (after prescale)",
   [{
-    'path': "L1T2016/L1TStage2uGT/algoBits_after_prescaler",
-    'description': ""
-  }])
-l1t_quickCollection(dqmitems, "10 - uGT Algorithm Trigger Bits (after BX mask) vs. BX Number in Event",
-  [{
-    'path': "L1T2016/L1TStage2uGT/algoBits_after_bxomask_bx_inEvt",
+    'path': "L1T2016/L1TStage2uGT/algoBits_after_prescale",
     'description': ""
   }])
 

--- a/dqmgui/layouts/shift_l1t_layout.py
+++ b/dqmgui/layouts/shift_l1t_layout.py
@@ -55,13 +55,12 @@ l1tlayout(dqmitems,"25 - uGMT EMTF Input HW Global PHI Negative",
 l1tlayout(dqmitems,"26 - uGMT EMTF Input HW Global PHI Positive",
     [{'path': "L1T2016/L1TStage2uGMT/EMTFInput/ugmtEMTFglbhwPhiPos", 'description': "uGMT EMTF Input HW Global PHI Positive. x-axis: uGMT EMTF Input HW Global PHI Positive.  For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
 l1tlayout(dqmitems,"27 - uGT Algorithm Trigger Bits (after prescale) vs. Global BX Number",
-    [{'path': "L1T2016/L1TStage2uGT/algoBits_after_prescaler_bx_global", 'description': "uGT Algorithm Trigger Bits (after prescale) vs. Global BX Number. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
+    [{'path': "L1T2016/L1TStage2uGT/algoBits_after_prescale_bx_global", 'description': "uGT Algorithm Trigger Bits (after prescale) vs. Global BX Number. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
 l1tlayout(dqmitems,"28 - uGT Algorithm Trigger Bits (after prescale) vs. BX Number in Event",
-    [{'path': "L1T2016/L1TStage2uGT/algoBits_after_prescaler_bx_inEvt", 'description': "uGT Algorithm Trigger Bits (after prescale) vs. BX Number in Event. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
+    [{'path': "L1T2016/L1TStage2uGT/algoBits_after_prescale_bx_inEvt", 'description': "uGT Algorithm Trigger Bits (after prescale) vs. BX Number in Event. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
 l1tlayout(dqmitems,"29 - uGMT Muon Phi for EMTF Inputs",
     [{'path': "L1T2016/L1TStage2uGMT/ugmtMuonPhiEmtf", 'description': "uGMT Muon Phi for EMTF Inputs.  For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
 l1tlayout(dqmitems,"30 - EMTF Chamber Occupancy",
     [{'path': "L1T2016/L1TStage2EMTF/emtfHitOccupancy", 'description': "EMTF Chamber Occupancy. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
 l1tlayout(dqmitems,"31 - EMTF Track Bunch Crossing",
     [{'path': "L1T2016/L1TStage2EMTF/emtfTrackBX", 'description': "EMTF Track Bunch Crossing. For more information please click <a href=\"https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftL1T\">here</a>."}])
-

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -162,7 +162,6 @@ server.workspace('DQMContent', 40, 'Trigger/Lumi', 'L1T', '^(L1T|L1T2016)/', '',
                  'L1T/Layouts/Stage2-QuickCollection/07 - uGT Algorithm Trigger Bits (after prescale) vs. Global BX Number',
                  'L1T/Layouts/Stage2-QuickCollection/08 - uGT Algorithm Trigger Bits (after prescale) vs. BX Number in Event',
                  'L1T/Layouts/Stage2-QuickCollection/09 - uGT Algorithm Trigger Bits (after prescale)',
-                 'L1T/Layouts/Stage2-QuickCollection/10 - uGT Algorithm Trigger Bits (after BX mask) vs. BX Number in Event',
                 )
 
 server.workspace('DQMContent', 41, 'Trigger/Lumi', 'L1TEMU', '^(L1TEMU|L1T2016EMU)/', '',


### PR DESCRIPTION
- Updated uGT DQM histogram names to align with changes in CMSSW (https://github.com/cms-sw/cmssw/pull/16537 and https://github.com/cms-sw/cmssw/pull/16583)
- Removed the "uGT Algorithm Trigger Bits (after BX mask) vs. BX Number in Event" histogram reference in Quick Collection