### PR TITLE
Fix a problem moving reqmgr couchapps to reqmgr2

### DIFF
--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -53,10 +53,10 @@ deploy_reqmgr2_post()
          >> $root/state/${couch%%:*}/stagingarea/reqmgr2
     echo "couchapp push $reqmgrapp/data/couchapps/ReqMgr" \
          "http://localhost:${couch##*:}/reqmgr_workload_cache" \
-         >> $root/state/${couch%%:*}/stagingarea/reqmgr
+         >> $root/state/${couch%%:*}/stagingarea/reqmgr2
     echo "couchapp push $reqmgrapp/data/couchapps/ConfigCache" \
          "http://localhost:${couch##*:}/reqmgr_config_cache" \
-         >> $root/state/${couch%%:*}/stagingarea/reqmgr
+         >> $root/state/${couch%%:*}/stagingarea/reqmgr2
   done
 
   # Setup reqmgr2 cronjobs


### PR DESCRIPTION
Complement this PR #412 
In which I was writing the couchapp commands into the wrong file.

BTW, during the deployment we should remove this file
`/data/srv/state/couchdb/stagingarea/reqmgr
otherwise couch manage script will try to source it (with the old couchapps commands), though there is no longer *reqmgr directory.

Bruno, I'm still testing it.