### PR TITLE
Re-arranging workspaces and adding info workspaces

### DIFF
--- a/dqmgui/layouts/info-layouts.py
+++ b/dqmgui/layouts/info-layouts.py
@@ -1,0 +1,43 @@
+# Definition of custom function used further below
+# (It's unlikely that you need to modify this code)
+def make_basic_layout_function(everything_tree_dict, base_path):
+
+    # Prepare a layout function that takes the following 3 arguments:
+    #   source_path: The path in "everything" where the plot is now
+    #   new_relative_path: The path relative to your base path of your layouts
+    #                      where you want the layout to appear
+    #   description: Description of the layout, to be displayed in the GUI when
+    #                the "Describe" button is clicked. Note that this
+    #                description can use basic html syntax.
+
+    def layout_function(source_path, new_relative_path, description):
+        target_path = base_path + new_relative_path
+        simple_details = [{"path":source_path, "description": description}]
+        everything_tree_dict[target_path] = DQMItem(layout=[simple_details])
+    return layout_function
+
+# Create the actual layout function
+# Set your "base path" here:
+info_layout = make_basic_layout_function(dqmitems, "Info/Layouts/")
+
+# Define the actual layouts:
+
+info_layout("Info/EventInfo/reportSummaryMap",
+            "1 - HV and Beam Status per LumiSection",
+            "High Voltage (HV) flag for all sub-detector parts, as well as basic beam information, per LumiSection (LS), based on information from DCS, injected into the events by SCAL.")
+
+info_layout("Info/ProvInfo/Run Type",
+            "2 - Run key set for DQM",
+            "Run key set for the DQM module in the DAQ Level0 Funtionmanager. The value typically defines whether the run is <i>collisions</i> or <i>cosmics</i>. Depending on this run key the DQM applications running for the different sub-systems can process the run in different ways.")
+
+info_layout("Info/ProvInfo/hltKey",
+            "3 - HLT menu used",
+            "Path of the HLT menu that was used for this run.")
+
+info_layout("Info/ProvInfo/CMSSW",
+            "4 - Version of CMSSW used",
+            "Version of CMSSW used to process this run. There might be extra PRs added manually. Please refer to the <a href='https://twiki.cern.ch/twiki/bin/view/CMS/DQMP5TagCollector'>Tag Collector</a> for details.")
+
+info_layout("Info/ProvInfo/Globaltag",
+            "5 - Global Tag used",
+            "Global Tag (GT) used in the online DQM cluster.")

--- a/dqmgui/layouts/info_T0_layouts.py
+++ b/dqmgui/layouts/info_T0_layouts.py
@@ -1,0 +1,47 @@
+# Definition of custom function used further below
+# (It's unlikely that you need to modify this code)
+def make_basic_layout_function(everything_tree_dict, base_path):
+
+    # Prepare a layout function that takes the following 3 arguments:
+    #   source_path: The path in "everything" where the plot is now
+    #   new_relative_path: The path relative to your base path of your layouts
+    #                      where you want the layout to appear
+    #   description: Description of the layout, to be displayed in the GUI when
+    #                the "Describe" button is clicked. Note that this
+    #                description can use basic html syntax.
+
+    def layout_function(source_path, new_relative_path, description):
+        target_path = base_path + new_relative_path
+        simple_details = [{"path":source_path, "description": description}]
+        everything_tree_dict[target_path] = DQMItem(layout=[simple_details])
+    return layout_function
+
+# Create the actual layout function
+# Set your "base path" here:
+info_layout = make_basic_layout_function(dqmitems, "Info/Layouts/")
+
+# Define the actual layouts:
+
+info_layout("Info/EventInfo/reportSummaryMap",
+            "1 - High Voltage (HV) per LumiSection",
+            "High Voltage (HV) flag for all sub-detector parts, per LumiSection (LS), based on information from DCS, injected into the events by SCAL.")
+
+info_layout("Info/EventInfo/ProcessedLS",
+            "2 - Processed LumiSections",
+            "Processing flag per LumiSection (LS): -1 means that the LS was not processed, +1 means that the LS was processed.")
+
+info_layout("Info/ProvInfo/runIsComplete",
+            "3 - Run is completely processed",
+            "This flag becomes 1 if the run is completely processed.<br><br><ul><li>For <b>Prompt Reconstruction</b> this is the case by default, since the info is only uploaded to the GUI when the run is completely processed.</li><li>However for <b>Express Reconstruction</b>, the GUI will show intermediate results and the run you're looking at might not be completely processed yet.</li></ul>")
+
+info_layout("Info/ProvInfo/CMSSW",
+            "4 - Version of CMSSW used",
+            "Version of CMSSW used to process this run.")
+
+info_layout("Info/CMSSWInfo/globalTag_Step1",
+            "5 - Global Tag used for filling",
+            "Global Tag (GT) used for <i>step_1</i>, i.e. the LumiSection based filling of the plots.")
+
+info_layout("Info/CMSSWInfo/globalTag_Harvesting",
+            "6 - Global Tag used for harvesting",
+            "Global Tag (GT) used for the <i>harvesting</i> step, i.e. when the statistics for all the lumisections are combined into the final plots.")

--- a/dqmgui/workspaces-offline.py
+++ b/dqmgui/workspaces-offline.py
@@ -13,15 +13,35 @@
 # This file can be edited by many people, please respect the formatting!
 # (I.e.: Don't make a mess.)
 
-# DQM workspaces:
+# DQM/general workspaces:
 server.workspace('DQMQuality', 0, 'Summaries', 'Summary')
-server.workspace('DQMSummary', 1, 'Summaries', 'Reports')
-server.workspace('DQMShift',   2, 'Summaries', 'Shift')
-server.workspace('DQMCertification', 3, 'Summaries', 'Certification')
-server.workspace('DQMContent', 4, 'Summaries', 'Everything', '^', '^')
 
-# Tracker/Muons workspaces:
-server.workspace('DQMContent', 10, 'Tracker/Muons', 'Pixel', '^Pixel/', '',
+server.workspace('DQMSummary', 1, 'Summaries', 'Reports')
+
+server.workspace('DQMShift', 2, 'Summaries', 'Shift')
+
+server.workspace('DQMContent', 3, 'Summaries', 'Info', '^Info/', '',
+                 'Info/Layouts/1 - High Voltage (HV) per LumiSection',
+                 'Info/Layouts/2 - Processed LumiSections',
+                 'Info/Layouts/3 - Run is completely processed',
+                 'Info/Layouts/4 - Version of CMSSW used',
+                 'Info/Layouts/5 - Global Tag used for filling',
+                 'Info/Layouts/6 - Global Tag used for harvesting',
+                )
+
+server.workspace('DQMCertification', 4, 'Summaries', 'Certification')
+
+server.workspace('DQMContent', 5, 'Summaries', 'Everything', '^', '^')
+
+# Trigger workspaces:
+server.workspace('DQMContent', 11, 'Trigger', 'L1T', '^L1T/', '')
+
+server.workspace('DQMContent', 12, 'Trigger', 'L1TEMU', '^L1TEMU/', '')
+
+server.workspace('DQMContent', 13, 'Trigger', 'HLT', '^HLT/', '')
+
+# Tracker workspaces:
+server.workspace('DQMContent', 20, 'Tracker', 'Pixel', '^Pixel/', '',
                  'Pixel/Layouts/00b - Pixel_Error_Summary',
                  'Pixel/Layouts/01 - Pixel_FEDOccupancy_Summary',
                  'Pixel/Layouts/02 - Pixel_Cluster_Summary',
@@ -32,7 +52,8 @@ server.workspace('DQMContent', 10, 'Tracker/Muons', 'Pixel', '^Pixel/', '',
                  'Pixel/Layouts/08 - ROC occupancies',
                  'Pixel/Layouts/09 - Pixel Clusters vs LS',
                 )
-server.workspace('DQMContent', 11, 'Tracker/Muons', 'SiStrip', '^SiStrip/', '',
+
+server.workspace('DQMContent', 21, 'Tracker', 'SiStrip', '^SiStrip/', '',
                  'SiStrip/Layouts/00 - SiStrip ReportSummary',
                  'SiStrip/Layouts/01 - FED-Detected Errors Summary',
                  'SiStrip/Layouts/02 - FED-Detected Errors',
@@ -41,24 +62,14 @@ server.workspace('DQMContent', 11, 'Tracker/Muons', 'SiStrip', '^SiStrip/', '',
                  'SiStrip/Layouts/05 - OffTrackCluster (Total Number)',
                  'SiStrip/Layouts/06 - FED Errors vs FED ID',
                 )
-server.workspace('DQMContent', 12, 'Tracker/Muons', 'CSC', '^CSC/', '',
-                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 01',
-                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 02',
-                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 04 - CSCs Reporting Data and Unpacked',
-                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 08 - CSCs Occupancy Overal',
-                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 07 - CSCs Occupancy 2D',
-                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 09 - RecHits Minus',
-                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 10 - RecHits Plus',
-                )
-server.workspace('DQMContent', 13, 'Tracker/Muons', 'DT', '^DT/', '')
-server.workspace('DQMContent', 14, 'Tracker/Muons', 'RPC', '^RPC/', '')
 
 # Calorimeter workspaces:
-server.workspace('DQMContent', 21, 'Calorimeter', 'Ecal', '^Ecal(|Barrel|Endcap)/', 'Ecal/Layouts',
+server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '^Ecal(|Barrel|Endcap)/', 'Ecal/Layouts',
                  'Ecal/Layouts/00 Summary',
                  'Ecal/Layouts/01 Occupancy Summary',
                 )
-server.workspace('DQMContent', 22, 'Calorimeter', 'EcalPreshower', '^EcalPreshower/', '',
+
+server.workspace('DQMContent', 31, 'Calorimeters', 'EcalPreshower', '^EcalPreshower/', '',
                  'EcalPreshower/Layouts/01-IntegritySummary-EcalPreshower',
                  'EcalPreshower/Layouts/02-GoodRechitOccupancySummary-EcalPreshower',
                  'EcalPreshower/Layouts/03-GoodRechitEnergySummary-EcalPreshower',
@@ -66,7 +77,7 @@ server.workspace('DQMContent', 22, 'Calorimeter', 'EcalPreshower', '^EcalPreshow
                  'EcalPreshower/Layouts/05-ESGain-EcalPreshower',
                 )
 
-server.workspace('DQMContent', 23, 'Calorimeter', 'HCAL', '^(Hcal|Hcal2)/', '',
+server.workspace('DQMContent', 32, 'Calorimeters', 'HCAL', '^(Hcal|Hcal2)/', '',
                  'Hcal/Layouts/00 Current Summary',
                  'Hcal/Layouts/01 RAW Bad Quality',
                  'Hcal/Layouts/02 RAW Bad Quality depth',
@@ -92,7 +103,8 @@ server.workspace('DQMContent', 23, 'Calorimeter', 'HCAL', '^(Hcal|Hcal2)/', '',
                  'Hcal/Layouts/22 TP Et Missing',
                  'Hcal/Layouts/23 TP Et Occupancy'
                 )
-server.workspace('DQMContent',24,'Calorimeter','HCALcalib', '^HcalCalib/', '',
+
+server.workspace('DQMContent',33,'Calorimeters','HCALcalib', '^HcalCalib/', '',
                  'HcalCalib/Layouts/00 Current Summary',
                  'HcalCalib/Layouts/01 Pedestal Mean',
                  'HcalCalib/Layouts/02 Pedestal Mean by FED',
@@ -114,23 +126,39 @@ server.workspace('DQMContent',24,'Calorimeter','HCALcalib', '^HcalCalib/', '',
                  'HcalCalib/Layouts/18 Number of Bad RMS vs LS'
                 )
 
-server.workspace('DQMContent', 25, 'Calorimeter', 'Castor', '^Castor/', '',
+server.workspace('DQMContent', 34, 'Calorimeters', 'Castor', '^Castor/', '',
                  'Castor/Layouts/01 - Map of frontend and readout errors',
                  'Castor/Layouts/02 - Channel-wise timing',
                  'Castor/Layouts/02b - Channel-wise timing (rms)',
                  'Castor/Layouts/Digi/05 - DigiSize',
                 )
 
-# Trigger/Lumi workspaces:
-server.workspace('DQMContent', 31, 'Trigger/Lumi', 'L1T', '^L1T/', '')
-server.workspace('DQMContent', 32, 'Trigger/Lumi', 'L1TEMU', '^L1TEMU/', '')
-server.workspace('DQMContent', 33, 'Trigger/Lumi', 'HLT', '^HLT/', '')
+# Muons workspaces:
+server.workspace('DQMContent', 40, 'Muons', 'CSC', '^CSC/', '',
+                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 01',
+                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 02',
+                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 04 - CSCs Reporting Data and Unpacked',
+                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 08 - CSCs Occupancy Overal',
+                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 07 - CSCs Occupancy 2D',
+                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 09 - RecHits Minus',
+                 'CSC/Layouts/00 Data Integrity/Physics Efficiency 10 - RecHits Plus',
+                )
+
+server.workspace('DQMContent', 41, 'Muons', 'DT', '^DT/', '')
+
+server.workspace('DQMContent', 42, 'Muons', 'RPC', '^RPC/', '')
+
+# CTPPS workspaces:
+server.workspace('DQMContent', 50, 'CTPPS', 'TrackingStrip', '^CTPPS/', 'CTPPS/TrackingStrip/Layouts')
 
 # POG workspaces:
-server.workspace('DQMContent', 41, 'POG', 'Muons', '^Muons/', '')
-server.workspace('DQMContent', 42, 'POG', 'JetMet', '^JetMET/', '')
-server.workspace('DQMContent', 43, 'POG', 'EGamma', '^Egamma/', '')
-server.workspace('DQMContent', 44, 'POG', 'Btag', '^Btag/', '',
+server.workspace('DQMContent', 60, 'POG', 'Muons', '^Muons/', '')
+
+server.workspace('DQMContent', 61, 'POG', 'JetMet', '^JetMET/', '')
+
+server.workspace('DQMContent', 62, 'POG', 'EGamma', '^Egamma/', '')
+
+server.workspace('DQMContent', 63, 'POG', 'Btag', '^Btag/', '',
                  'Btag/Layouts/00 - Jet Property',
                  'Btag/Layouts/01 - Tracks in Jet',
                  'Btag/Layouts/02 - Vertex Property',
@@ -139,14 +167,16 @@ server.workspace('DQMContent', 44, 'POG', 'Btag', '^Btag/', '',
                  'Btag/Layouts/05 - 2D-Impact Parameter',
                  'Btag/Layouts/06 - 3D-Impact Parameter',
                 )
-server.workspace('DQMContent', 45, 'POG', 'Tracking', '^(Tracking|AlcaBeamMonitor|OfflinePV)/', '',
+
+server.workspace('DQMContent', 64, 'POG', 'Tracking', '^(Tracking|AlcaBeamMonitor|OfflinePV)/', '',
                  'Tracking/Layouts/01 - Tracking ReportSummary',
                  'Tracking/Layouts/02 - Tracks (pp collisions)',
                  'Tracking/Layouts/03 - Tracks (Cosmic Tracking)',
                  'Tracking/Layouts/04 - Tracks (HI run)',
                  'Tracking/Layouts/06 - Number of Seeds (pp collisions)',
                 )
-server.workspace('DQMContent', 46, 'POG', 'Tau', '^RecoTauV/', '',
+
+server.workspace('DQMContent', 65, 'POG', 'Tau', '^RecoTauV/', '',
                  'RecoTauV/Layouts/SingleMu/00aa - Fake rate from muons vs pt',
                  'RecoTauV/Layouts/SingleMu/00ab - Fake rate from muons vs pt',
                  'RecoTauV/Layouts/SingleMu/01a - Muon rejection fake rate vs pt',
@@ -166,6 +196,3 @@ server.workspace('DQMContent', 46, 'POG', 'Tau', '^RecoTauV/', '',
                  'RecoTauV/Layouts/DoubleElectron_OR_TauPlusX/00ba - Fake rate from electrons vs pileup',
                  'RecoTauV/Layouts/DoubleElectron_OR_TauPlusX/00bb - Fake rate from electrons vs pileup',
                 )
-
-# CTPPS workspaces:
-server.workspace('DQMContent', 51, 'CTPPS', 'TrackingStrip', '^CTPPS/', 'CTPPS/TrackingStrip/Layouts')

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -15,141 +15,23 @@
 
 # DQM workspaces:
 server.workspace('DQMQuality', 0, 'Summaries', 'Summary')
+
 server.workspace('DQMSummary', 1, 'Summaries', 'Reports')
+
 server.workspace('DQMShift',   2, 'Summaries', 'Shift')
-server.workspace('DQMContent', 3, 'Summaries', 'Everything', '^', '^')
 
-# Tracker/Muons workspaces:
-server.workspace('DQMContent', 20, 'Tracker/Muons', 'Pixel', '^Pixel/', '',
-                 'Pixel/Layouts/000 - Pixel FED Occupancy vs Lumi Sections',
-                 'Pixel/Layouts/00a - Pixel_Error_Summary',
-                 'Pixel/Layouts/00b - Pixel_Error_Summary',
-                 'Pixel/Layouts/00c - Pixel_Error_Summary',
-                 'Pixel/Layouts/09 - Pixel Clusters vs LS',
-                 'Pixel/Layouts/20a - Cluster occupancy Barrel Layer 1',
-                 'Pixel/Layouts/20b - Cluster occupancy Barrel Layer 2',
-                 'Pixel/Layouts/20c - Cluster occupancy Barrel Layer 3',
-                 'Pixel/Layouts/20d - Cluster occupancy Endcap -z Disk 1',
-                 'Pixel/Layouts/20e - Cluster occupancy Endcap -z Disk 2',
-                 'Pixel/Layouts/20f - Cluster occupancy Endcap +z Disk 1',
-                 'Pixel/Layouts/20g - Cluster occupancy Endcap +z Disk 2',
-                 'Pixel/Layouts/30a - Pixel event rates',
-                )
-server.workspace('DQMContent', 21, 'Tracker/Muons', 'SiStrip', '^(SiStrip|Tracking)/', '',
-                 'SiStrip/Layouts/00 - SiStrip ReportSummary',
-                 'SiStrip/Layouts/01 - FED-Detected Errors Summary',
-                 'SiStrip/Layouts/02 - FED-Detected Errors Trend',
-                 'SiStrip/Layouts/03 - # of Digi Trend',
-                 'SiStrip/Layouts/04 - # of Cluster Trend',
-                 'SiStrip/Layouts/05 - OnTrackCluster (StoN)',
-                 'SiStrip/Layouts/06 - OffTrackCluster (Total Number)',
-                 'SiStrip/Layouts/07 - Tracking ReportSummary',
-                 'SiStrip/Layouts/08 - Tracks (pp collisions)',
-                 'SiStrip/Layouts/09 - Tracks (Cosmic Tracking)',
-                 'SiStrip/Layouts/10 - Tracks (HI run)',
-                 'SiStrip/Layouts/11a - FED Errors vs FED ID',
-                )
-server.workspace('DQMContent', 22, 'Tracker/Muons', 'DT', '^DT/', '',
-                 'DT/Layouts/00-Summary/00-DataIntegritySummary',
-                 'DT/Layouts/00-Summary/00-ROChannelSummary',
-                 'DT/Layouts/00-Summary/01-OccupancySummary',
-                 'DT/Layouts/00-Summary/02-SegmentSummary',
-                 'DT/Layouts/00-Summary/03-TM_TriggerCorrFractionSummary',
-                 'DT/Layouts/00-Summary/04-TM_Trigger2ndFractionSummary',
-                 'DT/Layouts/00-Summary/05-NoiseChannelsSummary',
-                 'DT/Layouts/00-Summary/06-SynchNoiseSummary',
-                )
-server.workspace('DQMContent', 23, 'Tracker/Muons', 'RPC', '^RPC/', '',
-                 'RPC/Layouts/01-Fatal_FED_Errors',
-                 'RPC/Layouts/02-RPC_Events',
-                 'RPC/Layouts/08-Barrel_Occupancy',
-                 'RPC/Layouts/09-Endcap_Occupancy',
-                )
-server.workspace('DQMContent', 24, 'Tracker/Muons', 'CSC', '^CSC/', '',
-                 'CSC/Layouts/00 Top Physics Efficiency',
-                 'CSC/Layouts/01 Station Physics Efficiency',
-                 'CSC/Layouts/02 EMU Summary/EMU Test01 - DDUs in Readout',
-                 'CSC/Layouts/02 EMU Summary/EMU Test03 - DDU Reported Errors',
-                 'CSC/Layouts/02 EMU Summary/EMU Test04 - DDU Format Errors',
-                 'CSC/Layouts/02 EMU Summary/EMU Test05 - DDU Inputs Status',
-                 'CSC/Layouts/02 EMU Summary/EMU Test06 - DDU Inputs in ERROR-WARNING State',
-                 'CSC/Layouts/02 EMU Summary/EMU Test08 - CSCs Reporting Data and Unpacked',
-                 'CSC/Layouts/02 EMU Summary/EMU Test10 - CSCs with Errors and Warnings (Fractions)',
-                 'CSC/Layouts/02 EMU Summary/EMU Test11 - CSCs without Data Blocks',
-                 'CSC/Layouts/06 Physics Efficiency - RecHits Minus',
-                 'CSC/Layouts/07 Physics Efficiency - RecHits Plus',
+server.workspace('DQMContent', 3, 'Summaries', 'Info', '^Info/', '',
+                 'Info/Layouts/1 - HV and Beam Status per LumiSection',
+                 'Info/Layouts/2 - Run key set for DQM',
+                 'Info/Layouts/3 - HLT menu used',
+                 'Info/Layouts/4 - Version of CMSSW used',
+                 'Info/Layouts/5 - Global Tag used',
                 )
 
-# Calorimeter workspaces:
-server.workspace('DQMContent', 30, 'Calorimeter', 'EcalPreshower', '^EcalPreshower/', '',
-                 'EcalPreshower/Layouts/01-IntegritySummary-EcalPreshower',
-                 'EcalPreshower/Layouts/02-GoodRechitOccupancySummary-EcalPreshower',
-                 'EcalPreshower/Layouts/03-GoodRechitEnergySummary-EcalPreshower',
-                 'EcalPreshower/Layouts/04-ESTimingTaskSummary-EcalPreshower',
-                 'EcalPreshower/Layouts/05-ESGain-EcalPreshower',
-                )
-server.workspace('DQMContent', 31, 'Calorimeter', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass)', 'Ecal/Layouts',
-                 'Ecal/Layouts/00 Summary',
-                 'Ecal/Layouts/01 Occupancy Summary',
-                 'Ecal/Layouts/02 Calibration Summary',
-                )
-# Ecal workspace modified above to include three L1 Trigger plots and one HLT plot as requested by Ecal team
-server.workspace('DQMContent', 32, 'Calorimeter', 'HCAL', '^(Hcal|Hcal2)/', '',
-                 'Hcal/Layouts/00 Current Summary',
-                 'Hcal/Layouts/01 RAW Bad Quality',
-                 'Hcal/Layouts/02 RAW Bad Quality depth',
-                 'Hcal/Layouts/03 RAW Mismatches',
-                 'Hcal/Layouts/04 DIGI Missing 1LS',
-                 'Hcal/Layouts/05 DIGI Occupancy',
-                 'Hcal/Layouts/06 DIGI Occupancy Total',
-                 'Hcal/Layouts/07 DIGI Occupancy Cut',
-                 'Hcal/Layouts/08 DIGI Timing',
-                 'Hcal/Layouts/09 DIGI Total Charge',
-                 'Hcal/Layouts/10 DIGI Occupancy vs LS',
-                 'Hcal/Layouts/11 DIGI Amplitude vs LS',
-                 'Hcal/Layouts/12 RECO Energy',
-                 'Hcal/Layouts/13 RECO Occupancy',
-                 'Hcal/Layouts/14 RECO Occupancy Cut',
-                 'Hcal/Layouts/15 RECO Timing',
-                 'Hcal/Layouts/16 RECO HBHEabc Timing',
-                 'Hcal/Layouts/17 RECO Timing vs Energy',
-                 'Hcal/Layouts/18 TP Et Correlation',
-                 'Hcal/Layouts/19 TP Et Correlation Ratio',
-                 'Hcal/Layouts/20 TP Et Distribution',
-                 'Hcal/Layouts/21 TP Et Mismatches',
-                 'Hcal/Layouts/22 TP Et Missing',
-                 'Hcal/Layouts/23 TP Et Occupancy'
-                )
-server.workspace('DQMContent',33,'Calorimeter','HCALcalib', '^HcalCalib/', '',
-                 'HcalCalib/Layouts/00 Current Summary',
-                 'HcalCalib/Layouts/01 Pedestal Mean',
-                 'HcalCalib/Layouts/02 Pedestal Mean by FED',
-                 'HcalCalib/Layouts/03 Pedestal RMS',
-                 'HcalCalib/Layouts/04 Pedestal RMS by FED',
-                 'HcalCalib/Layouts/05 Pedestal Mean DB Ref',
-                 'HcalCalib/Layouts/06 Pedestal Mean DB Ref by FED',
-                 'HcalCalib/Layouts/07 Pedestal RMS DB Ref',
-                 'HcalCalib/Layouts/08 Pedestal RMS DB Ref by FED',
-                 'HcalCalib/Layouts/09 Pedestal Mean Bad',
-                 'HcalCalib/Layouts/10 Pedestal Mean Bad by FED',
-                 'HcalCalib/Layouts/11 Pedestal RMS Bad',
-                 'HcalCalib/Layouts/12 Pedestal RMS Bad by FED',
-                 'HcalCalib/Layouts/13 Pedestal Missing',
-                 'HcalCalib/Layouts/14 Pedestal Missing by FED',
-                 'HcalCalib/Layouts/15 Pedestal Occupancy vs LS',
-                 'HcalCalib/Layouts/16 Missing vs LS',
-                 'HcalCalib/Layouts/17 Number of Bad Mean vs LS',
-                 'HcalCalib/Layouts/18 Number of Bad RMS vs LS'
-                )
-server.workspace('DQMContent', 34, 'Calorimeter', 'Castor', '^Castor/', '',
-                 'Castor/Layouts/01 - Map of frontend and readout errors',
-                 'Castor/Layouts/02 - Channel-wise timing',
-                 'Castor/Layouts/02b - Channel-wise timing (rms)',
-                 'Castor/Layouts/Digi/05 - DigiSize',
-                )
+server.workspace('DQMContent', 4, 'Summaries', 'Everything', '^', '^')
 
-# Trigger/Lumi workspaces:
-server.workspace('DQMContent', 40, 'Trigger/Lumi', 'L1T', '^(L1T|L1T2016)/', '',
+# Trigger workspaces:
+server.workspace('DQMContent', 10, 'Trigger', 'L1T', '^(L1T|L1T2016)/', '',
                  # Please add plots to Stage2-QuickCollection layout in layouts/l1t-layouts.py
                  # with a useful name and description, then reference them here
                  'L1T/Layouts/Stage2-QuickCollection/00 - Calo Layer1 ECAL Input Occupancy',
@@ -164,12 +46,13 @@ server.workspace('DQMContent', 40, 'Trigger/Lumi', 'L1T', '^(L1T|L1T2016)/', '',
                  'L1T/Layouts/Stage2-QuickCollection/09 - uGT Algorithm Trigger Bits (after prescale)',
                 )
 
-server.workspace('DQMContent', 41, 'Trigger/Lumi', 'L1TEMU', '^(L1TEMU|L1T2016EMU)/', '',
+server.workspace('DQMContent', 11, 'Trigger', 'L1TEMU', '^(L1TEMU|L1T2016EMU)/', '',
                  # Please add plots to Stage2-QuickCollection layout in layouts/l1temulator-layouts.py
                  # with a useful name and description, then reference them here
                  # 'L1TEMU/Layouts/Stage2-QuickCollection/',
                 )
-server.workspace('DQMContent', 42, 'Trigger/Lumi', 'HLT', '^HLT/', '',
+
+server.workspace('DQMContent', 12, 'Trigger', 'HLT', '^HLT/', '',
                  'HLT/ObjectMonitor/MainShifter/Photon_pT',
                  'HLT/ObjectMonitor/MainShifter/Muon_pT',
                  'HLT/ObjectMonitor/MainShifter/Electron_pT',
@@ -202,5 +85,144 @@ server.workspace('DQMContent', 42, 'Trigger/Lumi', 'HLT', '^HLT/', '',
                  'HLT/Layouts/highestRate Summary',
                 )
 
+# Tracker workspaces:
+server.workspace('DQMContent', 20, 'Tracker', 'Pixel', '^Pixel/', '',
+                 'Pixel/Layouts/000 - Pixel FED Occupancy vs Lumi Sections',
+                 'Pixel/Layouts/00a - Pixel_Error_Summary',
+                 'Pixel/Layouts/00b - Pixel_Error_Summary',
+                 'Pixel/Layouts/00c - Pixel_Error_Summary',
+                 'Pixel/Layouts/09 - Pixel Clusters vs LS',
+                 'Pixel/Layouts/20a - Cluster occupancy Barrel Layer 1',
+                 'Pixel/Layouts/20b - Cluster occupancy Barrel Layer 2',
+                 'Pixel/Layouts/20c - Cluster occupancy Barrel Layer 3',
+                 'Pixel/Layouts/20d - Cluster occupancy Endcap -z Disk 1',
+                 'Pixel/Layouts/20e - Cluster occupancy Endcap -z Disk 2',
+                 'Pixel/Layouts/20f - Cluster occupancy Endcap +z Disk 1',
+                 'Pixel/Layouts/20g - Cluster occupancy Endcap +z Disk 2',
+                 'Pixel/Layouts/30a - Pixel event rates',
+                )
+
+server.workspace('DQMContent', 21, 'Tracker', 'SiStrip', '^(SiStrip|Tracking)/', '',
+                 'SiStrip/Layouts/00 - SiStrip ReportSummary',
+                 'SiStrip/Layouts/01 - FED-Detected Errors Summary',
+                 'SiStrip/Layouts/02 - FED-Detected Errors Trend',
+                 'SiStrip/Layouts/03 - # of Digi Trend',
+                 'SiStrip/Layouts/04 - # of Cluster Trend',
+                 'SiStrip/Layouts/05 - OnTrackCluster (StoN)',
+                 'SiStrip/Layouts/06 - OffTrackCluster (Total Number)',
+                 'SiStrip/Layouts/07 - Tracking ReportSummary',
+                 'SiStrip/Layouts/08 - Tracks (pp collisions)',
+                 'SiStrip/Layouts/09 - Tracks (Cosmic Tracking)',
+                 'SiStrip/Layouts/10 - Tracks (HI run)',
+                 'SiStrip/Layouts/11a - FED Errors vs FED ID',
+                )
+
+# Calorimeter workspaces:
+server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T2016/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass)', 'Ecal/Layouts',
+                 'Ecal/Layouts/00 Summary',
+                 'Ecal/Layouts/01 Occupancy Summary',
+                 'Ecal/Layouts/02 Calibration Summary',
+                )
+                # Ecal workspace modified above to include three L1 Trigger
+                # plots and one HLT plot as requested by Ecal team
+
+server.workspace('DQMContent', 31, 'Calorimeters', 'EcalPreshower', '^EcalPreshower/', '',
+                 'EcalPreshower/Layouts/01-IntegritySummary-EcalPreshower',
+                 'EcalPreshower/Layouts/02-GoodRechitOccupancySummary-EcalPreshower',
+                 'EcalPreshower/Layouts/03-GoodRechitEnergySummary-EcalPreshower',
+                 'EcalPreshower/Layouts/04-ESTimingTaskSummary-EcalPreshower',
+                 'EcalPreshower/Layouts/05-ESGain-EcalPreshower',
+                )
+
+server.workspace('DQMContent', 32, 'Calorimeters', 'HCAL', '^(Hcal|Hcal2)/', '',
+                 'Hcal/Layouts/00 Current Summary',
+                 'Hcal/Layouts/01 RAW Bad Quality',
+                 'Hcal/Layouts/02 RAW Bad Quality depth',
+                 'Hcal/Layouts/03 RAW Mismatches',
+                 'Hcal/Layouts/04 DIGI Missing 1LS',
+                 'Hcal/Layouts/05 DIGI Occupancy',
+                 'Hcal/Layouts/06 DIGI Occupancy Total',
+                 'Hcal/Layouts/07 DIGI Occupancy Cut',
+                 'Hcal/Layouts/08 DIGI Timing',
+                 'Hcal/Layouts/09 DIGI Total Charge',
+                 'Hcal/Layouts/10 DIGI Occupancy vs LS',
+                 'Hcal/Layouts/11 DIGI Amplitude vs LS',
+                 'Hcal/Layouts/12 RECO Energy',
+                 'Hcal/Layouts/13 RECO Occupancy',
+                 'Hcal/Layouts/14 RECO Occupancy Cut',
+                 'Hcal/Layouts/15 RECO Timing',
+                 'Hcal/Layouts/16 RECO HBHEabc Timing',
+                 'Hcal/Layouts/17 RECO Timing vs Energy',
+                 'Hcal/Layouts/18 TP Et Correlation',
+                 'Hcal/Layouts/19 TP Et Correlation Ratio',
+                 'Hcal/Layouts/20 TP Et Distribution',
+                 'Hcal/Layouts/21 TP Et Mismatches',
+                 'Hcal/Layouts/22 TP Et Missing',
+                 'Hcal/Layouts/23 TP Et Occupancy'
+                )
+
+server.workspace('DQMContent',33,'Calorimeters','HCALcalib', '^HcalCalib/', '',
+                 'HcalCalib/Layouts/00 Current Summary',
+                 'HcalCalib/Layouts/01 Pedestal Mean',
+                 'HcalCalib/Layouts/02 Pedestal Mean by FED',
+                 'HcalCalib/Layouts/03 Pedestal RMS',
+                 'HcalCalib/Layouts/04 Pedestal RMS by FED',
+                 'HcalCalib/Layouts/05 Pedestal Mean DB Ref',
+                 'HcalCalib/Layouts/06 Pedestal Mean DB Ref by FED',
+                 'HcalCalib/Layouts/07 Pedestal RMS DB Ref',
+                 'HcalCalib/Layouts/08 Pedestal RMS DB Ref by FED',
+                 'HcalCalib/Layouts/09 Pedestal Mean Bad',
+                 'HcalCalib/Layouts/10 Pedestal Mean Bad by FED',
+                 'HcalCalib/Layouts/11 Pedestal RMS Bad',
+                 'HcalCalib/Layouts/12 Pedestal RMS Bad by FED',
+                 'HcalCalib/Layouts/13 Pedestal Missing',
+                 'HcalCalib/Layouts/14 Pedestal Missing by FED',
+                 'HcalCalib/Layouts/15 Pedestal Occupancy vs LS',
+                 'HcalCalib/Layouts/16 Missing vs LS',
+                 'HcalCalib/Layouts/17 Number of Bad Mean vs LS',
+                 'HcalCalib/Layouts/18 Number of Bad RMS vs LS'
+                )
+
+server.workspace('DQMContent', 34, 'Calorimeters', 'Castor', '^Castor/', '',
+                 'Castor/Layouts/01 - Map of frontend and readout errors',
+                 'Castor/Layouts/02 - Channel-wise timing',
+                 'Castor/Layouts/02b - Channel-wise timing (rms)',
+                 'Castor/Layouts/Digi/05 - DigiSize',
+                )
+
+# Muons workspaces:
+server.workspace('DQMContent', 40, 'Muons', 'DT', '^DT/', '',
+                 'DT/Layouts/00-Summary/00-DataIntegritySummary',
+                 'DT/Layouts/00-Summary/00-ROChannelSummary',
+                 'DT/Layouts/00-Summary/01-OccupancySummary',
+                 'DT/Layouts/00-Summary/02-SegmentSummary',
+                 'DT/Layouts/00-Summary/03-TM_TriggerCorrFractionSummary',
+                 'DT/Layouts/00-Summary/04-TM_Trigger2ndFractionSummary',
+                 'DT/Layouts/00-Summary/05-NoiseChannelsSummary',
+                 'DT/Layouts/00-Summary/06-SynchNoiseSummary',
+                )
+
+server.workspace('DQMContent', 41, 'Muons', 'RPC', '^RPC/', '',
+                 'RPC/Layouts/01-Fatal_FED_Errors',
+                 'RPC/Layouts/02-RPC_Events',
+                 'RPC/Layouts/08-Barrel_Occupancy',
+                 'RPC/Layouts/09-Endcap_Occupancy',
+                )
+
+server.workspace('DQMContent', 42, 'Muons', 'CSC', '^CSC/', '',
+                 'CSC/Layouts/00 Top Physics Efficiency',
+                 'CSC/Layouts/01 Station Physics Efficiency',
+                 'CSC/Layouts/02 EMU Summary/EMU Test01 - DDUs in Readout',
+                 'CSC/Layouts/02 EMU Summary/EMU Test03 - DDU Reported Errors',
+                 'CSC/Layouts/02 EMU Summary/EMU Test04 - DDU Format Errors',
+                 'CSC/Layouts/02 EMU Summary/EMU Test05 - DDU Inputs Status',
+                 'CSC/Layouts/02 EMU Summary/EMU Test06 - DDU Inputs in ERROR-WARNING State',
+                 'CSC/Layouts/02 EMU Summary/EMU Test08 - CSCs Reporting Data and Unpacked',
+                 'CSC/Layouts/02 EMU Summary/EMU Test10 - CSCs with Errors and Warnings (Fractions)',
+                 'CSC/Layouts/02 EMU Summary/EMU Test11 - CSCs without Data Blocks',
+                 'CSC/Layouts/06 Physics Efficiency - RecHits Minus',
+                 'CSC/Layouts/07 Physics Efficiency - RecHits Plus',
+                )
+
 # CTPPS workspaces:
-server.workspace('DQMContent', 51, 'CTPPS', 'TrackingStrip', '^CTPPS/', 'CTPPS/TrackingStrip/Layouts')
+server.workspace('DQMContent', 50, 'CTPPS', 'TrackingStrip', '^CTPPS/', 'CTPPS/TrackingStrip/Layouts')


### PR DESCRIPTION
For both the online and the offline GUI the workspaces are re-ordered
and made more logical and consistent.
We also added layouts for the "Info" plots, so that we could add
documentation. These layouts were then added as workspaces as well, so
that from now on, you can double-click on the HV plot in the summary
page to get more general info on the run, also allowing you to zoom in
to this plot.