### PR TITLE
Force IPv4 for dev DQMGUI server

### DIFF
--- a/dqmgui/server-conf-dev.py
+++ b/dqmgui/server-conf-dev.py
@@ -39,7 +39,7 @@ server.source('DQMUnknown')
 server.source('DQMOverlay')
 server.source('DQMStripChart')
 server.source('DQMCertification')
-server.source('DQMLive', "localhost:8061")
+server.source('DQMLive', "127.0.0.1:8061")
 server.source('DQMArchive', "%s/ix128" % STATEDIR, '^/Global/')
 server.source('DQMLayout')
 


### PR DESCRIPTION
The underlying network layer of DQMGUI is forced to use IPv4
network addressing space since the DQMCollector application
is using such version. Usage of the generic 'localhost'
interface could result in IPv6 usage, depending on how the
hosting machine is configured, the facto preventing the Live
source to work properly.