### PR TITLE
Remove leftover duration cycle for logDBTasks thread

### DIFF
--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -94,7 +94,6 @@ if HOST.startswith("vocms0140") or HOST.startswith("vocms0131") or HOST.startswi
     logDBTasks.central_logdb_url = LOG_DB_URL
     logDBTasks.log_reporter = LOG_REPORTER
     logDBTasks.logDBCleanDuration = 60 * 60 * 24 * 1 # 1 day
-    logDBTasks.logDBUpdateDuration = 60 * 10 # every 10 min
     logDBTasks.log_file = '%s/logs/reqmon/logDBTasks-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
     
     # Cleaning up wmstats db


### PR DESCRIPTION
This variable is no longer used in WMCore. @ticoann please review