### PR TITLE
Put back to the default the palette for additional strip summary maps

### DIFF
--- a/dqmgui/style/SiStripRenderPlugin.cc
+++ b/dqmgui/style/SiStripRenderPlugin.cc
@@ -151,12 +151,12 @@ private:
       {
         obj->SetStats( kFALSE );
         dqm::utils::reportSummaryMapPalette(obj);
-
+	/*
         if ( o.name.find( "_has" )  != std::string::npos)
         {
           gStyle->SetPalette(60);
         }
-
+	*/
         obj->SetOption("colztext");
         return;
       }


### PR DESCRIPTION
The title says it all, commenting the lines to give a different palette to summary maps