### PR TITLE
Hiding CASTOR and ZDC from the HV plot again

### DIFF
--- a/dqmgui/style/DQMInfoRenderPlugin.cc
+++ b/dqmgui/style/DQMInfoRenderPlugin.cc
@@ -293,8 +293,8 @@ private:
         TString label = TString(myClonedPlot->GetYaxis()->GetBinLabel(binYOrig));
         // This is where we do the filtering: We skip the lines with the
         // following labels
-        ////if (label != "CASTOR" && label != "ZDC") { // enable this line to filter CASTOR and ZDC away
-        if (true) {
+        if (label != "CASTOR" && label != "ZDC") { // enable this line to filter CASTOR and ZDC away
+        ////if (true) {
           binYNew++;
           for ( int binX = 1; binX < maxBinX; binX++ ) {
             // Just copy the data, with possible offset in Y


### PR DESCRIPTION
HI runs are over, so for the next 2 years CASTOR and ZDC will be off again. 
So we should not show a big red line anymore on the main HV summary plot when they are off, since that will be the normal situation anyway.