### PR TITLE
Adding Tomas + Jim to receivers of agent warnings

### DIFF
--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -327,7 +327,7 @@ start_agents_dqm_prod_local()
     $DQM_DATA/repository/original \
     $STATEDIR/online/ix128 \
     --rsync \
-    --email broen.van.besien@cern.ch,marco.rovere@cern.ch
+    --email broen.van.besien@cern.ch,marco.rovere@cern.ch,tomas.hreus@cern.ch,james.patrick@cern.ch
 
   startagent $D/agent-sound \
     visDQMSoundAlarmDaemon \
@@ -404,7 +404,7 @@ start_agents_offline()
       --next $DQM_DATA/agents/qcontrol $DQM_DATA/agents/vcontrol \
       --rsync \
       --rsyncnext $DQM_DATA/agents/ixstageout \
-      --email broen.van.besien@cern.ch,marco.rovere@cern.ch
+      --email broen.van.besien@cern.ch,marco.rovere@cern.ch,tomas.hreus@cern.ch,james.patrick@cern.ch
 
     startagent $D/agent-qcontrol \
       visDQMRootFileQuotaControlDaemon \
@@ -469,7 +469,7 @@ start_agents_relval()
       --next $DQM_DATA/agents/qcontrol $DQM_DATA/agents/vcontrol \
       --rsync \
       --rsyncnext $DQM_DATA/agents/ixstageout \
-      --email broen.van.besien@cern.ch,marco.rovere@cern.ch
+      --email broen.van.besien@cern.ch,marco.rovere@cern.ch,tomas.hreus@cern.ch,james.patrick@cern.ch
 
     startagent $D/agent-qcontrol \
       visDQMRootFileQuotaControlDaemon \
@@ -522,7 +522,7 @@ start_agents_offline_relval_test()
         --next $DQM_DATA/agents/qcontrol $DQM_DATA/agents/vcontrol \
         --rsync \
         --rsyncnext $DQM_DATA/agents/ixstageout \
-        --email broen.van.besien@cern.ch,marco.rovere@cern.ch
+        --email broen.van.besien@cern.ch,marco.rovere@cern.ch,tomas.hreus@cern.ch,james.patrick@cern.ch
       # We do the rsync, but only for the dev instance, it's propagated to the
       # agent dropbox to be backed up on Castor
     else
@@ -539,7 +539,7 @@ start_agents_offline_relval_test()
         $DQM_DATA/ix128 \
         --next $DQM_DATA/agents/qcontrol $DQM_DATA/agents/vcontrol \
         --rsync \
-        --email broen.van.besien@cern.ch,marco.rovere@cern.ch
+        --email broen.van.besien@cern.ch,marco.rovere@cern.ch,tomas.hreus@cern.ch,james.patrick@cern.ch
     fi
 
     startagent $D/agent-qcontrol \
@@ -751,7 +751,7 @@ indexbackup()
           $DQM_DATA/agents/ixstageout \
           $DQM_DATA/ix128 \
           $CASTORDIR \
-          broen.van.besien@cern.ch,marco.rovere@cern.ch \
+          broen.van.besien@cern.ch,marco.rovere@cern.ch,tomas.hreus@cern.ch,james.patrick@cern.ch \
           --fullbackup 50 \
           </dev/null 2>&1 | rotatelogs $LOGDIR/$LOGSTEM-%Y%m%d.log 86400 >/dev/null 2>&1
       esac
@@ -825,7 +825,7 @@ zipbackupcheck()
         # It is supposed to be started from/by acrontab.
         visDQMZipCastorVerifier \
           $DQM_DATA/agents/verify \
-          broen.van.besien@cern.ch,marco.rovere@cern.ch \
+          broen.van.besien@cern.ch,marco.rovere@cern.ch,tomas.hreus@cern.ch,james.patrick@cern.ch \
           $DQM_DATA/zipped \
           $CASTORDIR \
           24 \


### PR DESCRIPTION
When the agents notice something weird they notify Broen and Marco with an email.
Usually we then wait to see if the problem persists and launch an investigation if needed.
We added two more people to the list: Tomas and Jim