### PR TITLE
Fix style of  L1T Stage2 Report Summary Map

### DIFF
--- a/dqmgui/style/L1TRenderPlugin.cc
+++ b/dqmgui/style/L1TRenderPlugin.cc
@@ -126,7 +126,8 @@ public:
       // determine whether core object is an L1T object
       if (o.name.find( "L1T/" ) != std::string::npos )
         // Stage 2 trigger will have new render plugin
-        if (o.name.find( "L1TStage2" ) == std::string::npos )
+        if (o.name.find( "L1TStage2" ) == std::string::npos && 
+            o.name.find( "reportSummaryMap" ) == std::string::npos ) 
           return true;
 
       return false;


### PR DESCRIPTION
Description of the Problem:
Currently we observe that the style of the L1T Report Summary Map in the Online DQM GUI is not adequate. The name of the Legacy and the Stage2 L1T Systems are written on top of each other making it very difficult to determine which  L1T System corresponds to each row in the plot. After checking, I found out that the reason is because the render plugins of both the Legacy L1T (L1TRenderPlugin.cc) and the Stage2 L1T (L1TStage2RenderPlugin.cc) are applied simultaneously on the L1T Summary Map, overlaying the names of each L1T system.

Description of the PR: 
This PR disables the render plugin of the legacy L1T when the input DQM plot is the L1T Report Summary Map, so that only the L1T Stage2 render plugin is applied on the report summary.


@thomreis @bortigno