### PR TITLE
Allow 400k lumi sections in MC global workqueue

### DIFF
--- a/workqueue/config.py
+++ b/workqueue/config.py
@@ -28,7 +28,7 @@ LOG_REPORTER = "global_workqueue"
 root = __file__.rsplit('/', 4)[0]
 cache_dir = os.path.join(root, 'state', 'workqueue', 'cache')
 os.environ['WMCORE_CACHE_DIR'] = cache_dir
-os.environ['MAX_LUMIS_PER_WQE'] = '200000'
+os.environ['MAX_LUMIS_PER_WQE'] = '400000'
 
 ROOTDIR = __file__.rsplit('/', 3)[0]
 config = Configuration()


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/7855

@h4d4 we'd like to check whether global workqueue behaves with this setting. 

Can you please make this change to the workqueue configuration file in production (I think in vocms0140) and restart this service?
If the P&R team confirms it's Ok, then I'll ask you to merge and push it to testbed as well.