### PR TITLE
Fix style of L1TEMU Stage2 Report Summary Map

### DIFF
--- a/dqmgui/style/L1TEMURenderPlugin.cc
+++ b/dqmgui/style/L1TEMURenderPlugin.cc
@@ -49,9 +49,11 @@ public:
     virtual bool applies(const VisDQMObject& dqmObj, const VisDQMImgInfo&) {
         if (dqmObj.name.find("L1TEMU/") != std::string::npos) {
 
-            // return true for all L1TEMU, except L1TdeRCT
-            if (dqmObj.name.find("L1TEMU/L1TdeRCT/") != std::string::npos) {
-                return false;
+            // return true for all L1TEMU, except L1TdeRCT, L1TStage2 and reportSummaryMap
+            if (dqmObj.name.find("L1TEMU/L1TdeRCT/") != std::string::npos ||
+                dqmObj.name.find("L1TStage2") != std::string::npos ||
+                dqmObj.name.find("reportSummaryMap") != std::string::npos) {
+              return false;
             } else {
                 return true;
             }


### PR DESCRIPTION
Description:

This PR disables the render plugin of the legacy L1TEMU when the input DQM plot is the L1TEMU Report Summary Map, so that only the L1T Stage2 render plugin is applied on the report summary.

