### PR TITLE
#Clusters per ring and layer

### DIFF
--- a/dqmgui/style/SiStripRenderPlugin.cc
+++ b/dqmgui/style/SiStripRenderPlugin.cc
@@ -463,6 +463,37 @@ private:
 	return;
       }
 
+	if( o.name.find( "NumberOfClusterPerLayerTrendVar" ) != std::string::npos)
+	{
+		if (((TString)obj->GetTitle()).Contains( "TIB" )) {
+			obj->GetYaxis()->SetRangeUser(1,4);
+		} else if (((TString)obj->GetTitle()).Contains( "TOB" ) ) {
+			obj->GetYaxis()->SetRangeUser(1,6);
+		} else if (((TString)obj->GetTitle()).Contains( "TEC" ) ) {
+			obj->GetYaxis()->SetRangeUser(1,9);
+		} else if (((TString)obj->GetTitle()).Contains( "TID" )) {
+			obj->GetYaxis()->SetRangeUser(1,3);
+		}
+		obj->SetStats( kFALSE );
+		gStyle->SetPalette(1,0);
+		obj->SetOption("colz");
+	}
+
+	if( o.name.find("NumberOfClusterPerRingVsTrendVar") != std::string::npos){
+		obj->SetStats( kFALSE );
+		gStyle->SetPalette(1,0);
+		obj->SetOption("colz");
+		if (((TString)obj->GetTitle()).Contains( "TID" )) {
+			obj->GetYaxis()->SetRangeUser(1,3);
+		}
+		if (((TString)obj->GetTitle()).Contains( "TEC" )) {
+			if (((TString)obj->GetTitle()).Contains( "wheel__1" ) or ((TString)obj->GetTitle()).Contains( "wheel__2" ) or ((TString)obj->GetTitle()).Contains( "wheel__3" )) obj->GetYaxis()->SetRangeUser(1,7);
+			if (((TString)obj->GetTitle()).Contains( "wheel__4" ) or ((TString)obj->GetTitle()).Contains( "wheel__5" ) or ((TString)obj->GetTitle()).Contains( "wheel__6" )) obj->GetYaxis()->SetRangeUser(2,7);
+			if (((TString)obj->GetTitle()).Contains( "wheel__7" ) or ((TString)obj->GetTitle()).Contains( "wheel__8" ) ) obj->GetYaxis()->SetRangeUser(3,7);
+			if (((TString)obj->GetTitle()).Contains( "wheel__9" ) ) obj->GetYaxis()->SetRangeUser(4,7);
+		}
+	}
+
       return;
     }
   void preDrawTProfile( TCanvas *c, const VisDQMObject &o )


### PR DESCRIPTION
- NumberOfClusterPerLayerTrendVar and NumberOfClusterPerRingVsTrendVar plots are changed to TProfiles2D ( see this PR https://github.com/cms-sw/cmssw/pull/19396 )
- SiStripRender plugin modified in order to set the range and the palette of these plots.
- [Plot](https://goo.gl/cjh5hX) before this fix.
- [Plot](http://tracker-dqm.cern.ch:8080/dqm/offline/start?runnr=284036;dataset=/StreamExpress/Run2017A-Express-v1/DQMIO;sampletype=offline_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=SiStrip;size=M;root=SiStrip/MechanicalView/TOB;focus=SiStrip/MechanicalView/TOB/NumberOfClusterPerLayerTrendVar;zoom=yes;) after this fix. 