### PR TITLE
adding support for new TrackingHLTBeamspotStream for reportSummaryMap, near L28

### DIFF
--- a/dqmgui/style/BeamRenderPlugin.cc
+++ b/dqmgui/style/BeamRenderPlugin.cc
@@ -23,8 +23,9 @@ class BeamRenderPlugin : public DQMRenderPlugin {
 
 public:
   virtual bool applies( const VisDQMObject &o, const VisDQMImgInfo & ) {
-    if ((o.name.find( "BeamMonitor/" ) == std::string::npos) &&
-	(o.name.find( "BeamMonitor_PixelLess/" ) == std::string::npos))
+    if ((o.name.find( "BeamMonitor/" )               == std::string::npos) &&
+	(o.name.find( "BeamMonitor_PixelLess/" )     == std::string::npos) &&
+	(o.name.find( "TrackingHLTBeamspotStream/" ) == std::string::npos))
       return false;
 
     if (o.name.find( "/EventInfo/" ) != std::string::npos)


### PR DESCRIPTION
Adding a line in BeamRenderPlugin.cc to handle the new beamhlt client ("TrackingHLTBeamspotStream/"), to treat it in a similar way to the previous BeamMonitor/ and BeamMonitor_PixelLess/ folders.

The motivation was to properly plot reportSummaryMap for TrackingHLTBeamspotStream. It seems that reuse of BeamRenderPlugin.cc with the above addition should solve the problem.