### PR TITLE
Updated the deploy and manage scripts for CC7

### DIFF
--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -16,26 +16,12 @@ deploy_dqmgui_deps()
 deploy_dqmgui_prep()
 {
   extra=
-  case $host in
-    dqm-C2D07-0[12] | dqm-C2D07-12 )
-      extra="$extra /dqmdata/dqm/uploads"
-      extra="$extra /dqmdata/dqm/agents"
-      extra="$extra /dqmdata/dqm/repository/original"
-      extra="$extra online online/sessions $project_logs/online"
-      for a in import-local  import-offsite  import-test; do
-        extra="$extra /dqmdata/dqm/agents/$a"
-      done
-      ;;
-
-    * )
-      for d in online offline relval dev; do
-        extra="$extra $d $d/sessions $d/agents $d/data $d/uploads $d/zipped $project_logs/$d"
-	for a in clean freezer ixmerge ixstageout qcontrol vcontrol register register128 stageout verify zip; do
-	  extra="$extra $d/agents/$a"
-	done
-      done
-      ;;
-  esac
+  for d in online offline relval dev; do
+    extra="$extra $d $d/sessions $d/agents $d/data $d/uploads $d/zipped $project_logs/$d"
+    for a in clean freezer ixmerge ixstageout qcontrol vcontrol register register128 stageout verify zip; do
+      extra="$extra $d/agents/$a"
+    done
+  done
   mkproj $extra backup
   [ ! $variant == online ] &&  mkproxy
   $nogroups || chmod g+ws */data */zipped */agents/*
@@ -68,6 +54,10 @@ deploy_dqmgui_post()
 
   # Castor stageout acronjobs enabled only for the
   # official offline, relval and dev instances
+  ###################################### START TODO FOR CC7
+  # Now the acron jobs are only created for the SLC servers
+  # We will have to add vocms073[89] here
+  ###################################### END TODO FOR CC7
   case $host:$root in
     vocms013[189]:/data/srv )
       klist -s # must have afs kerberos token

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -75,7 +75,9 @@ case $HOST:$DOMAIN in
   # On the production machines in the CERN network, flavor is based on the
   # machine and they get an alternate user
   vocms0138:* ) FLAVOR=offline;                ALTERNATIVE_USER='cmsweb' ;;
+  vocms0738:* ) FLAVOR=offline;                ALTERNATIVE_USER='cmsweb' ;;
   vocms0139:* ) FLAVOR=relval;                 ALTERNATIVE_USER='cmsweb' ;;
+  vocms0739:* ) FLAVOR=relval;                 ALTERNATIVE_USER='cmsweb' ;;
   vocms0131:* ) FLAVOR=offline-relval-testing; ALTERNATIVE_USER='cmsweb' ;;
   # Private instances get the dev flavor, unless specified differently
   *:cern.ch )   FLAVOR=dev;;
@@ -266,7 +268,7 @@ start_agents()
     # nothing gets backed up
     srv-c2f11-29-04:*agents* )
       start_agents_dqm_test ;;
-    ##### OFFLINE: offline server vocms0138
+    ##### OFFLINE: offline servers vocms0138 (SLC6) and vocms0738 (CC7)
     # The offline server runs
     # - the standard receive and import daemons
     # - the quota and version control daemons
@@ -275,18 +277,18 @@ start_agents()
     #   online to offline
     # note that the agents to copy zip to castor, verify zip from castor and
     # copy index to castor run as tasks under acron.
-    vocms0138:*agents* )
+    vocms0138:*agents* | vocms0738:*agents* )
       start_agents_offline ;;
-    ##### OFFLINE: Relval server vocms0139
+    ##### OFFLINE: relval server vocms0139 (SLC6) and vocms0739 (CC7)
     # The Relval server runs
     # - the standard receive and import daemons
     # - the quota and version control daemons
     # - the zip and zipfreeze daemons
     # Note that the agents to copy zip to Castor, verify zip from Castor and
     # copy index to Castor run as tasks under acron.
-    vocms0139:*agents* )
+    vocms0139:*agents* | vocms0739:*agents* )
       start_agents_relval ;;
-    ##### OFFLINE: Test server vocms0131
+    ##### OFFLINE: test server vocms0131
     # This server runs 3 gui's in 3 flavors: dev, offline and relval
     # The test server runs
     # - the standard receive and import daemons
@@ -728,6 +730,12 @@ indexbackup()
     D=${D}
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
+    ######################################### START TODO
+    # TODO FOR CC7: Add vocms0738:offline | vocms0739:relval to this
+    # (We will add, not replace, so that rollback stays possible.
+    #  But this also means that the old server should not be started if
+    #  the migration is a success.)
+    ######################################### END TODO
     case $HOST:$D in
       vocms0131:dev | vocms0138:offline | vocms0139:relval )
         CASTORDIR=/castor/cern.ch/cms/store/dqm/ixbackup/$D
@@ -767,6 +775,12 @@ zipbackup()
     D=${D}
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
+    ######################################### START TODO
+    # TODO FOR CC7: Add vocms0738:offline | vocms0739:relval to this
+    # (We will add, not replace, so that rollback stays possible.
+    #  But this also means that the old server should not be started if
+    #  the migration is a success.)
+    ######################################### END TODO
     case $HOST:$D in
       vocms0131:dev | vocms0138:offline | vocms0139:relval )
         CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$D
@@ -804,6 +818,12 @@ zipbackupcheck()
     D=${D}
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
+    ######################################### START TODO
+    # TODO FOR CC7: Add vocms0738:offline | vocms0739:relval to this
+    # (We will add, not replace, so that rollback stays possible.
+    #  But this also means that the old server should not be started if
+    #  the migration is a success.)
+    ######################################### END TODO
     case $HOST:$D in
       vocms0131:dev | vocms0138:offline | vocms0139:relval )
         CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$D

--- a/dqmgui/monitoring-dqm-dev-agents.ini
+++ b/dqmgui/monitoring-dqm-dev-agents.ini
@@ -1,4 +1,4 @@
-ENABLE_IF='app_is_enabled and host not in ("vocms0139", "vocms0138", "dqm-c2d07-01", "dqm-c2d07-02", "dqm-c2d07-11", "dqm-c2d07-12", "dqm-c2d07-21", "dqm-c2d07-22" )'
+ENABLE_IF='app_is_enabled and host not in ("vocms0138", "vocms0139", "vocms0738", "vocms0739")'
 
 LOG_FILES='dev/agent-*.log'
 LOG_ERROR_REGEX='ERROR|WARNING'

--- a/dqmgui/monitoring-dqm-dev-web.ini
+++ b/dqmgui/monitoring-dqm-dev-web.ini
@@ -1,4 +1,4 @@
-ENABLE_IF='app_is_enabled and host not in ("vocms0139", "vocms0138", "dqm-c2d07-01", "dqm-c2d07-02", "dqm-c2d07-11", "dqm-c2d07-12", "dqm-c2d07-21", "dqm-c2d07-22")'
+ENABLE_IF='app_is_enabled and host not in ("vocms0138", "vocms0139", "vocms0738", "vocms0739")'
 
 LOG_FILES='dev/[wr]*.log'
 LOG_ERROR_REGEX='\S+ \(pid=\d+ ppid=\d+\) received fatal signal'

--- a/dqmgui/monitoring-dqm-offline-agents.ini
+++ b/dqmgui/monitoring-dqm-offline-agents.ini
@@ -1,4 +1,4 @@
-ENABLE_IF='app_is_enabled and host == "vocms0138"'
+ENABLE_IF='app_is_enabled and host in ("vocms0138", "vocms0738")'
 
 LOG_FILES='offline/agent-*.log'
 LOG_ERROR_REGEX='ERROR|WARNING'

--- a/dqmgui/monitoring-dqm-offline-web.ini
+++ b/dqmgui/monitoring-dqm-offline-web.ini
@@ -1,4 +1,4 @@
-ENABLE_IF='app_is_enabled and host == "vocms0138"'
+ENABLE_IF='app_is_enabled and host in ("vocms0138", "vocms0738")'
 
 LOG_FILES='offline/[wr]*.log'
 LOG_ERROR_REGEX='\S+ \(pid=\d+ ppid=\d+\) received fatal signal'

--- a/dqmgui/monitoring-dqm-relval-agents.ini
+++ b/dqmgui/monitoring-dqm-relval-agents.ini
@@ -1,4 +1,4 @@
-ENABLE_IF='app_is_enabled and host == "vocms0139"'
+ENABLE_IF='app_is_enabled and host in ("vocms0139", "vocms0739")'
 
 LOG_FILES='relval/agent-*.log'
 LOG_ERROR_REGEX='ERROR|WARNING'

--- a/dqmgui/monitoring-dqm-relval-web.ini
+++ b/dqmgui/monitoring-dqm-relval-web.ini
@@ -1,4 +1,4 @@
-ENABLE_IF='app_is_enabled and host == "vocms0139"'
+ENABLE_IF='app_is_enabled and host in ("vocms0139", "vocms0739")'
 
 LOG_FILES='relval/[wr]*.log'
 LOG_ERROR_REGEX='\S+ \(pid=\d+ ppid=\d+\) received fatal signal'

--- a/dqmgui/server-conf-offline.py
+++ b/dqmgui/server-conf-offline.py
@@ -21,8 +21,11 @@ server.logFile     = '%s/weblog-%%Y%%m%%d.log' % LOGDIR
 server.title       = 'CMS data quality'
 # For convenience, we change the service name, depending on the server:
 hostname = socket.gethostname().lower().split('.')[0]
-# Offline production server
+# Offline production servers
 if hostname == 'vocms0138':
+  server.serviceName = 'Offline'
+  server.baseUrl     = '/dqm/offline'
+elif hostname == 'vocms0738':
   server.serviceName = 'Offline'
   server.baseUrl     = '/dqm/offline'
 # Relval test server

--- a/dqmgui/server-conf-relval.py
+++ b/dqmgui/server-conf-relval.py
@@ -35,8 +35,11 @@ server.logFile     = '%s/weblog-%%Y%%m%%d.log' % LOGDIR
 server.title       = 'CMS data quality'
 # For convenience, we change the service name, depending on the server:
 hostname = socket.gethostname().lower().split('.')[0]
-# Relval production server
+# Relval production servers
 if hostname == 'vocms0139':
+  server.serviceName = 'RelVal'
+  server.baseUrl     = '/dqm/relval'
+elif hostname == 'vocms0739':
   server.serviceName = 'RelVal'
   server.baseUrl     = '/dqm/relval'
 # Relval test server


### PR DESCRIPTION
The manage script basically enables you to start the servers and agents
on the new servers: vocms0738 and vocms0739.
The deploy script was _not_ changed, to the extend that the acron jobs
that do the backups to CASTOR will _not_ be installed on the new servers.
(Even if they were activated, they would not get the correct path on CASTOR)
But of course this will be needed when we do the real migration.
Also some changes to the monitoring scripts. This is basically for the
logging and I just added the new servers where the old servers where.
Also removed some very old servers from those files.

@threus Note: This PR is not needed for the online at all.