### PR TITLE
Ecal pedestal render plugin

### DIFF
--- a/dqmgui/style/EcalPedestalsRenderPlugin.cc
+++ b/dqmgui/style/EcalPedestalsRenderPlugin.cc
@@ -1,7 +1,9 @@
 #include "DQM/DQMRenderPlugin.h"
+#include "TROOT.h"
+#include "TStyle.h"
 #include "TH2.h"
 
-class TestDQMRenderPlugin : public DQMRenderPlugin
+class EcalPedestalsPCLRenderPlugin : public DQMRenderPlugin
 {
 public:
   virtual bool applies (const VisDQMObject &dqmObject, const VisDQMImgInfo &)
@@ -15,8 +17,11 @@ public:
     TH2* obj(dynamic_cast<TH2*>(dqmObject.object));
 
     // apply colz to all 2D histos
-    if (obj) renderInfo.drawOptions = "colz";
+    if (obj) {
+      obj->SetStats(false);
+      renderInfo.drawOptions = "colz";
+    }
   }
 };
 
-static TestDQMRenderPlugin instance;
+static EcalPedestalsPCLRenderPlugin instance;

--- a/dqmgui/style/EcalPedestalsRenderPlugin.cc
+++ b/dqmgui/style/EcalPedestalsRenderPlugin.cc
@@ -1,0 +1,22 @@
+#include "DQM/DQMRenderPlugin.h"
+#include "TH2.h"
+
+class TestDQMRenderPlugin : public DQMRenderPlugin
+{
+public:
+  virtual bool applies (const VisDQMObject &dqmObject, const VisDQMImgInfo &)
+  {
+    return (dqmObject.name.substr(0, 33) == "AlCaReco/EcalPedestalsPCL/Summary");
+  }
+
+  virtual void preDraw (TCanvas*, const VisDQMObject& dqmObject,
+                        const VisDQMImgInfo &, VisDQMRenderInfo & renderInfo)
+  {
+    TH2* obj(dynamic_cast<TH2*>(dqmObject.object));
+
+    // apply colz to all 2D histos
+    if (obj) renderInfo.drawOptions = "colz";
+  }
+};
+
+static TestDQMRenderPlugin instance;


### PR DESCRIPTION
ECAL now extracts gain 12 pedestals from events in the calibration stream. These pedestal values are monitored on offline DQM and some useful 2D summary plots can be found in: /AlcaReco/EcalPedestalsPCL/Summary

To make these 2D plots more readable, we require a new render plugin. This PR contains a first version, developed by Stefano Argiro based on the tutorial in: https://twiki.cern.ch/twiki/bin/view/CMS/DQMGuiPlugins

At the moment, the only functionality is to set drawing style to COLZ for 2D histograms in the Summary folder, and to remove the statistics box from all such histograms.