### PR TITLE
Updating deploy and manage scripts for CC migration

### DIFF
--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -59,16 +59,33 @@ deploy_dqmgui_post()
   # We will have to add vocms073[89] here
   ###################################### END TODO FOR CC7
   case $host:$root in
-    vocms013[189]:/data/srv )
+    # SLC6 Offline and Relval GUIs
+    vocms013[89]:/data/srv )
+      klist -s # must have afs kerberos token
+      # For the SLC6 servers, we actually explicitely _remove_ their acron entries
+      (acrontab -l | { egrep -v -e " $host.*$project_config/" || true; }
+      ) | acrontab
+      ;;
+    # SLC6 dev machine - One day this should become CC7
+    vocms0131:/data/srv )
       klist -s # must have afs kerberos token
       (acrontab -l | { egrep -v -e " $host.*$project_config/" || true; }
-
        # backup of the index
        echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'"
-
        # backup of the zipped root files
        echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'"
-
+       # check/verification of the backup of the zipped root files
+       echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'"
+      ) | acrontab
+      ;;
+    # CC7 Offline and Relval GUIs
+    vocms073[89]:/data/srv )
+      klist -s # must have afs kerberos token
+      (acrontab -l | { egrep -v -e " $host.*$project_config/" || true; }
+       # backup of the index
+       echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'"
+       # backup of the zipped root files
+       echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'"
        # check/verification of the backup of the zipped root files
        echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'"
       ) | acrontab

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -730,14 +730,8 @@ indexbackup()
     D=${D}
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
-    ######################################### START TODO
-    # TODO FOR CC7: Add vocms0738:offline | vocms0739:relval to this
-    # (We will add, not replace, so that rollback stays possible.
-    #  But this also means that the old server should not be started if
-    #  the migration is a success.)
-    ######################################### END TODO
     case $HOST:$D in
-      vocms0131:dev | vocms0138:offline | vocms0139:relval )
+      vocms0131:dev | vocms0138:offline | vocms0139:relval | vocms0738:offline | vocms0739:relval )
         CASTORDIR=/castor/cern.ch/cms/store/dqm/ixbackup/$D
         ;;
       * )
@@ -775,14 +769,8 @@ zipbackup()
     D=${D}
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
-    ######################################### START TODO
-    # TODO FOR CC7: Add vocms0738:offline | vocms0739:relval to this
-    # (We will add, not replace, so that rollback stays possible.
-    #  But this also means that the old server should not be started if
-    #  the migration is a success.)
-    ######################################### END TODO
     case $HOST:$D in
-      vocms0131:dev | vocms0138:offline | vocms0139:relval )
+      vocms0131:dev | vocms0138:offline | vocms0139:relval | vocms0738:offline | vocms0739:relval )
         CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$D
         ;;
       * )
@@ -818,14 +806,8 @@ zipbackupcheck()
     D=${D}
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
-    ######################################### START TODO
-    # TODO FOR CC7: Add vocms0738:offline | vocms0739:relval to this
-    # (We will add, not replace, so that rollback stays possible.
-    #  But this also means that the old server should not be started if
-    #  the migration is a success.)
-    ######################################### END TODO
     case $HOST:$D in
-      vocms0131:dev | vocms0138:offline | vocms0139:relval )
+      vocms0131:dev | vocms0138:offline | vocms0139:relval | vocms0738:offline | vocms0739:relval )
         CASTORDIR=/castor/cern.ch/cms/store/dqm/data/$D
         ;;
       * )


### PR DESCRIPTION
Basically: In the manage script we "arm" the CASTOR backup commands so
that from now on they can also be used from the new servers.

In the deploy script we made 2 changes:
- When the new servers are installed, the acrontab will be updated to
  send the backup commands to the new servers.
- When the old servers are installed, the acrontab lines to send the
  backup commands to the old servers will be removed.