### PR TITLE
Change the color palette for CaloLayer2,BMTF,uGMT and uGT in online DQM

### DIFF
--- a/dqmgui/style/L1TStage2BMTFRenderPlugin.cc
+++ b/dqmgui/style/L1TStage2BMTFRenderPlugin.cc
@@ -2,7 +2,7 @@
 #include <string>
 
 #include "DQM/DQMRenderPlugin.h"
-
+#include "TText.h"
 #include "TCanvas.h"
 #include "TColor.h"
 #include "TH1F.h"
@@ -12,6 +12,7 @@
 class L1TStage2BMTFRenderPlugin : public DQMRenderPlugin {
 
   int palette_kry[256];
+  TText tlabels_;
 
 public:
 
@@ -37,11 +38,11 @@ public:
     return false;
   }
 
-  virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo&) {
+  virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo& r) {
     if (dynamic_cast<TH1F*>(o.object)) {
       preDrawTH1F(c, o);
     } else if (dynamic_cast<TH2F*>(o.object)) {
-      preDrawTH2F(c, o);
+      preDrawTH2F(c, o, r);
     }
   }
 
@@ -55,14 +56,47 @@ public:
 
  private:
 
+bool checkAndRemove(std::string &s, const char * key)
+  {
+    if( s.find(key) != std::string::npos )
+    {
+      s.replace(s.find(key), strlen(key), "");
+      return true;
+    }
+    return false;
+  }
+
   void preDrawTH1F(TCanvas*, const VisDQMObject&) {}
 
-  void preDrawTH2F(TCanvas*, const VisDQMObject& o) {
+  void preDrawTH2F(TCanvas *c, const VisDQMObject& o, VisDQMRenderInfo &r) {
     TH2F* obj = dynamic_cast<TH2F*>(o.object);
     assert(obj);
 
     obj->SetOption("colz");
-    gStyle->SetPalette(256, palette_kry);
+  
+
+    checkAndRemove(r.drawOptions,"tlabels");
+
+    // Colormap setup
+    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+     {
+    //  Choose trigger from hell palette
+        obj->SetContour(256);
+        gStyle->SetPalette(256, palette_kry);
+        c->SetFrameFillColor(kBlack);
+        obj->GetXaxis()->SetAxisColor(kWhite);
+        obj->GetYaxis()->SetAxisColor(kWhite);
+        tlabels_.SetTextColor(kWhite);
+     }
+    else
+     {
+    // Set up default palette
+       obj->SetContour(100);
+       gStyle->SetPalette(1);
+       tlabels_.SetTextColor(kBlack);
+    }
+ 
+
   }
 
   void postDrawTH1F(TCanvas*, const VisDQMObject&) {}

--- a/dqmgui/style/L1TStage2BMTFRenderPlugin.cc
+++ b/dqmgui/style/L1TStage2BMTFRenderPlugin.cc
@@ -78,7 +78,7 @@ bool checkAndRemove(std::string &s, const char * key)
     checkAndRemove(r.drawOptions,"tlabels");
 
     // Colormap setup
-    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+    if( checkAndRemove(r.drawOptions, "DarkBodyRadiator") )
      {
     //  Choose trigger from hell palette
         obj->SetContour(256);
@@ -87,6 +87,13 @@ bool checkAndRemove(std::string &s, const char * key)
         obj->GetXaxis()->SetAxisColor(kWhite);
         obj->GetYaxis()->SetAxisColor(kWhite);
         tlabels_.SetTextColor(kWhite);
+     }
+    else if( checkAndRemove(r.drawOptions, "InvertedDarkBodyRadiator") )
+     {
+    // Choose the Inverted Dark Body Radiator palette   
+       obj->SetContour(100);
+       gStyle->SetPalette(56);
+       tlabels_.SetTextColor(kBlack);
      }
     else
      {

--- a/dqmgui/style/L1TStage2CaloLayer2RenderPlugin.cc
+++ b/dqmgui/style/L1TStage2CaloLayer2RenderPlugin.cc
@@ -2,7 +2,7 @@
 #include <string>
 
 #include "DQM/DQMRenderPlugin.h"
-
+#include "TText.h"
 #include "TCanvas.h"
 #include "TColor.h"
 #include "TH1F.h"
@@ -12,6 +12,7 @@
 class L1TStage2CaloLayer2RenderPlugin : public DQMRenderPlugin {
 
   int palette_kry[256];
+  TText tlabels_;
 
 public:
 
@@ -37,11 +38,11 @@ public:
     return false;
   }
 
-  virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo&) {
+  virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo& r) {
     if (dynamic_cast<TH1F*>(o.object)) {
       preDrawTH1F(c, o);
     } else if (dynamic_cast<TH2F*>(o.object)) {
-      preDrawTH2F(c, o);
+      preDrawTH2F(c, o, r);
     }
   }
 
@@ -54,6 +55,16 @@ public:
   }
 
  private:
+
+bool checkAndRemove(std::string &s, const char * key)
+  {
+    if( s.find(key) != std::string::npos )
+    {
+      s.replace(s.find(key), strlen(key), "");
+      return true;
+    }
+    return false;
+  }
 
   void preDrawTH1F(TCanvas*, const VisDQMObject& o) {
     TH1F* obj = dynamic_cast<TH1F*>(o.object);
@@ -83,12 +94,33 @@ public:
 
   }
 
-  void preDrawTH2F(TCanvas*, const VisDQMObject& o) {
+  void preDrawTH2F(TCanvas *c, const VisDQMObject& o, VisDQMRenderInfo &r) {
     TH2F* obj = dynamic_cast<TH2F*>(o.object);
     assert(obj);
 
     obj->SetOption("colz");
-    gStyle->SetPalette(256, palette_kry);  
+  
+    checkAndRemove(r.drawOptions,"tlabels");
+
+    // Colormap setup
+    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+      {
+    //  Choose trigger from hell palette
+        obj->SetContour(256);
+        gStyle->SetPalette(256, palette_kry);
+        c->SetFrameFillColor(kBlack);
+        obj->GetXaxis()->SetAxisColor(kWhite);
+        obj->GetYaxis()->SetAxisColor(kWhite);
+        tlabels_.SetTextColor(kWhite);
+      }
+     else
+      {
+    // Set up default palette
+       obj->SetContour(100);
+       gStyle->SetPalette(1);
+       tlabels_.SetTextColor(kBlack);
+      }
+    
   }
 
   void postDrawTH1F(TCanvas*, const VisDQMObject& o) {

--- a/dqmgui/style/L1TStage2CaloLayer2RenderPlugin.cc
+++ b/dqmgui/style/L1TStage2CaloLayer2RenderPlugin.cc
@@ -103,7 +103,7 @@ bool checkAndRemove(std::string &s, const char * key)
     checkAndRemove(r.drawOptions,"tlabels");
 
     // Colormap setup
-    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+    if( checkAndRemove(r.drawOptions, "DarkBodyRadiator") )
       {
     //  Choose trigger from hell palette
         obj->SetContour(256);
@@ -112,6 +112,13 @@ bool checkAndRemove(std::string &s, const char * key)
         obj->GetXaxis()->SetAxisColor(kWhite);
         obj->GetYaxis()->SetAxisColor(kWhite);
         tlabels_.SetTextColor(kWhite);
+      }
+     else if( checkAndRemove(r.drawOptions, "InvertedDarkBodyRadiator") )
+      {
+    // Choose the Inverted Dark Body Radiator palette
+       obj->SetContour(100);
+       gStyle->SetPalette(56);
+       tlabels_.SetTextColor(kBlack);
       }
      else
       {

--- a/dqmgui/style/L1TStage2uGMTRenderPlugin.cc
+++ b/dqmgui/style/L1TStage2uGMTRenderPlugin.cc
@@ -100,7 +100,7 @@ bool checkAndRemove(std::string &s, const char * key)
     checkAndRemove(r.drawOptions,"tlabels");
 
     //Colormap setup
-    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+    if( checkAndRemove(r.drawOptions, "DarkBodyRadiator") )
       {
      // Choose trigger from hell palette
         obj->SetContour(256);
@@ -109,6 +109,13 @@ bool checkAndRemove(std::string &s, const char * key)
         obj->GetXaxis()->SetAxisColor(kWhite);
         obj->GetYaxis()->SetAxisColor(kWhite);
         tlabels_.SetTextColor(kWhite);
+      }
+    else if( checkAndRemove(r.drawOptions, "InvertedDarkBodyRadiator") )
+      {
+     // Choose the Inverted Dark Body Radiator palette
+      obj->SetContour(100);
+      gStyle->SetPalette(56);
+      tlabels_.SetTextColor(kBlack);
       }
     else
       {

--- a/dqmgui/style/L1TStage2uGMTRenderPlugin.cc
+++ b/dqmgui/style/L1TStage2uGMTRenderPlugin.cc
@@ -2,7 +2,7 @@
 #include <string>
 
 #include "DQM/DQMRenderPlugin.h"
-
+#include "TText.h"
 #include "TCanvas.h"
 #include "TColor.h"
 #include "TH1F.h"
@@ -12,6 +12,7 @@
 class L1TStage2uGMTRenderPlugin : public DQMRenderPlugin {
 
   int palette_kry[256];
+  TText tlabels_;
 
 public:
 
@@ -37,11 +38,11 @@ public:
     return false;
   }
 
-  virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo&) {
-    if (dynamic_cast<TH1F*>(o.object)) {
+ virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo& r) { 
+ if (dynamic_cast<TH1F*>(o.object)) {
       preDrawTH1F(c, o);
     } else if (dynamic_cast<TH2F*>(o.object)) {
-      preDrawTH2F(c, o);
+      preDrawTH2F(c, o, r);
     }
   }
 
@@ -54,6 +55,16 @@ public:
   }
 
  private:
+
+bool checkAndRemove(std::string &s, const char * key)
+  {
+    if( s.find(key) != std::string::npos )
+    {
+      s.replace(s.find(key), strlen(key), "");
+      return true;
+    }
+    return false;
+  }
 
   void preDrawTH1F(TCanvas*, const VisDQMObject& o) {
     TH1F* obj = dynamic_cast<TH1F*>(o.object);
@@ -80,12 +91,32 @@ public:
     }
   }
 
-  void preDrawTH2F(TCanvas*, const VisDQMObject& o) {
-    TH2F* obj = dynamic_cast<TH2F*>(o.object);
+  void preDrawTH2F(TCanvas* c, const VisDQMObject& o, VisDQMRenderInfo &r) {   
+  TH2F* obj = dynamic_cast<TH2F*>(o.object);
     assert(obj);
 
     obj->SetOption("colz");
-    //gStyle->SetPalette(kDarkBodyRadiator);
+
+    checkAndRemove(r.drawOptions,"tlabels");
+
+    //Colormap setup
+    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+      {
+     // Choose trigger from hell palette
+        obj->SetContour(256);
+        gStyle->SetPalette(256, palette_kry);
+        c->SetFrameFillColor(kBlack);
+        obj->GetXaxis()->SetAxisColor(kWhite);
+        obj->GetYaxis()->SetAxisColor(kWhite);
+        tlabels_.SetTextColor(kWhite);
+      }
+    else
+      {
+   // Set up default palette
+      obj->SetContour(100);
+      gStyle->SetPalette(1);
+      tlabels_.SetTextColor(kBlack);
+  }
 
     if (o.name.find("ugmtMuonBXvshwCharge") != std::string::npos) {
       obj->SetOption("text colz");
@@ -99,9 +130,8 @@ public:
       obj->SetOption("text colz");
     }
 
-    gStyle->SetPalette(256, palette_kry);
-
-  }
+ 
+    }
 
   void postDrawTH1F(TCanvas*, const VisDQMObject&) {}
 

--- a/dqmgui/style/L1TStage2uGTRenderPlugin.cc
+++ b/dqmgui/style/L1TStage2uGTRenderPlugin.cc
@@ -76,7 +76,7 @@ bool checkAndRemove(std::string &s, const char * key)
     checkAndRemove(r.drawOptions,"tlabels");
 
     // Colormap setup
-    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+    if( checkAndRemove(r.drawOptions, "DarkBodyRadiator") )
       {
     //  Choose trigger from hell palette
         obj->SetContour(256);
@@ -85,6 +85,13 @@ bool checkAndRemove(std::string &s, const char * key)
         obj->GetXaxis()->SetAxisColor(kWhite);
         obj->GetYaxis()->SetAxisColor(kWhite);
         tlabels_.SetTextColor(kWhite);
+      }
+    else if( checkAndRemove(r.drawOptions, "InvertedDarkBodyRadiator") )
+      {
+    // Choose the Inverted Dark Body Radiator palette
+       obj->SetContour(100);
+       gStyle->SetPalette(56);
+       tlabels_.SetTextColor(kBlack);
       }
     else
       {

--- a/dqmgui/style/L1TStage2uGTRenderPlugin.cc
+++ b/dqmgui/style/L1TStage2uGTRenderPlugin.cc
@@ -2,7 +2,7 @@
 #include <string>
 
 #include "DQM/DQMRenderPlugin.h"
-
+#include "TText.h"
 #include "TCanvas.h"
 #include "TColor.h"
 #include "TH1F.h"
@@ -12,6 +12,7 @@
 class L1TStage2uGTRenderPlugin : public DQMRenderPlugin {
 
   int palette_kry[256];
+  TText tlabels_;
 
 public:
 
@@ -37,11 +38,11 @@ public:
     return false;
   }
 
-  virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo&) {
+  virtual void preDraw(TCanvas* c, const VisDQMObject& o, const VisDQMImgInfo&, VisDQMRenderInfo& r) {
     if (dynamic_cast<TH1F*>(o.object)) {
       preDrawTH1F(c, o);
     } else if (dynamic_cast<TH2F*>(o.object)) {
-      preDrawTH2F(c, o);
+      preDrawTH2F(c, o, r);
     }
   }
 
@@ -55,14 +56,44 @@ public:
 
  private:
 
+bool checkAndRemove(std::string &s, const char * key)
+  {
+    if( s.find(key) != std::string::npos )
+    {
+      s.replace(s.find(key), strlen(key), "");
+      return true;
+    }
+    return false;
+  }
+
   void preDrawTH1F(TCanvas*, const VisDQMObject&) {}
 
-  void preDrawTH2F(TCanvas*, const VisDQMObject& o) {
+  void preDrawTH2F(TCanvas *c, const VisDQMObject& o, VisDQMRenderInfo& r) {
     TH2F* obj = dynamic_cast<TH2F*>(o.object);
     assert(obj);
 
     obj->SetOption("colz");
-    gStyle->SetPalette(256, palette_kry);
+    checkAndRemove(r.drawOptions,"tlabels");
+
+    // Colormap setup
+    if( checkAndRemove(r.drawOptions, "triggerfromhell") )
+      {
+    //  Choose trigger from hell palette
+        obj->SetContour(256);
+        gStyle->SetPalette(256, palette_kry);
+        c->SetFrameFillColor(kBlack);
+        obj->GetXaxis()->SetAxisColor(kWhite);
+        obj->GetYaxis()->SetAxisColor(kWhite);
+        tlabels_.SetTextColor(kWhite);
+      }
+    else
+      {
+   // Set up default palette
+       obj->SetContour(100);
+       gStyle->SetPalette(1);
+       tlabels_.SetTextColor(kBlack);
+      }
+  
   }
 
   void postDrawTH1F(TCanvas*, const VisDQMObject&) {}


### PR DESCRIPTION
This pull request comes with this Jira ticket : https://its.cern.ch/jira/browse/CMSLITDPG-167

-Replacement of the "trigger from hell palette" with the default palette for the CaloLayer2, BMTF, uGMT and uGT
-Palette option as in the CaloLayer1
