### PR TITLE
[SiStripAPVGains] Fix layouts to display correctly NoMPV histograms in summary and fix axis labels

### DIFF
--- a/dqmgui/layouts/sistripAPVgain_T0_layouts.py
+++ b/dqmgui/layouts/sistripAPVgain_T0_layouts.py
@@ -91,9 +91,13 @@ sistripAPVgainLayout(dqmitems, "04 - TEC Gain Summary",
   }])
 
 sistripAPVgainLayout(dqmitems, "05 - Missing APV Summary",
- [{ 'path': "AlCaReco/SiStripGainsHarvesting/NoMPV",
+ [{ 'path': "AlCaReco/SiStripGainsHarvesting/NoMPVfit",
     'description': "Position of non-calibrated APV ",
     'draw': { 'withref': "no" }
+  },
+  { 'path': "AlCaReco/SiStripGainsHarvesting/NoMPVmasked",
+    'description': "Position of masked APV ",
+    'draw': { 'withref': "no" },
   }])
 
 sistripAPVgainLayout(dqmitems, "06 - TIB performance Summary",

--- a/dqmgui/style/SiStripGainsRenderPlugin.cc
+++ b/dqmgui/style/SiStripGainsRenderPlugin.cc
@@ -22,6 +22,7 @@
 #include "TMath.h"
 #include "TLegend.h"
 #include "TString.h"
+#include "TLatex.h"
 #include <cassert>
 
 class SiStripGainsRenderPlugin : public DQMRenderPlugin
@@ -278,6 +279,12 @@ private:
     else if ( o.name.find("WRTP")!=std::string::npos )
       {
         xa->SetTitle("New Gain / Previous Gain");
+        ya->SetTitle("Number of APVs");
+        legend = new TLegend(.52,.77,.65,.86);
+      }
+    else if ( o.name.find("/Gains")!=std::string::npos )
+      {
+        xa->SetTitle("SiStrip Gain values from fit");
         ya->SetTitle("Number of APVs");
         legend = new TLegend(.52,.77,.65,.86);
       }
@@ -551,6 +558,14 @@ private:
               st->SetY1NDC( .81 );
               st->SetY2NDC( .89 );
             }
+	  
+	  TLatex myt; 
+	  myt.SetTextFont(42);
+	  myt.SetTextSize(0.06);
+	  myt.SetTextColor(kBlue);
+	  myt.DrawLatexNDC(0.15,0.20, o.name.find("fit")!=std::string::npos ? "NO FIT" : "MASKED");
+	  myt.Draw();
+
         }
 
     

--- a/dqmgui/style/SiStripGainsRenderPlugin.cc
+++ b/dqmgui/style/SiStripGainsRenderPlugin.cc
@@ -275,18 +275,21 @@ private:
         ya->SetTitle("Number of Clusters");
         //legend = new TLegend(.34,.77,.48,.86);
         legend = new TLegend(.57,.77,.74,.86);
+	legend->SetBit(kCanDelete);
       }
     else if ( o.name.find("WRTP")!=std::string::npos )
       {
         xa->SetTitle("New Gain / Previous Gain");
         ya->SetTitle("Number of APVs");
         legend = new TLegend(.52,.77,.65,.86);
+	legend->SetBit(kCanDelete);
       }
     else if ( o.name.find("/Gains")!=std::string::npos )
       {
         xa->SetTitle("SiStrip Gain values from fit");
         ya->SetTitle("Number of APVs");
         legend = new TLegend(.52,.77,.65,.86);
+	legend->SetBit(kCanDelete);
       }
     else
       {
@@ -294,6 +297,7 @@ private:
         xa->SetTitle("Cluster Charge [ADC/mm]");
         ya->SetTitle("Number of Clusters");
         legend = new TLegend(.52,.77,.65,.86);
+	legend->SetBit(kCanDelete);
       }
 
     gPad->Update();


### PR DESCRIPTION
 Hello,
this PR is meant to fix minor graphics issues in the display of `AlCaReco/GainValidation` and `AlCaReco/SiStripGainsHarvesting`.
Tested on top of  release`HG1711f`:

![screenshot 2017-10-31 11 56 31](https://user-images.githubusercontent.com/5082376/32220609-a1bfb690-be32-11e7-9acf-b78469d999b6.png)

attn: @dimattia 
