### PR TITLE
Adding Render Plugin and Layout for OfflinePV/AlignmentValidation

### DIFF
--- a/dqmgui/layouts/aliOfflinePV_T0_layouts.py
+++ b/dqmgui/layouts/aliOfflinePV_T0_layouts.py
@@ -1,0 +1,84 @@
+def aliOfflinePVLayout(i, p, *rows): i["OfflinePV/AlignmentValidation/" + p] = DQMItem(layout=rows) 
+
+aliOfflinePVLayout(dqmitems, "00 - Vertex and vertex tracks quality",
+                   [{ 'path': "OfflinePV/Alignment/chi2ndf",
+                      'description': "Chi square of vertex tracks (pT>1GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/chi2prob",
+                      'description': "Chi square probability of vertex tracks (pT>1GeV)",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/sumpt",
+                      'description': "sum of transverse momentum squared of vertex tracks (pT>1GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/weight",
+                      'description': "weight of track in vertex fit",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/ntracks",
+                      'description': "number of tracks in vertex",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxy",
+                      'description': "transverse impact parameter",
+                      'draw': { 'withref': "no" }
+                      }])
+
+aliOfflinePVLayout(dqmitems, "01 - Impact parameters and errors",
+                   [{ 'path': "OfflinePV/Alignment/dxyzoom",
+                      'description': "transverse impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxyErr",
+                      'description': "error on transverse impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/dz",
+                      'description': "longitudinal impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dzErr",
+                      'description': "error on longitudinal impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      }])
+
+aliOfflinePVLayout(dqmitems, "02 - Impact parameters projections (pT>1 GeV)",
+                   [{ 'path': "OfflinePV/Alignment/dxyVsPhi_pt1",
+                      'description': "transverse impact parameter vs track azimuth (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxyVsEta_pt1",
+                      'description': "transverse impact parameter vs track pseudorapitidy (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/dzVsPhi_pt1",
+                      'description': "longitudinal impact parameter vs track azimuth (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dzVsEta_pt1",
+                      'description': "longidutinal impact parameter vs track pseudorapidity (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      }])
+
+aliOfflinePVLayout(dqmitems, "03 - Impact parameters projections (pT>10 GeV)",
+                   [{ 'path': "OfflinePV/Alignment/dxyVsPhi_pt10",
+                      'description': "transverse impact parameter vs track azimuth (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxyVsEta_pt10",
+                      'description': "transverse impact parameter vs track pseudorapitidy (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/dzVsPhi_pt10",
+                      'description': "longitudinal impact parameter vs track azimuth (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dzVsEta_pt10",
+                      'description': "longidutinal impact parameter vs track pseudorapidity (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      }])
+
+
+

--- a/dqmgui/style/OfflinePVAlignmentRenderPlugin.cc
+++ b/dqmgui/style/OfflinePVAlignmentRenderPlugin.cc
@@ -1,0 +1,258 @@
+/*!
+  \file OfflinePVAlignmentRenderPlugin
+  \Display Plugin for Alignment Primary Vertex Validation 
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2017/06/29 10:51:56 $
+*/
+
+#include "DQM/DQMRenderPlugin.h"
+#include "TCanvas.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TProfile2D.h"
+#include "TStyle.h"
+#include "TGaxis.h"
+#include "TPaveStats.h"
+#include "TList.h"
+#include <cassert>
+
+class OfflinePVAlignmentRenderPlugin : public DQMRenderPlugin
+{
+public:
+
+  virtual bool applies(const VisDQMObject &o, const VisDQMImgInfo &)
+  {
+    if(o.name.find( "OfflinePV/Alignment/" ) != std::string::npos)return true;
+    else return false;
+  }
+
+  virtual void preDraw(TCanvas *c, const VisDQMObject &o, const VisDQMImgInfo &, VisDQMRenderInfo &)
+  {
+    c->cd();
+
+    if( dynamic_cast<TH1F*>( o.object ) )
+    {
+      this->preDrawTH1F( c, o );
+    }
+    else if( dynamic_cast<TH2F*>( o.object ) )
+    {
+      this->preDrawTH2F( c, o );
+    }
+    else if( dynamic_cast<TProfile*>( o.object ) )
+    {
+      this->preDrawTProfile( c, o );
+    }
+    else if( dynamic_cast<TProfile2D*>( o.object ) )
+    {
+      this->preDrawTProfile2D( c, o );
+    }
+  }
+
+  virtual void postDraw(TCanvas *c, const VisDQMObject &o, const VisDQMImgInfo &)
+  {
+    c->cd();
+
+    if( dynamic_cast<TH1F*>( o.object ) )
+    {
+      this->postDrawTH1F( c, o );
+    }
+    else if( dynamic_cast<TH2F*>( o.object ) )
+    {
+      this->postDrawTH2F( c, o );
+    }
+    else if( dynamic_cast<TProfile*>( o.object ) )
+    {
+      this->postDrawTProfile( c, o );
+    }
+    else if( dynamic_cast<TProfile2D*>( o.object ) )
+    {
+      this->postDrawTProfile2D( c, o );
+    }
+  }
+
+private:
+
+  void preDrawTH1F(TCanvas *, const VisDQMObject &o)
+  {
+    TH1F* obj = dynamic_cast<TH1F*>( o.object );
+    assert( obj );
+
+    obj->SetLineWidth(2);
+
+  }
+
+  void preDrawTH2F(TCanvas *, const VisDQMObject &o)
+  {
+    TH2F* obj = dynamic_cast<TH2F*>( o.object );
+    assert( obj );
+
+  }
+
+  void preDrawTProfile(TCanvas *, const VisDQMObject &o)
+  {
+    TProfile* obj = dynamic_cast<TProfile*>( o.object );
+    assert( obj );
+
+    obj->SetMarkerStyle(20);
+    obj->SetMarkerSize(1);
+
+  }
+
+  void preDrawTProfile2D(TCanvas *, const VisDQMObject &o)
+  {
+    TProfile2D* obj = dynamic_cast<TProfile2D*>( o.object );
+    assert( obj );
+
+  }
+
+  void postDrawTH1F(TCanvas *, const VisDQMObject &o)
+  {
+    TH1F* obj = dynamic_cast<TH1F*>( o.object );
+    assert( obj );
+    
+    TAxis* xa = obj->GetXaxis();
+    TAxis* ya = obj->GetYaxis();
+
+    xa->SetTitleOffset(0.9);
+    xa->SetTitleSize(0.05);
+    xa->SetLabelSize(0.04);
+    xa->CenterTitle();
+
+    ya->SetTitleOffset(0.9);
+    ya->SetTitleSize(0.05);
+    ya->SetLabelSize(0.04);
+    ya->CenterTitle();
+
+    // first layout
+
+    if( o.name.find("chi2ndf")!=std::string::npos ){
+     
+      xa->SetTitle("#chi^{2}/ndf of track");
+      ya->SetTitle("tracks");
+
+    } else if(o.name.find("chi2prob")!=std::string::npos ){
+
+      xa->SetTitle("Prob(#chi^{2},ndf)");
+      ya->SetTitle("tracks");
+
+    } else if(o.name.find("sumpt")!=std::string::npos ){
+
+      xa->SetTitle("#sum p^{2}_{T} [GeV^{2}]");
+      ya->SetTitle("tracks");
+
+    } else if(o.name.find("weight")!=std::string::npos ){
+      
+      xa->SetTitle("track weight");
+      ya->SetTitle("tracks");
+      
+    } else if(o.name.find("ntracks")!=std::string::npos ){
+
+      xa->SetTitle("n. of tracks (p_{T}>1GeV)");
+      ya->SetTitle("vertices");
+      gPad->SetLogy(1); 
+
+    } else if(o.name.find("dxyErr")!=std::string::npos ){
+
+      xa->SetTitle("error on d_{xy}(trk-PV) [#mum]");
+      ya->SetTitle("tracks");
+      gPad->SetLogy(1); 
+
+    } else if(o.name.find("dzErr")!=std::string::npos ){
+
+      xa->SetTitle("error on d_{z}(trk-PV) [#mum]");
+      ya->SetTitle("tracks");
+      gPad->SetLogy(1); 
+
+    } else if(o.name.find("dxy")!=std::string::npos ){
+
+      xa->SetTitle("d_{xy}(trk-PV) [#mum]");
+      ya->SetTitle("tracks");
+
+      if(o.name.find("dxyzoom")==std::string::npos ){
+	gPad->SetLogy(1); 
+      }
+
+    } else if(o.name.find("dz")!=std::string::npos ){
+
+      xa->SetTitle("d_{z}(trk-PV) [#mum]");
+      ya->SetTitle("tracks");
+
+    }
+
+    gPad->Update();
+    TPaveStats* st = (TPaveStats*)obj->GetListOfFunctions()->FindObject("stats");
+    if(st!=0)  {
+      st->SetBorderSize(0);
+      st->SetOptStat( 1110 );
+      st->SetTextColor( obj->GetLineColor() );
+
+      if(o.name.find("ntrack")!=std::string::npos ||
+	 o.name.find("sumpt")!=std::string::npos ||
+	 o.name.find("chi2ndf")!=std::string::npos ||
+	 o.name.find("Err")!=std::string::npos
+	 ) {
+	
+	st->SetX1NDC( .65 );
+	st->SetX2NDC( .88 );
+	st->SetY1NDC( .73 );
+	st->SetY2NDC( .89 );
+
+      } else {
+
+	st->SetX1NDC( .12 );
+	st->SetX2NDC( .35 );
+	st->SetY1NDC( .73 );
+	st->SetY2NDC( .89 );
+      }
+    }
+  }
+
+  void postDrawTH2F(TCanvas *, const VisDQMObject &o)
+  {
+    TH2F* obj = dynamic_cast<TH2F*>( o.object );
+    assert( obj );
+
+  }
+
+  void postDrawTProfile(TCanvas *, const VisDQMObject &o)
+  {
+    TProfile* obj = dynamic_cast<TProfile*>( o.object );
+    assert( obj );
+
+    gStyle->SetOptStat(0);
+
+    TAxis* xa = obj->GetXaxis();
+    TAxis* ya = obj->GetYaxis();
+
+    xa->SetTitleOffset(0.9);
+    xa->SetTitleSize(0.05);
+    xa->SetLabelSize(0.04);
+    xa->CenterTitle();
+
+    ya->SetTitleOffset(0.9);
+    ya->SetTitleSize(0.05);
+    ya->SetLabelSize(0.04);
+    ya->CenterTitle();
+
+    gPad->Update();
+
+    TLine tl;
+    tl.SetLineColor(kMagenta);
+    tl.SetLineWidth(3);
+    tl.SetLineStyle(7);
+    tl.DrawLine(gPad->GetUxmin(),0.,gPad->GetUxmax(),0.);
+
+   
+  }
+
+void postDrawTProfile2D(TCanvas *, const VisDQMObject &o)
+  {
+    TProfile2D* obj = dynamic_cast<TProfile2D*>( o.object );
+    assert( obj );
+
+  }
+};
+
+static OfflinePVAlignmentRenderPlugin instance;


### PR DESCRIPTION
 Greeting,
the aim of this PR is to introduce a new specific `OfflinePV/AlignmentValidation` workspace layout filled by selected plots existing in `OfflinePV/Alignment`, to facilitate the scrutiny of alignment changes in release validation as well as for data monitoring. 
Tested against `deployment` release  `HG1711l `.
Example of final look & feel:

![screenshot 2017-11-22 13 59 45](https://user-images.githubusercontent.com/5082376/33128800-06c39da6-cf8e-11e7-9491-152224d2c36b.png)

![screenshot 2017-11-22 14 01 23](https://user-images.githubusercontent.com/5082376/33128802-09707fd8-cf8e-11e7-89e3-d7b079c0067e.png)



