### PR TITLE
Add if block to SiStripRenderPlugin to plot fedErrorsVsIdVsLumi 2DPro…

### DIFF
--- a/dqmgui/style/SiStripRenderPlugin.cc
+++ b/dqmgui/style/SiStripRenderPlugin.cc
@@ -455,6 +455,13 @@ private:
       return;
     }
 
+	if( o.name.find( "fedErrorsVsIdVsLumi" )  != std::string::npos){
+		obj->SetStats( kFALSE );
+        	gStyle->SetPalette(1,0);
+		obj->SetOption("colz");
+		return;
+	}
+
 	  if( o.name.find( "StripClusVsBXandOrbit" ) != std::string::npos)
       {
         obj->SetStats( kFALSE );


### PR DESCRIPTION
…file as colz.

Simple block of code in SiStripRenderPlugin that asserts the 'colz' option for new SiStrip TProfile 2D plots that monitor the number of channel errors per fedid per lumisection - pull request:

https://github.com/cms-sw/cmssw/pull/21355