### PR TITLE
SiStripRenderPlugin: Draw partition boundaries where appropriate

### DIFF
--- a/dqmgui/style/SiStripRenderPlugin.cc
+++ b/dqmgui/style/SiStripRenderPlugin.cc
@@ -655,9 +655,26 @@ private:
 
   void postDrawTH1F( TCanvas *, const VisDQMObject &o )
   {
+    TH1F* obj = dynamic_cast<TH1F*>( o.object );
+    assert( obj );
+
+    TLine tl2;
+    tl2.SetLineColor(922); // 15?
+    tl2.SetLineWidth(2);
+    tl2.SetLineStyle(7);
+
+    TLine tl3;
+    tl3.SetLineColor(922); // 15?
+    tl3.SetLineWidth(1);
+    tl3.SetLineStyle(7);
 
     TText tt;
     tt.SetTextSize(0.12);
+    
+    TText tt2;
+    tt2.SetTextSize(0.04);
+    tt2.SetTextColor(15);
+    
     if (o.flags == 0) return;
     else
       {
@@ -677,6 +694,21 @@ private:
 	    tt.DrawTextNDC(0.5, 0.5, "Other ");
 	  }
       }
+      
+      if( o.name.find( "/ReadoutView/FE/VsId/" ) != std::string::npos || o.name.find( "/ReadoutView/FED/VsId/" ) != std::string::npos || o.name.find( "/ReadoutView/Fiber/VsId/" ) != std::string::npos || o.name.find( "/ReadoutView/DataPresent" ) != std::string::npos )
+    {
+      float plot_ymax = 1.049*(obj->GetMaximum());
+      if ( plot_ymax == 0 ) plot_ymax = 1.049;
+      tl3.DrawLine(134.0, 0., 134.0, plot_ymax);
+      tl2.DrawLine(164.0, 0., 164.0, plot_ymax);
+      tl2.DrawLine(260.0, 0., 260.0, plot_ymax);
+      tl2.DrawLine(356.0, 0., 356.0, plot_ymax);
+
+      tt2.DrawTextNDC(0.18, 0.91, "TIB/D");
+      tt2.DrawTextNDC(0.38, 0.91, "TEC-");
+      tt2.DrawTextNDC(0.55, 0.91, "TEC+");
+      tt2.DrawTextNDC(0.72, 0.91, "TOB");
+    }
 
   }
 
@@ -701,9 +733,14 @@ private:
       float mask2_ymax = 458.5;
 
       TLine tl2;
-      tl2.SetLineColor(921); // 15?
+      tl2.SetLineColor(922); // 15?
       tl2.SetLineWidth(2);
       tl2.SetLineStyle(7);
+      
+      TLine tl3;
+      tl3.SetLineColor(922); // 15?
+      tl3.SetLineWidth(1);
+      tl3.SetLineStyle(7);
 
       TText tt;
       tt.SetTextSize(0.12);
@@ -776,15 +813,16 @@ private:
         }
         return;
       }
-      if( o.name.find( "FEDErrorsVsId" )  != std::string::npos)
+      if( o.name.find( "FEDErrorsVsId" )  != std::string::npos || o.name.find( "ApvIdVsFedId" )  != std::string::npos )
 	    {
         float err_ymin = obj->GetYaxis()->GetXmin();
         float err_ymax = obj->GetYaxis()->GetXmax();
+        tl3.DrawLine(134.0, err_ymin, 134.0, err_ymax);
         tl2.DrawLine(164.0, err_ymin, 164.0, err_ymax);
         tl2.DrawLine(260.0, err_ymin, 260.0, err_ymax);
         tl2.DrawLine(356.0, err_ymin, 356.0, err_ymax);
 
-        tt2.DrawTextNDC(0.28, 0.92, "TIB");
+        tt2.DrawTextNDC(0.27, 0.92, "TIB/D");
         tt2.DrawTextNDC(0.43, 0.92, "TEC-");
         tt2.DrawTextNDC(0.58, 0.92, "TEC+");
         tt2.DrawTextNDC(0.77, 0.92, "TOB");
@@ -805,6 +843,20 @@ private:
     TLine tl2;
     tl2.SetLineColor(4);
     tl2.SetLineWidth(3);
+    
+    TLine tl3;
+    tl3.SetLineColor(922); // 15?
+    tl3.SetLineWidth(2);
+    tl3.SetLineStyle(7);
+
+    TLine tl4;
+    tl4.SetLineColor(922); // 15?
+    tl4.SetLineWidth(1);
+    tl4.SetLineStyle(7);
+
+    TText tt;
+    tt.SetTextSize(0.04);
+    tt.SetTextColor(15);
 
     float xmin = 0.0;
     float xmax = obj->GetXaxis()->GetXmax();
@@ -908,6 +960,21 @@ private:
         }
         return;
       }
+    
+    if( o.name.find( "/ReadoutView/FedEventSize" ) != std::string::npos )
+    {
+      float plot_ymax = 1.049*(obj->GetMaximum()+2*sqrt(obj->GetMaximum()));
+      if ( plot_ymax == 0 ) plot_ymax = 1.049;
+      tl4.DrawLine(134.0, -0.05, 134.0, plot_ymax);
+      tl3.DrawLine(164.0, -0.05, 164.0, plot_ymax);
+      tl3.DrawLine(260.0, -0.05, 260.0, plot_ymax);
+      tl3.DrawLine(356.0, -0.05, 356.0, plot_ymax);
+
+      tt.DrawTextNDC(0.18, 0.91, "TIB/D");
+      tt.DrawTextNDC(0.38, 0.91, "TEC-");
+      tt.DrawTextNDC(0.55, 0.91, "TEC+");
+      tt.DrawTextNDC(0.72, 0.91, "TOB");
+    }
   }
 
 };


### PR DESCRIPTION
All changes in style/SiStripRenderPlugin.cc (postDraw)
- Add line between TIB/TID
- Extend drawing of partition boundaries to other plots as a function of FED ID
(Extension of PR #418)

@fioriNTU @jandrea