### PR TITLE
New option for reqmgr2 manage script; push default docs to reqmgrAux

### DIFF
--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -1,6 +1,13 @@
 # vim: set ft=sh sw=2 ts=8 et :
 deploy_reqmgr2_variants="default prod preprod dev"
 
+case $variant in
+  prod )    base_url="https://cmsweb.cern.ch"         dbs_ins="prod";;
+  preprod ) base_url="https://cmsweb-testbed.cern.ch" dbs_ins="int";;
+  dev )     base_url="https://cmsweb-dev.cern.ch"     dbs_ins="dev";;
+  * )       base_url="https://`hostname -f`"          dbs_ins="private_vm";;
+esac
+
 deploy_reqmgr2_deps()
 {
   deploy $stage backend
@@ -26,12 +33,6 @@ deploy_reqmgr2_sw()
     note "WARNING: replace certificates in $project_auth with real ones"
   else :; fi
 
-  case $variant in
-    prod )    base_url="https://cmsweb.cern.ch"         dbs_ins="prod";;
-    preprod ) base_url="https://cmsweb-testbed.cern.ch" dbs_ins="int";;
-    dev )     base_url="https://cmsweb-dev.cern.ch"     dbs_ins="dev";;
-    * )       base_url="https://`hostname -f`"          dbs_ins="private_vm";;
-  esac
   perl -p -i -e "s{\"\@\@BASE_URL\@\@\"}{\"$base_url\"}g; \
                  s{\"\@\@DBS_INS\@\@\"}{\"$dbs_ins\"}g"   \
        $root/$cfgversion/config/$project/config.py
@@ -58,6 +59,11 @@ deploy_reqmgr2_post()
          "http://localhost:${couch##*:}/reqmgr_config_cache" \
          >> $root/state/${couch%%:*}/stagingarea/reqmgr2
   done
+
+  # Upload default configuration to reqmgr auxiliary db
+  local cmd="$project_config/manage postdefaultconfig $base_url 'I did read documentation'"
+  $nogroups || cmd="sudo -H -u _reqmgr2 bashs -l -c \"${cmd}\""
+  eval $cmd
 
   (mkcrontab; sysboot) | crontab -
 }

--- a/reqmgr2/manage
+++ b/reqmgr2/manage
@@ -9,6 +9,7 @@
 ##H   sysboot           start server from crond if not running
 ##H   restart           (re)start the service
 ##H   updateversions    update database with ScramArchs/CMSSW releases
+##H   postdefaultconfig post the default configuration to ReqMgr Auxiliary DB
 ##H   start             (re)start the service
 ##H   stop              stop the service
 ##H
@@ -43,6 +44,7 @@ COLOR_NORMAL="\\033[0;39m"
 
 . $ROOT/apps/$ME/etc/profile.d/init.sh
 
+WMCORE_BIN=$ROOT/apps/$ME/bin
 export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH
 export WMCORE_ROOT=$REQMGR2_ROOT/lib/python*/site-packages
 export REQMGR_CACHE_DIR=$STATEDIR
@@ -96,8 +98,13 @@ check()
 
 updateversions()
 {
-  cd $STATEDIR
-  reqmgr-sw-update $CFGFILE
+  ${WMCORE_BIN}/reqmgr-sw-update $CFGFILE
+}
+
+
+postdefaultconfig()
+{
+  ${WMCORE_BIN}/reqmgr-put-default-config $1
 }
 
 
@@ -125,6 +132,11 @@ case ${1:-status} in
   updateversions )
     check "$2"
     updateversions
+    ;;
+
+  postdefaultconfig )
+    check "$3"
+    postdefaultconfig $2
     ;;
 
   help )


### PR DESCRIPTION
Drawback is that every single backend will push these documents, though it's not a big deal...
I still have to test it.