### PR TITLE
ECAL histograms metadata fix

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -34,9 +34,9 @@ ecallayout(dqmitems, 'Ecal/Layouts/00 Overview/03 Occupancy',
 	   [{'path': 'EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE -', 'description': 'Digi occupancy.'},
 	    {'path': 'EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE +', 'description': 'Digi occupancy.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/00 Overview/04 Noise',
-	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
-	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
-	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
+	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
+	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/00 Overview/05 RecHit Energy',
 	   [{'path': 'EcalBarrel/EBSummaryClient/EBOT energy summary', 'description': '2D distribution of the mean rec hit energy.'}],
 	   [{'path': 'EcalEndcap/EESummaryClient/EEOT EE - energy summary', 'description': '2D distribution of the mean rec hit energy.'},
@@ -325,9 +325,9 @@ for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]
 
 #____________________ Layouts / 03 Noise ____________________
 ecallayout(dqmitems, 'Ecal/Layouts/03 Noise/00 Presample Quality',
-	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
-	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
-	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
+	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
+	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/03 Noise/01 RMS Map',
 	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal G12 RMS map', 'description': '2D distribution of the presample RMS. Channels with entries less than 6 are not considered.'}],
 	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal G12 RMS map', 'description': '2D distribution of the presample RMS. Channels with entries less than 6 are not considered.'},
@@ -358,7 +358,7 @@ for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]
       channellabel = '%s%s%02d' % (label, sign, channel) # e.g. "EE+05"
       ecallayout(dqmitems,'Ecal/Layouts/03 Noise/By SuperModule/Quality/Quality %s' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineClient/%sPOT pedestal quality G12 %s' % (detector, label, label, channellabel),
-                   'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+                   'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
       ecallayout(dqmitems,'Ecal/Layouts/03 Noise/By SuperModule/Mean/Mean %s' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineTask/Gain12/%sPOT pedestal %s G12' % (detector, label, label, channellabel),
                    'description': '2D distribution of mean presample value.'}],
@@ -974,7 +974,7 @@ for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]
                    'description': 'Digi occupancy.'}])
       ecallayout(dqmitems,'Ecal/Layouts/12 By SuperModule/%s/03 Presample Quality' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineClient/%sPOT pedestal quality G12 %s' % (detector, label, label, channellabel),
-                   'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+                   'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
       ecallayout(dqmitems,'Ecal/Layouts/12 By SuperModule/%s/04 Presample Mean' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineTask/Gain12/%sPOT pedestal %s G12' % (detector, label, label, channellabel),
                    'description': '2D distribution of mean presample value.'}],

--- a/dqmgui/layouts/ecal_T0_layouts.py
+++ b/dqmgui/layouts/ecal_T0_layouts.py
@@ -34,9 +34,9 @@ ecallayout(dqmitems, 'Ecal/Layouts/00 Overview/03 Occupancy',
 	   [{'path': 'EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE -', 'description': 'Digi occupancy.'},
 	    {'path': 'EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE +', 'description': 'Digi occupancy.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/00 Overview/04 Noise',
-	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
-	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
-	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
+	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
+	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/00 Overview/05 RecHit Energy',
 	   [{'path': 'EcalBarrel/EBSummaryClient/EBOT energy summary', 'description': '2D distribution of the mean rec hit energy.'}],
 	   [{'path': 'EcalEndcap/EESummaryClient/EEOT EE - energy summary', 'description': '2D distribution of the mean rec hit energy.'},
@@ -325,9 +325,9 @@ for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]
 
 #____________________ Layouts / 03 Noise ____________________
 ecallayout(dqmitems, 'Ecal/Layouts/03 Noise/00 Presample Quality',
-	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
-	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
-	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}],
+	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'},
+	    {'path': 'EcalEndcap/EESummaryClient/EEPOT EE + pedestal quality summary G12', 'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/03 Noise/01 RMS Map',
 	   [{'path': 'EcalBarrel/EBSummaryClient/EBPOT pedestal G12 RMS map', 'description': '2D distribution of the presample RMS. Channels with entries less than 6 are not considered.'}],
 	   [{'path': 'EcalEndcap/EESummaryClient/EEPOT EE - pedestal G12 RMS map', 'description': '2D distribution of the presample RMS. Channels with entries less than 6 are not considered.'},
@@ -358,7 +358,7 @@ for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]
       channellabel = '%s%s%02d' % (label, sign, channel) # e.g. "EE+05"
       ecallayout(dqmitems,'Ecal/Layouts/03 Noise/By SuperModule/Quality/Quality %s' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineClient/%sPOT pedestal quality G12 %s' % (detector, label, label, channellabel),
-                   'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+                   'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
       ecallayout(dqmitems,'Ecal/Layouts/03 Noise/By SuperModule/Mean/Mean %s' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineTask/Gain12/%sPOT pedestal %s G12' % (detector, label, label, channellabel),
                    'description': '2D distribution of mean presample value.'}],
@@ -958,7 +958,7 @@ for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]
                    'description': 'Digi occupancy.'}])
       ecallayout(dqmitems,'Ecal/Layouts/12 By SuperModule/%s/03 Presample Quality' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineClient/%sPOT pedestal quality G12 %s' % (detector, label, label, channellabel),
-                   'description': 'Summary of the presample data quality. A channel is red if presample mean is off by 25.0 from 200.0 or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
+                   'description': 'Summary of the presample data quality. A channel is red if presample mean is outside the range (175.0, 240.0) or RMS is greater than 3.0. RMS threshold is 6.0 in the forward region (|eta| > 2.1). Channels with entries less than 6 are not considered.'}])
       ecallayout(dqmitems,'Ecal/Layouts/12 By SuperModule/%s/04 Presample Mean' % channellabel,
                  [{'path': 'Ecal%s/%sPedestalOnlineTask/Gain12/%sPOT pedestal %s G12' % (detector, label, label, channellabel),
                    'description': '2D distribution of mean presample value.'}],

--- a/dqmgui/style/EcalRenderPlugin.cc
+++ b/dqmgui/style/EcalRenderPlugin.cc
@@ -870,8 +870,9 @@ EcalRenderPlugin::preDraw(TCanvas* canvas, const VisDQMObject& dqmObject, const 
   unsigned& btype(types.second);
 
   bool isEB(fullpath.Contains("EcalBarrel"));
-  bool isNewStyle(obj->TestBit(0x00f80000));
-  bool isMap(isNewStyle ? obj->TestBit(0x00080000) : isTH2Derived); // if not new style, assume TH2 is a map
+  uint32_t packedInfo = obj->GetUniqueID();
+  bool isNewStyle = (packedInfo > 0);
+  bool isMap = (isNewStyle? (packedInfo % 2 == 1) : isTH2Derived);
 
   if(isMap){
 
@@ -998,9 +999,10 @@ EcalRenderPlugin::postDraw(TCanvas* canvas, const VisDQMObject& dqmObject, const
 
   bool isEB(fullpath.Contains("EcalBarrel"));
 
-  bool isNewStyle(obj->TestBit(0x00f80000));
   bool isTH2Derived(obj->InheritsFrom(TH2::Class()));
-  bool isMap(isNewStyle ? obj->TestBit(0x00080000) : isTH2Derived);
+  uint32_t packedInfo = obj->GetUniqueID();
+  bool isNewStyle = (packedInfo > 0);
+  bool isMap = (isNewStyle? (packedInfo % 2 == 1) : isTH2Derived);
 
   if(isMap){
 
@@ -1170,7 +1172,7 @@ EcalRenderPlugin::preDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject, 
 
   TH1* obj(static_cast<TH1*>(dqmObject.object));
 
-  bool isNewStyle(obj->TestBit(0x00f80000));
+  bool isNewStyle = (obj->GetUniqueID() > 0);
 
   if(TPRegexp("E[BE]LaserTask/Laser[1-4]/E[BE]LT shape E[BE][+-][0-1][0-9] L[1-4]").MatchB(fullpath) ||
      TPRegexp("E[BE]TestPulseTask/Gain[0-9]+/E[BE]TPT shape E[BE][+-][0-1][0-9] G[0-9]+").MatchB(fullpath) ||
@@ -1332,7 +1334,7 @@ EcalRenderPlugin::postDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject,
 
   TH1* obj(static_cast<TH1*>(dqmObject.object));
 
-  bool isNewStyle(obj->TestBit(0x00f80000));
+  bool isNewStyle = (obj->GetUniqueID() > 0);
 
   if(!isNewStyle && TPRegexp("E[BE]TimingTask/E[BE]TMT timing E[BE][+-][0-1][0-9]").MatchB(fullpath)){
     if(obj->GetZaxis()) obj->GetZaxis()->SetLabelSize(0.);
@@ -1415,11 +1417,11 @@ EcalRenderPlugin::getPlotType(TH1 const* obj, TString const& fullpath) const
   bool isEB(fullpath.Contains("EcalBarrel"));
   bool isEE(fullpath.Contains("EcalEndcap"));
 
-  uint32_t packedInfo(obj->TestBits(0x00f80000) >> 19);
+  uint32_t packedInfo(obj->GetUniqueID());
 
-  if(packedInfo != 0){ // new style
-    otype = (packedInfo >> 1) - 1;
-    bool isMap(packedInfo % 2 == 1);
+  if(packedInfo > 0){ // new style
+    otype = (packedInfo/2) - 1;
+    bool isMap = (packedInfo % 2 == 1);
 
     if(isMap){
       switch(otype){


### PR DESCRIPTION
Modified storage of ECAL object types in TH1s to use TObject's UniqueID() rather than TH1's fBits, because the latter is intended for ROOT internal use only.

This was done because the rendering was broken by https://github.com/cms-sw/cmssw/pull/216350 , which was created as a response to https://github.com/cms-sw/cmssw/issues/21423 .

The corresponding PRs to CMSSW master and P5 production version are, respectively, https://github.com/cms-sw/cmssw/pull/22744 and https://github.com/cms-sw/cmssw/pull/22743.

In addition, there are some minor changes to plot descriptions to keep them up-to-date with evolving thresholds that have already been reset in CMSSW.