### PR TITLE
Added plots on Track and Quick collection, replacing cluster charge with cluster charge (on-track) on shifter, and stylistic changes to digi occupancy on-track plot

### DIFF
--- a/dqmgui/layouts/pixelPhase1-layouts.py
+++ b/dqmgui/layouts/pixelPhase1-layouts.py
@@ -500,3 +500,166 @@ pixellayout(dqmitems, "32 - PixelPhase1 Dead ROC Trends in endcap",
      'description': "Dead ROCs per lumisections in ring 2 of endcap",
      'draw': { 'withref': "no"}}],
    )
+
+
+pixellayout(dqmitems, "33 - ntracks",
+  [{ 'path': "PixelPhase1/Tracks/ntracks",
+     'description': "Number of Tracks in all pixel det",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Tracks/ntracksinpixvolume",
+     'description': "Number of Tracks in pix volume",
+     'draw': {'withref' : "no"}}]
+  )
+
+pixellayout(dqmitems, "34 - Charge and size",
+  [{ 'path': "PixelPhase1/Tracks/charge_PXBarrel",
+     'description': "charge PXBarrel",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Tracks/charge_PXForward",
+     'description': "charge PXForward",
+     'draw': {'withref' : "no"}}],
+  [{ 'path': "PixelPhase1/Tracks/size_PXBarrel",
+     'description': "size of PXBarrel",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Tracks/size_PXForward",
+     'description': "size of PXForward",
+     'draw': {'withref' : "no"}}]
+  )
+
+pixellayout(dqmitems, "35a - Cluster on track charge per Inner Ladders",
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/chargeInner_PXLayer_1",
+     'description': "corrected cluster charge (on track) in inner ladders in PXLayer 1",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Tracks/PXBarrel/chargeInner_PXLayer_2",
+     'description': "corrected cluster charge (on track) in inner ladders in PXLayer 2",
+     'draw': {'withref' : "no"}}],
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/chargeInner_PXLayer_3",
+     'description': "corrected cluster charge (on track) in inner ladders in PXLayer 3",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Tracks/PXBarrel/chargeInner_PXLayer_4",
+     'description': "corrected cluster charge (on track) in inner ladders in PXLayer 4",
+     'draw': {'withref' : "no"}}]
+  )
+
+pixellayout(dqmitems, "35b - Cluster on track charge per Outer Ladders",
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/chargeOuter_PXLayer_1",
+     'description': "corrected cluster charge (on track) in outer ladders in PXLayer 1",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Tracks/PXBarrel/chargeOuter_PXLayer_2",
+     'description': "corrected cluster charge (on track) in outer ladders in PXLayer 2",
+     'draw': {'withref' : "no"}}],
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/chargeOuter_PXLayer_3",
+     'description': "corrected cluster charge (on track) in outer ladders in PXLayer 3",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Tracks/PXBarrel/chargeOuter_PXLayer_4",
+     'description': "corrected cluster charge (on track) in outer ladders in PXLayer 4",
+     'draw': {'withref' : "no"}}]
+  )
+
+
+pixellayout(dqmitems, "36 -  Ontrack PXLayer",
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_1",
+     'description': "clusterposition_zphi_ontrack_PXLayer_1",
+     'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+     { 'path': "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_2",
+        'description': "clusterposition_zphi_ontrack_PXLayer_2",
+        'draw': {'withref' : "no", 'drawopts': "COLZ"}}],
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_3",
+      'description': "clusterposition_zphi_ontrack_PXLayer_3",
+      'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+      { 'path': "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_4",
+         'description': "clusterposition_zphi_ontrack_PXLayer_4",
+         'draw': {'withref' : "no", 'drawopts': "COLZ"}}]
+  )
+
+pixellayout(dqmitems, "37 - Ontrack Disk",
+  [{'path': "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_+1",
+  'description': "Cluster on track positions in global coordinates by Global Y (y-axis) vs Global X (x-axis) in disk +1 of pixel endcap",
+  'draw': { 'withref': "no"}},
+  {'path': "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_+2",
+  'description': "Cluster on track positions in global coordinates by Global Y (y-axis) vs Global X (x-axis) in disk +2 of pixel endcap",
+  'draw': { 'withref': "no"}},
+  {'path': "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_+3",
+  'description': "Cluster on track positions in global coordinates by Global Y (y-axis) vs Global X (x-axis) in disk +3 of pixel endcap",
+  'draw': { 'withref': "no"}}],
+  [{'path': "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_-1",
+  'description': "Clusteron on track positions in global coordinates by Global Y (y-axis) vs Global X (x-axis) in disk -1 of pixel endcap",
+  'draw': { 'withref': "no"}},
+  {'path': "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_-2",
+  'description': "Cluster on track positions in global coordinates by Global Y (y-axis) vs Global X (x-axis) in disk -2 of pixel endcap",
+  'draw': { 'withref': "no"}},
+  {'path': "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_-3",
+  'description': "Cluster on track positions in global coordinates by Global Y (y-axis) vs Global X (x-axis) in disk -3 of pixel endcap",
+  'draw': { 'withref': "no"}}],
+  )
+
+pixellayout(dqmitems, "38 - Hit Efficiency Barrel",
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_1",
+     'description': "hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_1",
+     'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+     { 'path': "PixelPhase1/Tracks/PXBarrel/hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_2",
+        'description': "hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_2",
+        'draw': {'withref' : "no", 'drawopts': "COLZ"}}],
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_3",
+     'description': "hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_3",
+     'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+     { 'path': "PixelPhase1/Tracks/PXBarrel/hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_4",
+        'description': "hitefficiency_per_SignedModule_per_SignedLadder_PXLayer_4",
+        'draw': {'withref' : "no", 'drawopts': "COLZ"}}]
+  )
+
+pixellayout(dqmitems, "39 - Hit Efficiency Forward",
+   [{'path': "PixelPhase1/Tracks/PXForward/hitefficiency_per_PXDisk_per_SignedBladePanel_PXRing_1",
+     'description': "hitefficiency_per_PXDisk_per_SignedBl",
+     'draw': { 'withref': "no", 'drawopts': "COLZ" }},
+    {'path': "PixelPhase1/Tracks/PXForward/hitefficiency_per_PXDisk_per_SignedBladePanel_PXRing_2",
+     'description': "hitefficiency_per_PXDisk_per_SignedB2",
+     'draw': { 'withref': "no", 'drawopts': "COLZ" }}
+    ]
+   )
+
+pixellayout(dqmitems, "40 - PixelPhase1 Residuals",
+   [{ 'path': "PixelPhase1/Tracks/residual_x_PXBarrel",
+      'description': "Track residuals x in PXBarrel",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/residual_x_PXForward",
+      'description': "Track residuals x in PXForward",
+      'draw': { 'withref': "no" }}],
+   [{ 'path': "PixelPhase1/Tracks/residual_y_PXBarrel",
+      'description': "Track residuals y in PXBarrel",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/residual_y_PXForward",
+      'description': "Track residuals y in PXForward",
+      'draw': { 'withref': "no" }}]
+   )
+
+
+pixellayout(dqmitems, "41a - ClusterSize Vs Eta (OnTrack) inner",
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_inner_PXLayer_1",
+     'description': "ClusterSize_Vs_Eta_OnTrack_PXLayer_1",
+     'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+     { 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_inner_PXLayer_2",
+        'description': "ClusterSize_Vs_Eta_OnTrack_inner_PXLayer_2",
+        'draw': {'withref' : "no", 'drawopts': "COLZ"}}],
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_inner_PXLayer_3",
+     'description': "ClusterSize_Vs_Eta_OnTrack_PXLayer_3",
+     'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+     { 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_inner_PXLayer_4",
+        'description': "ClusterSize_Vs_Eta_OnTrack_PXLayer_4",
+        'draw': {'withref' : "no", 'drawopts': "COLZ"}}]
+  )
+
+pixellayout(dqmitems, "41b - ClusterSize Vs Eta (OnTrack) outer",
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_outer_PXLayer_1",
+     'description': "ClusterSize_Vs_Eta_OnTrack_outer_PXLayer_1",
+     'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+     { 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_outer_PXLayer_2",
+        'description': "ClusterSize_Vs_Eta_OnTrack_outer_PXLayer_2",
+        'draw': {'withref' : "no", 'drawopts': "COLZ"}}],
+  [{ 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_outer_PXLayer_3",
+     'description': "ClusterSize_Vs_Eta_OnTrack_PXLayer_3",
+     'draw': {'withref' : "no", 'drawopts': "COLZ"}},
+     { 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_outer_PXLayer_4",
+        'description': "ClusterSize_Vs_Eta_OnTrack_PXLayer_4",
+        'draw': {'withref' : "no", 'drawopts': "COLZ"}}]
+  )

--- a/dqmgui/layouts/pixelPhase1-layouts.py
+++ b/dqmgui/layouts/pixelPhase1-layouts.py
@@ -511,7 +511,7 @@ pixellayout(dqmitems, "33 - ntracks",
      'draw': {'withref' : "no"}}]
   )
 
-pixellayout(dqmitems, "34 - Charge and size",
+pixellayout(dqmitems, "34 - Charge and size (on-track)",
   [{ 'path': "PixelPhase1/Tracks/charge_PXBarrel",
      'description': "charge PXBarrel",
      'draw': {'withref' : "no"}},
@@ -526,7 +526,7 @@ pixellayout(dqmitems, "34 - Charge and size",
      'draw': {'withref' : "no"}}]
   )
 
-pixellayout(dqmitems, "35a - Cluster on track charge per Inner Ladders",
+pixellayout(dqmitems, "35a - Cluster charge (on-track) per Inner Ladders",
   [{ 'path': "PixelPhase1/Tracks/PXBarrel/chargeInner_PXLayer_1",
      'description': "corrected cluster charge (on track) in inner ladders in PXLayer 1",
      'draw': {'withref' : "no"}},
@@ -541,7 +541,7 @@ pixellayout(dqmitems, "35a - Cluster on track charge per Inner Ladders",
      'draw': {'withref' : "no"}}]
   )
 
-pixellayout(dqmitems, "35b - Cluster on track charge per Outer Ladders",
+pixellayout(dqmitems, "35b - Cluster charge (on-track) per Outer Ladders",
   [{ 'path': "PixelPhase1/Tracks/PXBarrel/chargeOuter_PXLayer_1",
      'description': "corrected cluster charge (on track) in outer ladders in PXLayer 1",
      'draw': {'withref' : "no"}},
@@ -557,7 +557,7 @@ pixellayout(dqmitems, "35b - Cluster on track charge per Outer Ladders",
   )
 
 
-pixellayout(dqmitems, "36 -  Ontrack PXLayer",
+pixellayout(dqmitems, "36 - Cluster position (on-track) per PXLayer",
   [{ 'path': "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_1",
      'description': "clusterposition_zphi_ontrack_PXLayer_1",
      'draw': {'withref' : "no", 'drawopts': "COLZ"}},
@@ -572,7 +572,7 @@ pixellayout(dqmitems, "36 -  Ontrack PXLayer",
          'draw': {'withref' : "no", 'drawopts': "COLZ"}}]
   )
 
-pixellayout(dqmitems, "37 - Ontrack Disk",
+pixellayout(dqmitems, "37 - Cluster position (on-track) per Disk",
   [{'path': "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_+1",
   'description': "Cluster on track positions in global coordinates by Global Y (y-axis) vs Global X (x-axis) in disk +1 of pixel endcap",
   'draw': { 'withref': "no"}},
@@ -634,7 +634,7 @@ pixellayout(dqmitems, "40 - PixelPhase1 Residuals",
    )
 
 
-pixellayout(dqmitems, "41a - ClusterSize Vs Eta (OnTrack) inner",
+pixellayout(dqmitems, "41a - ClusterSize Vs Eta (on-track) inner",
   [{ 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_inner_PXLayer_1",
      'description': "ClusterSize_Vs_Eta_OnTrack_PXLayer_1",
      'draw': {'withref' : "no", 'drawopts': "COLZ"}},
@@ -649,7 +649,7 @@ pixellayout(dqmitems, "41a - ClusterSize Vs Eta (OnTrack) inner",
         'draw': {'withref' : "no", 'drawopts': "COLZ"}}]
   )
 
-pixellayout(dqmitems, "41b - ClusterSize Vs Eta (OnTrack) outer",
+pixellayout(dqmitems, "41b - ClusterSize Vs Eta (on-track) outer",
   [{ 'path': "PixelPhase1/Tracks/PXBarrel/sizeyvseta_on_track_outer_PXLayer_1",
      'description': "ClusterSize_Vs_Eta_OnTrack_outer_PXLayer_1",
      'draw': {'withref' : "no", 'drawopts': "COLZ"}},

--- a/dqmgui/layouts/shift_pixelPhase1_layout.py
+++ b/dqmgui/layouts/shift_pixelPhase1_layout.py
@@ -34,15 +34,6 @@ shiftpixelP1layout(dqmitems,"03 - PixelPhase1 Digis: BladePannel vs Disk endcap 
       'draw': { 'withref': "no", 'drawopts': "COLZ" }}],
    )
 
-#shiftpixelP1layout(dqmitems, "04 - PixelPhase1_Cluster_Charge",
-#   [{ 'path': "PixelPhase1/Phase1_MechanicalView/charge_PXBarrel",
-#      'description': "Cluster charge in the BPix modules",
-#      'draw': { 'withref': "no" }},
-#    { 'path': "PixelPhase1/Phase1_MechanicalView/charge_PXForward",
-#      'description': "Cluster charge in FPix modules",
-#      'draw': { 'withref': "no" }}]
-#   )
-
 shiftpixelP1layout(dqmitems, "04 - PixelPhase1_Cluster_Charge",
    [{ 'path': "PixelPhase1/Tracks/charge_PXBarrel",
       'description': "Corrected Cluster charge (On Track) in the BPix modules",
@@ -51,8 +42,6 @@ shiftpixelP1layout(dqmitems, "04 - PixelPhase1_Cluster_Charge",
       'description': "Corrected Cluster charge (On Track) in FPix modules",
       'draw': { 'withref': "no" }}]
    )
-
-
 
 shiftpixelP1layout(dqmitems, "05 - PixelPhase1_Dead_ROCs",
    [{ 'path': "PixelPhase1/deadRocTrendLayer_1",

--- a/dqmgui/layouts/shift_pixelPhase1_layout.py
+++ b/dqmgui/layouts/shift_pixelPhase1_layout.py
@@ -34,14 +34,25 @@ shiftpixelP1layout(dqmitems,"03 - PixelPhase1 Digis: BladePannel vs Disk endcap 
       'draw': { 'withref': "no", 'drawopts': "COLZ" }}],
    )
 
+#shiftpixelP1layout(dqmitems, "04 - PixelPhase1_Cluster_Charge",
+#   [{ 'path': "PixelPhase1/Phase1_MechanicalView/charge_PXBarrel",
+#      'description': "Cluster charge in the BPix modules",
+#      'draw': { 'withref': "no" }},
+#    { 'path': "PixelPhase1/Phase1_MechanicalView/charge_PXForward",
+#      'description': "Cluster charge in FPix modules",
+#      'draw': { 'withref': "no" }}]
+#   )
+
 shiftpixelP1layout(dqmitems, "04 - PixelPhase1_Cluster_Charge",
-   [{ 'path': "PixelPhase1/Phase1_MechanicalView/charge_PXBarrel",
-      'description': "Cluster charge in the BPix modules",
+   [{ 'path': "PixelPhase1/Tracks/charge_PXBarrel",
+      'description': "Corrected Cluster charge (On Track) in the BPix modules",
       'draw': { 'withref': "no" }},
-    { 'path': "PixelPhase1/Phase1_MechanicalView/charge_PXForward",
-      'description': "Cluster charge in FPix modules",
+    { 'path': "PixelPhase1/Tracks/charge_PXForward",
+      'description': "Corrected Cluster charge (On Track) in FPix modules",
       'draw': { 'withref': "no" }}]
    )
+
+
 
 shiftpixelP1layout(dqmitems, "05 - PixelPhase1_Dead_ROCs",
    [{ 'path': "PixelPhase1/deadRocTrendLayer_1",

--- a/dqmgui/style/SiPixelRenderPlugin.cc
+++ b/dqmgui/style/SiPixelRenderPlugin.cc
@@ -348,7 +348,7 @@ private:
       ya->SetLabelSize(0.03);
       TGaxis::SetMaxDigits(3);
       
-      if( o.name.find("digi_occupancy_per_col_per_row") != std::string::npos ){
+      if( o.name.find("digi_occupancy_per_col_per_row") != std::string::npos || o.name.find("digi_occupancy_ontrack_per_col_per_row") != std::string::npos ){
          // Horizontal
          draw_line(0,416,79.5,79.5);
         

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -110,15 +110,15 @@ server.workspace('DQMContent', 19, 'Tracker', 'PixelPhase1', '^PixelPhase1/', ''
                   'PixelPhase1/Layouts/31 - PixelPhase1 Dead ROC Trends in barrel',
                   'PixelPhase1/Layouts/32 - PixelPhase1 Dead ROC Trends in endcap',
                   'PixelPhase1/Layouts/33 - ntracks',
-                  'PixelPhase1/Layouts/34 - Charge and size',
-                  'PixelPhase1/Layouts/35a - Cluster on track charge per Inner Ladders',
-                  'PixelPhase1/Layouts/35b - Cluster on track charge per Outer Ladders',  
+                  'PixelPhase1/Layouts/34 - Charge and size (on-track)',
+                  'PixelPhase1/Layouts/35a - Cluster charge (on-track) per Inner Ladders',
+                  'PixelPhase1/Layouts/35b - Cluster charge (on-track) per Outer Ladders',  
                   #'PixelPhase1/Layouts/35 - Cluster on track and vertices per lumi',
-                  'PixelPhase1/Layouts/36 -  Ontrack PXLayer',
-                  'PixelPhase1/Layouts/37 - Ontrack Disk',
+                  'PixelPhase1/Layouts/36 - Cluster position (on-track) per PXLayer',
+                  'PixelPhase1/Layouts/37 - Cluster position (on-track) per Disk',
                   'PixelPhase1/Layouts/40 - PixelPhase1 Residuals',
-                  'PixelPhase1/Layouts/41a - ClusterSize Vs Eta (OnTrack) inner',
-                  'PixelPhase1/Layouts/41b - ClusterSize Vs Eta (OnTrack) outer',
+                  'PixelPhase1/Layouts/41a - ClusterSize Vs Eta (on-track) inner',
+                  'PixelPhase1/Layouts/41b - ClusterSize Vs Eta (on-track) outer',
                 )
 
 

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -109,7 +109,18 @@ server.workspace('DQMContent', 19, 'Tracker', 'PixelPhase1', '^PixelPhase1/', ''
                   'PixelPhase1/Layouts/30 - PixelPhase1 Cluster Position: X vs Y endcap summary',
                   'PixelPhase1/Layouts/31 - PixelPhase1 Dead ROC Trends in barrel',
                   'PixelPhase1/Layouts/32 - PixelPhase1 Dead ROC Trends in endcap',
+                  'PixelPhase1/Layouts/33 - ntracks',
+                  'PixelPhase1/Layouts/34 - Charge and size',
+                  'PixelPhase1/Layouts/35a - Cluster on track charge per Inner Ladders',
+                  'PixelPhase1/Layouts/35b - Cluster on track charge per Outer Ladders',  
+                  #'PixelPhase1/Layouts/35 - Cluster on track and vertices per lumi',
+                  'PixelPhase1/Layouts/36 -  Ontrack PXLayer',
+                  'PixelPhase1/Layouts/37 - Ontrack Disk',
+                  'PixelPhase1/Layouts/40 - PixelPhase1 Residuals',
+                  'PixelPhase1/Layouts/41a - ClusterSize Vs Eta (OnTrack) inner',
+                  'PixelPhase1/Layouts/41b - ClusterSize Vs Eta (OnTrack) outer',
                 )
+
 
 server.workspace('DQMContent', 21, 'Tracker', 'SiStrip', '^(SiStrip|Tracking)/', '',
                  'SiStrip/Layouts/00 - SiStrip ReportSummary',


### PR DESCRIPTION

*Added plots on Track folder and Quick collection.  
*Replaced the inclusive cluster change with the on-track cluster charge in the shifter folder. 
*Added partition between the ROCs in the digi occupancy on track plot. 
*Changed the names to more sensible ones in the on-track plots. 