### PR TITLE
CSC ChamberMap color palette handling fix for ROOT6

### DIFF
--- a/dqmgui/style/CSCRenderPlugin_ChamberMap.cc
+++ b/dqmgui/style/CSCRenderPlugin_ChamberMap.cc
@@ -233,7 +233,7 @@ void ChamberMap::draw(TH2*& me) {
                             fillColor = 51 + (int) (((BinContent - HistoMinValue) / (HistoMaxValue - HistoMinValue)) * 49.0);
                         }
                         /** VR: just to be sure :) */
-                        if (fillColor > 100) fillColor = 100;
+                        if (fillColor > 99) fillColor = 99;
                         if (fillColor < 51) fillColor = 51;
 
                     }


### PR DESCRIPTION
CSC ChamberMap color palette handling fix for ROOT6.
Fixes the issue with CSC ChamberMap type of plots, when bins with calculated fillColor>99 were not properly shown.