### PR TITLE
Load reqmgr2 secrets file for AMQ settings

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -16,15 +16,12 @@ DBS_INS = "@@DBS_INS@@"
 COUCH_URL = "%s/couchdb" % BASE_URL
 LOG_DB_URL = "%s/wmstats_logdb" % COUCH_URL
 LOG_REPORTER = "reqmgr2"
-USER_AMQ = "@@USER_AMQ@@"
-PASS_AMQ = "@@PASS_AMQ@@"
-AMQ_TOPIC = "@@TOPIC@@"
 AMQ_HOST_PORT = [('dashb-mb.cern.ch', 61113)]
 
 ROOTDIR = __file__.rsplit('/', 3)[0]
 # load AMQ credentials
 sys.path.append(path.join(ROOTDIR, 'auth/reqmgr2'))
-from ReqMgr2Secrets import *
+from ReqMgr2Secrets import USER_AMQ, PASS_AMQ, AMQ_TOPIC
 
 config = Configuration()
 

--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -6,21 +6,26 @@ Everything configurable in ReqMgr is defined here.
 
 import socket
 import time
+import sys
 from WMCore.Configuration import Configuration
 from os import path
 
 HOST = socket.gethostname().lower()
 BASE_URL = "@@BASE_URL@@"
 DBS_INS = "@@DBS_INS@@"
-USER_AMQ = "@@USER_AMQ@@"
-PASS_AMQ = "@@PASS_AMQ@@"
 COUCH_URL = "%s/couchdb" % BASE_URL
 LOG_DB_URL = "%s/wmstats_logdb" % COUCH_URL
 LOG_REPORTER = "reqmgr2"
-AMQ_TOPIC = '/topic/cms.jobmon.wmagent'
+USER_AMQ = "@@USER_AMQ@@"
+PASS_AMQ = "@@PASS_AMQ@@"
+AMQ_TOPIC = "@@TOPIC@@"
 AMQ_HOST_PORT = [('dashb-mb.cern.ch', 61113)]
 
 ROOTDIR = __file__.rsplit('/', 3)[0]
+# load AMQ credentials
+sys.path.append(path.join(ROOTDIR, 'auth/reqmgr2'))
+from ReqMgr2Secrets import *
+
 config = Configuration()
 
 main = config.section_("main")
@@ -178,7 +183,10 @@ if HOST.startswith("vocms0136") or HOST.startswith("vocms0731") or HOST.startswi
     heartbeatMonitor.central_logdb_url = LOG_DB_URL
     heartbeatMonitor.log_reporter = LOG_REPORTER
     # AMQ MonIT settings
-    heartbeatMonitor.post_to_amq = True if HOST.startswith("vocms0136") else False  # only production nodes!
+    if HOST.startswith("vocms0731") or HOST.startswith("vocms0136"):
+        heartbeatMonitor.post_to_amq = True
+    else:
+        heartbeatMonitor.post_to_amq = False
     heartbeatMonitor.user_amq = USER_AMQ
     heartbeatMonitor.pass_amq = PASS_AMQ
     heartbeatMonitor.topic_amq = AMQ_TOPIC

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -17,10 +17,6 @@ deploy_reqmgr2_prep()
 
 deploy_reqmgr2_sw()
 {
-  deploy_pkg \
-    -a dmwm-service-cert.pem:wmcore/dmwm-service-cert.pem \
-    -a dmwm-service-key.pem:wmcore/dmwm-service-key.pem \
-    comp cms+reqmgr2
 
   if grep -rq "replace me" $project_auth; then
     note "WARNING: replace certificates in $project_auth with real ones"
@@ -32,6 +28,13 @@ deploy_reqmgr2_sw()
     dev )     base_url="https://cmsweb-dev.cern.ch"     dbs_ins="dev";;
     * )       base_url="https://`hostname -f`"          dbs_ins="private_vm";;
   esac
+
+  deploy_pkg \
+    -a dmwm-service-cert.pem:wmcore/dmwm-service-cert.pem \
+    -a dmwm-service-key.pem:wmcore/dmwm-service-key.pem \
+    -a ReqMgr2Secrets.py:reqmgr2/ReqMgr2Secrets.py \
+    comp cms+reqmgr2
+
   perl -p -i -e "s{\"\@\@BASE_URL\@\@\"}{\"$base_url\"}g; \
                  s{\"\@\@DBS_INS\@\@\"}{\"$dbs_ins\"}g"   \
        $root/$cfgversion/config/$project/config.py
@@ -65,7 +68,14 @@ deploy_reqmgr2_post()
 deploy_reqmgr2_auth()
 {
   case $1 in
-    */*-cert.pem ) echo "replace me with your dmwm service certificate" ;;
-    */*-key.pem )  echo "replace me with your dmwm service key" ;;
+    */*-cert.pem )
+      echo "replace me with your dmwm service certificate" ;;
+    */*-key.pem )
+      echo "replace me with your dmwm service key" ;;
+    */ReqMgr2Secrets*.py )
+      echo 'USER_AMQ = "FOO_FIXME"'
+      echo 'PASS_AMQ = "BAR_FIXME"'
+      echo 'AMQ_TOPIC = "FOOBAR_FIXME"'
+      ;;
   esac
 }


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/8569
With this change, reqmgr2 should be able to properly create the secrets file and use it in the service. The file format is the same as those 3 echo lines.
@h4d4 I still have to provide you two files, one for testbed and one for production (I understand you need to write them to a specific cmsweb area that will be accessed during the deployment).

I tested it in my VM, with the secrets under /data/auth/reqmgr2/ and it works fine.
@h4d4 @ticoann can you please review?