### PR TITLE
Changes in the layout and style for shifter plots 02-07 (CaloLayer2)

### DIFF
--- a/dqmgui/layouts/shift_l1t_layout.py
+++ b/dqmgui/layouts/shift_l1t_layout.py
@@ -7,17 +7,17 @@ l1tlayout(dqmitems,"00 - CaloLayer1 ECAL occupancy",
 l1tlayout(dqmitems,"01 - CaloLayer1 HCAL occupancy",
   [{'path': "L1T/L1TStage2CaloLayer1/hcalOccRecdEtWgt", 'description': "CaloLayer1 HCAL Et-weighted occupancy. "+moreInfoStr, 'draw': { 'withref': "no" }}])
 l1tlayout(dqmitems,"02 - CaloLayer2 central jet E_T eta phi",
-    [{'path': "L1T/L1TStage2CaloLayer2/Central-Jets/CenJetsEtEtaPhi", 'description': "CaloLayer2 central jet E_T eta phi. x-axis: CaloLayer2 central jet E_T eta; y-axis: CaloLayer2 central jet E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
+    [{'path': "L1T/L1TStage2CaloLayer2/shifter/CenJetsEtEtaPhi_shift", 'description': "CaloLayer2 central jet E_T eta phi. x-axis: CaloLayer2 central jet E_T eta; y-axis: CaloLayer2 central jet E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
 l1tlayout(dqmitems,"03 - CaloLayer2 forward jet E_T eta phi",
-    [{'path': "L1T/L1TStage2CaloLayer2/Forward-Jets/ForJetsEtEtaPhi", 'description': "CaloLayer2 forward jet E_T eta phi. x-axis: CaloLayer2 forward jet E_T eta; y-axis: CaloLayer2 forward jet E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
+    [{'path': "L1T/L1TStage2CaloLayer2/shifter/ForJetsEtEtaPhi_shift", 'description': "CaloLayer2 forward jet E_T eta phi. x-axis: CaloLayer2 forward jet E_T eta; y-axis: CaloLayer2 forward jet E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
 l1tlayout(dqmitems,"04 - CaloLayer2 iso EG E_T eta phi",
-    [{'path': "L1T/L1TStage2CaloLayer2/Isolated-EG/IsoEGsEtEtaPhi", 'description': "CaloLayer2 iso EG E_T eta phi. x-axis: CaloLayer2 iso EG E_T eta; y-axis: CaloLayer2 iso EG E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
+    [{'path': "L1T/L1TStage2CaloLayer2/shifter/IsoEGsEtEtaPhi_shift", 'description': "CaloLayer2 iso EG E_T eta phi. x-axis: CaloLayer2 iso EG E_T eta; y-axis: CaloLayer2 iso EG E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
 l1tlayout(dqmitems,"05 - CaloLayer2 noniso EG E_T eta phi",
-    [{'path': "L1T/L1TStage2CaloLayer2/NonIsolated-EG/NonIsoEGsEtEtaPhi", 'description': "CaloLayer2 noniso EG E_T eta phi. x-axis: CaloLayer2 noniso EG E_T eta; y-axis: CaloLayer2 noniso EG E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
+    [{'path': "L1T/L1TStage2CaloLayer2/shifter/NonIsoEGsEtEtaPhi_shift", 'description': "CaloLayer2 noniso EG E_T eta phi. x-axis: CaloLayer2 noniso EG E_T eta; y-axis: CaloLayer2 noniso EG E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
 l1tlayout(dqmitems,"06 - CaloLayer2 iso tau E_T eta phi",
-    [{'path': "L1T/L1TStage2CaloLayer2/Isolated-Tau/IsoTausEtEtaPhi", 'description': "CaloLayer2 iso tau E_T eta phi. x-axis: CaloLayer2 iso tau E_T eta; y-axis: CaloLayer2 iso tau E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
+    [{'path': "L1T/L1TStage2CaloLayer2/shifter/IsoTausEtEtaPhi_shift", 'description': "CaloLayer2 iso tau E_T eta phi. x-axis: CaloLayer2 iso tau E_T eta; y-axis: CaloLayer2 iso tau E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
 l1tlayout(dqmitems,"07 - CaloLayer2 noniso tau E_T eta phi",
-    [{'path': "L1T/L1TStage2CaloLayer2/NonIsolated-Tau/TausEtEtaPhi", 'description': "CaloLayer2 noniso tau E_T eta phi. x-axis: CaloLayer2 noniso tau E_T eta; y-axis: CaloLayer2 noniso tau E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
+    [{'path': "L1T/L1TStage2CaloLayer2/shifter/TausEtEtaPhi_shift", 'description': "CaloLayer2 noniso tau E_T eta phi. x-axis: CaloLayer2 noniso tau E_T eta; y-axis: CaloLayer2 noniso tau E_T phi. "+moreInfoStr, 'draw': { 'withref': "no" }}])
 l1tlayout(dqmitems,"08 - uGMT muon p_T",
     [{'path': "L1T/L1TStage2uGMT/ugmtMuonPt", 'description': "uGMT muon p_T. x-axis: uGMT muon p_T. "+moreInfoStr, 'draw': { 'withref': "yes" }}])
 l1tlayout(dqmitems,"09 - uGMT muon eta",

--- a/dqmgui/style/L1TStage2CaloLayer2RenderPlugin.cc
+++ b/dqmgui/style/L1TStage2CaloLayer2RenderPlugin.cc
@@ -8,18 +8,25 @@
 #include "TH1F.h"
 #include "TH2F.h"
 #include "TStyle.h"
+#include "TBox.h"
+#include "TFrame.h"
 
 class L1TStage2CaloLayer2RenderPlugin : public DQMRenderPlugin {
 
   int palette_kry[256];
   int palette_yrk[256];
-
+  TBox *exclusionBox_;
   TText tlabels_;
 
 public:
 
   virtual void initialise(int, char **)
-    {
+    { 
+      // For masking areas
+      exclusionBox_ = new TBox();
+      exclusionBox_->SetFillColor(kGray+2);
+      exclusionBox_->SetFillStyle(3002);
+      
       // Laugh all you want, but they do look pretty
       // http://arxiv.org/pdf/1509.03700v1.pdf
       // linear_kry_5-98_c75_n256 reversed
@@ -58,7 +65,11 @@ public:
   }
 
  private:
-
+void drawExclusionBox(double x1, double y1, double x2, double y2)
+  {
+    exclusionBox_->DrawBox(x1, y1, x2, y2);
+  }
+ 
 bool checkAndRemove(std::string &s, const char * key)
   {
     if( s.find(key) != std::string::npos )
@@ -149,6 +160,11 @@ bool checkAndRemove(std::string &s, const char * key)
   void postDrawTH2F(TCanvas*, const VisDQMObject& o) {
     TH2F* obj = dynamic_cast<TH2F*>(o.object);
     assert(obj);
+    
+    if( o.name.find( "ForJetsEtEtaPhi_shift" ) != std::string::npos )
+     {
+       drawExclusionBox(-68, -0.5, 68, 143.5);
+     }
 
     gStyle->SetOptStat(10);
   }


### PR DESCRIPTION
The online shifter plots 02-07 needed some work to make them more comprehensible for shifters and other non-experts. 
Requires: https://github.com/cms-sw/cmssw/pull/23046 , as this PR contains changes to the plots (location, binning) that are going to be displayed.