### PR TITLE
Extend TLine to fix drawing line on plots for Wheel -2 and +2 in RPCRenderPlugin

### DIFF
--- a/dqmgui/style/RPCRenderPlugin.cc
+++ b/dqmgui/style/RPCRenderPlugin.cc
@@ -165,11 +165,17 @@ private:
         //rb1out
         line.DrawLine(85, 2.5, 85, 4.5);
         line.DrawLine(85, 4.5, 91, 4.5);
-        //rb2in X 3
-        line.DrawLine(91, 4.5, 91, 7.5);
-        line.DrawLine(91, 7.5, 85, 7.5);
-        //rb2out
-        line.DrawLine(85, 7.5, 85, 9.5);
+        //rb2in and rb2out
+        if(o.name.find("Wheel_-2") != std::string::npos || o.name.find("Wheel_2") != std::string::npos)
+        {
+          line.DrawLine(91, 4.5, 91, 6.5);
+          line.DrawLine(91, 6.5, 85, 6.5);
+          line.DrawLine(85, 6.5, 85, 9.5);
+        } else {
+          line.DrawLine(91, 4.5, 91, 7.5);
+          line.DrawLine(91, 7.5, 85, 7.5);
+          line.DrawLine(85, 7.5, 85, 9.5);
+        }
         line.DrawLine(85, 9.5, 43, 9.5);
         //rb3
         line.DrawLine(43, 9.5, 43, 13.5);


### PR DESCRIPTION
Fixing DrawLine options for Wheel -2 and +2.
@andresib @mileva @jhgoh 