### PR TITLE
Add uGT data vs emulator plot to Quick Collection and Shift workspaces

### DIFF
--- a/dqmgui/layouts/l1temulator-layouts.py
+++ b/dqmgui/layouts/l1temulator-layouts.py
@@ -79,7 +79,7 @@ l1t_quickCollection(dqmitems,"10 - Calo Layer2 Tau Data-Emulator Agreement Summa
   }])
 l1t_quickCollection(dqmitems,"11 - uGT Data-Emulator misMatch ratio",
   [{
-    'path': "L1TEMU/L1TdeStage2uGTEmul/dataEmulMismatchRatio_CentralBX",
+    'path': "L1TEMU/L1TdeStage2uGT/dataEmulMismatchRatio_CentralBX",
     'description': "uGT Data-Emulator misMatch ratio -- Central BX",
     'draw': { 'withref': "no" }
   }])

--- a/dqmgui/layouts/l1temulator-layouts.py
+++ b/dqmgui/layouts/l1temulator-layouts.py
@@ -77,6 +77,13 @@ l1t_quickCollection(dqmitems,"10 - Calo Layer2 Tau Data-Emulator Agreement Summa
     'description': "Tau Data-Emulator Agreement Summary",
     'draw': { 'withref': "no" }
   }])
+l1t_quickCollection(dqmitems,"11 - uGT Data-Emulator misMatch ratio",
+  [{
+    'path': "L1TEMU/L1TdeStage2uGTEmul/dataEmulMismatchRatio_CentralBX",
+    'description': "uGT Data-Emulator misMatch ratio -- Central BX",
+    'draw': { 'withref': "no" }
+  }])
+
 ###############################################
 ### From here down is legacy/stage1 trigger ###
 ###           All in Legacy folder          ###

--- a/dqmgui/layouts/shift_l1temulator_layout.py
+++ b/dqmgui/layouts/shift_l1temulator_layout.py
@@ -34,3 +34,6 @@ l1temulayout(dqmitems,"09 - CaloLayer2 - Problem Summary",
 
 l1temulayout(dqmitems,"10 - CaloLayer2 - Tau Data-Emulator Agreement Summary",
   	         [{ 'path': "L1TEMU/L1TStage2CaloLayer2/L1TdeStage2CaloLayer2/Tau Agreement Summary",'description': "Tau Data-Emulator Agreement Summary"}])
+
+l1temulayout(dqmitems,"11 - uGT Data-Emulator misMatch ratio",
+  	         [{ 'path': "L1TEMU/L1TdeStage2uGTEmul/dataEmulMismatchRatio_CentralBX",'description': "uGT Data-Emulator misMatch ratio -- Central BX"}])

--- a/dqmgui/layouts/shift_l1temulator_layout.py
+++ b/dqmgui/layouts/shift_l1temulator_layout.py
@@ -36,4 +36,4 @@ l1temulayout(dqmitems,"10 - CaloLayer2 - Tau Data-Emulator Agreement Summary",
   	         [{ 'path': "L1TEMU/L1TStage2CaloLayer2/L1TdeStage2CaloLayer2/Tau Agreement Summary",'description': "Tau Data-Emulator Agreement Summary"}])
 
 l1temulayout(dqmitems,"11 - uGT Data-Emulator misMatch ratio",
-  	         [{ 'path': "L1TEMU/L1TdeStage2uGTEmul/dataEmulMismatchRatio_CentralBX",'description': "uGT Data-Emulator misMatch ratio -- Central BX"}])
+  	         [{ 'path': "L1TEMU/L1TdeStage2uGT/dataEmulMismatchRatio_CentralBX",'description': "uGT Data-Emulator misMatch ratio -- Central BX"}])

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -90,6 +90,7 @@ server.workspace('DQMContent', 11, 'Trigger', 'L1TEMU', '^(L1TEMU|L1T2016EMU)/',
 		 "L1TEMU/Layouts/Stage2-QuickCollection/08 - Calo Layer2 Jet Data-Emulator Agreement Summary",
 		 "L1TEMU/Layouts/Stage2-QuickCollection/09 - Calo Layer2 Problem Summary",
 		 "L1TEMU/Layouts/Stage2-QuickCollection/10 - Calo Layer2 Tau Data-Emulator Agreement Summary",
+                 "L1TEMU/Layouts/Stage2-QuickCollection/11 - uGT Data-Emulator misMatch ratio",
                 )
 
 server.workspace('DQMContent', 12, 'Trigger', 'HLT', '^HLT/', '',


### PR DESCRIPTION
The PR adds the uGT data vs emulator mismatch ratio summary plot to the L1T Quick Collection and Shift workspaces.