### PR TITLE
Small improvement for RPC Endcap and Barrel occupancy plots

### DIFF
--- a/dqmgui/style/RPCRenderPlugin.cc
+++ b/dqmgui/style/RPCRenderPlugin.cc
@@ -94,7 +94,12 @@ private:
 
       if( o.name.find("Occupancy") != std::string::npos )
       {
-	obj->SetStats( kTRUE );
+        if((o.name.find("_for_Barrel") != std::string::npos || o.name.find("_for_Endcap") != std::string::npos) && o.name.find("SummaryHistograms") != std::string::npos )
+        {
+          obj->SetStats( kFALSE );
+        } else {
+          obj->SetStats( kTRUE );
+        }
         return;
       }
 

--- a/dqmgui/style/RPCRenderPlugin.cc
+++ b/dqmgui/style/RPCRenderPlugin.cc
@@ -71,7 +71,12 @@ private:
       gStyle->SetPadBorderSize( 0 );
       gStyle->SetOptStat( 10 );
       gStyle->SetPalette( 1 );
-      obj->SetOption( "colz" );
+      if(o.name.find("Occupancy_for_") != std::string::npos && o.name.find("SummaryHistograms") != std::string::npos )
+      {
+        obj->SetOption( "colztext" );
+      } else {
+        obj->SetOption( "colz" );
+      }
       obj->SetStats( kFALSE );
 
       obj->GetXaxis()->SetNdivisions(-510);
@@ -82,7 +87,7 @@ private:
       c->SetGridy();
 
       if(o.name.find("SummaryMap") != std::string::npos)
-	{
+      {
         dqm::utils::reportSummaryMapPalette(obj);
 	return;
       }


### PR DESCRIPTION
For RPC Endcap and Barrel occupancy plots,
- changing draw options,
- removing statbox.

Please test on online playback and also on offline.
@andresib @jhgoh @mileva