### PR TITLE
Dissabling das to be instaled on vocsm0740

### DIFF
--- a/das/deploy
+++ b/das/deploy
@@ -21,7 +21,7 @@ deploy_das_sw()
 
 deploy_das_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0740) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
    for action in das_cleanup:'0 0-23/2 * * *' das_dbs_update:'0-59/20 * * * *'; do


### PR DESCRIPTION
@vkuznet @amaltaro 
This PR is to disable das/da2sgo on vocms0740, due to in today's production upgrade I found that das/da2sgo was installed on this node. As I understand, it should only run on vomcs074{1,2}
https://cms-http-group.web.cern.ch/cms-http-group/activity.html

I've disabled this service on vocms0740, in order to avoid alarms I also updated the metrics.

Best Regards, Lina
