### PR TITLE
New L1T plots in ECAL Workspace + New plot in ECAL Preshower Workspaces

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -606,13 +606,13 @@ ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/18 TT Flags vs Et',
 	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE -', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'},
 	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE +', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/19 Ratio_L1TEGamma_BX_0',
-           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0', 'description': 'This 2D plot in (eta, phi) shows the ratio of the total TP energy at BX = 0.'}])
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0', 'description': 'Fraction of (L1T EGamma objects with pT >= 20 GeV found in BX 0) over (all L1T EGamma objects with pT >= 20 GeV found in a BX range of +/-2 BX around BX 0).'}])
 ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/20 Ratio_L1TEGamma_BX_minus1',
-           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1', 'description': 'This 2D plot in (eta, phi) shows the ratio of the total TP energy at BX = -1.'}])
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1', 'description': 'Fraction of (L1T EGamma objects with pT >= 20 GeV found in BX -1) over (all L1T EGamma objects with pT >= 20 GeV found in a BX range of +/-2 BX around BX 0).'}])
 ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/21 noniso_bx_ieta_firstbunch',
-           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0', 'description': 'This 2D plot shows the fraction of the TP energy in a given BX as a function of eta in events from the first bunches.'}])
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_FirstCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_FirstCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the first bunch in a bunch train.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/22 noniso_bx_ieta_lastbunch',
-           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0', 'description': 'This 2D plot shows the fraction of the TP energy in a given BX as a function of eta in events from the last bunches.'}])
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_LastCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_LastCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the last bunch in a bunch train.'}])
 
 
 # By SuperModule _______________

--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -591,27 +591,25 @@ ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/13 Real vs Emulated TP 
 	   [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT Real vs Emulated TP Et', 'description': 'Real data VS emulated TP Et (in-time).'}],
 	   [{'path': 'EcalEndcap/EETriggerTowerTask/EETTT Real vs Emulated TP Et EE -', 'description': 'Real data VS emulated TP Et (in-time).'},
 	    {'path': 'EcalEndcap/EETriggerTowerTask/EETTT Real vs Emulated TP Et EE +', 'description': 'Real data VS emulated TP Et (in-time).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/14 ecalOccRecdEtWgt',
-           [{'path': 'L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt', 'description': 'The 2D plot shows Et-weighted ECAL TP occupancy received at Layer-1 in iEta and iPhi coordinate of the ECAL trigger tower. Each entry represents the energy of the ECAL TP in (iEta, iPhi).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/15 ecalOccSent',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/14 ecalOccSent',
            [{'path': 'L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent', 'description': 'The 2D plot shows ECAL TP occupancy sent by ECAL in iEta and iPhi coordinate of the ECAL trigger tower. Each entry represents the occupancy (multiplicity) of ECAL TP in (iEta, iPhi).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/16 ecalOccSentAndRecd',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/15 ecalOccSentAndRecd',
            [{'path': 'L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd', 'description': 'The 2D plot shows ECAL TP occupancy "sent" by ECAL and "received" at Layer-1 (fully matched), in iEta and iPhi coordinate of the ECAL trigger tower. Each entry represents the occupancy (multiplicity) of ECAL TPs in (iEta, iPhi). One can investigate the number of entries in 14 to 15 and 16 and check if the ECAL TP sent by ECAL is received at Layer-1.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/17 TT Flag-Readout Mismatch',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/16 TT Flag-Readout Mismatch',
 	   [{'path': 'EcalBarrel/EBSelectiveReadoutTask/EBSRT TT flag mismatch', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'}],
 	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT flag mismatch EE -', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'},
 	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT flag mismatch EE +', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/18 TT Flags vs Et',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/17 TT Flags vs Et',
 	   [{'path': 'EcalBarrel/EBSelectiveReadoutTask/EBSRT TT Flags vs Et', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'}],
 	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE -', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'},
 	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE +', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/19 Ratio_L1TEGamma_BX_0',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/18 Ratio_L1TEGamma_BX_0',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0', 'description': 'Fraction of (L1T EGamma objects with pT >= 20 GeV found in BX 0) over (all L1T EGamma objects with pT >= 20 GeV found in a BX range of +/-2 BX around BX 0).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/20 Ratio_L1TEGamma_BX_minus1',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/19 Ratio_L1TEGamma_BX_minus1',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1', 'description': 'Fraction of (L1T EGamma objects with pT >= 20 GeV found in BX -1) over (all L1T EGamma objects with pT >= 20 GeV found in a BX range of +/-2 BX around BX 0).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/21 noniso_bx_ieta_firstbunch',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/20 noniso_bx_ieta_firstbunch',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_FirstCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_FirstCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the first bunch in a bunch train.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/22 noniso_bx_ieta_lastbunch',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/21 noniso_bx_ieta_lastbunch',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_LastCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_LastCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the last bunch in a bunch train.'}])
 
 

--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -605,6 +605,15 @@ ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/18 TT Flags vs Et',
 	   [{'path': 'EcalBarrel/EBSelectiveReadoutTask/EBSRT TT Flags vs Et', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'}],
 	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE -', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'},
 	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE +', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/19 Ratio_L1TEGamma_BX_0',
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0', 'description': 'This 2D plot in (eta, phi) shows the ratio of the total TP energy at BX = 0.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/20 Ratio_L1TEGamma_BX_minus1',
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1', 'description': 'This 2D plot in (eta, phi) shows the ratio of the total TP energy at BX = -1.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/21 noniso_bx_ieta_firstbunch',
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0', 'description': 'This 2D plot shows the fraction of the TP energy in a given BX as a function of eta in events from the first bunches.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/22 noniso_bx_ieta_lastbunch',
+           [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0', 'description': 'This 2D plot shows the fraction of the TP energy in a given BX as a function of eta in events from the last bunches.'}])
+
 
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE

--- a/dqmgui/layouts/es-layouts.py
+++ b/dqmgui/layouts/es-layouts.py
@@ -33,6 +33,9 @@ ecalpreshowerlayout(dqmitems, "04-ESTimingTaskSummary-EcalPreshower",
 ecalpreshowerlayout(dqmitems, "05-ESGain-EcalPreshower",
   [{ 'path': "EcalPreshower/ESIntegrityTask/ES Gain used for data taking", 'description': "ES Gain configuration in the front-end electronics"}])
 
+ecalpreshowerlayout(dqmitems, "06-ES-Fiber-Error-Code",
+  [{ 'path': "EcalPreshower/ESIntegrityTask/ES Fiber Error Code", 'description': "Error codes for each ES integrity error; the number of entries is the number of events with an error."}])
+
 # Layouts
 ecalpreshowershiftlayout(dqmitems, "01-IntegritySummary-EcalPreshower",
   [{ 'path': "EcalPreshower/ESIntegrityClient/ES Integrity Summary 1 Z 1 P 1", 'description': "ES+ Front Integrity Summary 1 - <a href=https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftPreshower>DQMShiftPreshower</a> <br/> <table width=100%> <tr><td>1 - not used<td>2 - fiber problem<td>3 - OK<td>4 - FED problem<td><tr>5 - KCHIP problem<td>6 - ES counters are not synced with GT counters (see ESRawDataTask) <td> 7 - more than one problem<td>8 - SLink CRC error</table> " },
@@ -60,6 +63,9 @@ ecalpreshowershiftlayout(dqmitems, "04-ESTimingTaskSummary-EcalPreshower",
 
 ecalpreshowershiftlayout(dqmitems, "05-ESGain-EcalPreshower",
   [{ 'path': "EcalPreshower/ESIntegrityTask/ES Gain used for data taking", 'description': "ES Gain configuration in the front-end electronics"}])
+
+ecalpreshowershiftlayout(dqmitems, "06-ES-Fiber-Error-Code",
+  [{ 'path': "EcalPreshower/ESIntegrityTask/ES Fiber Error Code", 'description': "Error codes for each ES integrity error; the number of entries is the number of events with an error."}])
 
 ecalpreshowerintegritylayout(dqmitems, "01 Integrity Summary 1 Z 1 P 1",
    [{'path': "EcalPreshower/ESIntegrityClient/ES Integrity Summary 1 Z 1 P 1", 'description': "ES+ Front Integrity Summary 1 - <a href=https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftPreshower>DQMShiftPreshower</a> <br/> <table width=100%> <tr><td>1 - not used<td>2 - fiber problem<td>3 - OK<td>4 - FED problem<td><tr>5 - KCHIP problem<td>6 - ES counters are not synced with GT counters (see ESRawDataTask) <td> 7 - more than one problem<td>8 - SLink CRC error</table> " }])

--- a/dqmgui/layouts/shift_es_layout.py
+++ b/dqmgui/layouts/shift_es_layout.py
@@ -26,3 +26,6 @@ shifteslayout(dqmitems, "04-ESTimingTaskSummary-EcalPreshower",
 
 shifteslayout(dqmitems, "05-ESGain-EcalPreshower",
   [{ 'path': "EcalPreshower/ESIntegrityTask/ES Gain used for data taking", 'description': "ES Gain configuration in the front-end electronics"}])
+
+shifteslayout(dqmitems, "06-ES-Fiber-Error-Code",
+  [{ 'path': "EcalPreshower/ESIntegrityTask/ES Fiber Error Code", 'description': "Error codes for each ES integrity error; the number of entries is the number of events with an error."}])

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -218,12 +218,12 @@ server.workspace('DQMContent', 21, 'Tracker', 'SiStrip', '^(SiStrip|Tracking)/',
                 )
 
 # Calorimeter workspaces:
-server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1|^L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0|^L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0)', 'Ecal/Layouts',
+server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1|^L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0|^L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0)', 'Ecal/Layouts',
                  'Ecal/Layouts/00 Summary',
                  'Ecal/Layouts/01 Occupancy Summary',
                  'Ecal/Layouts/02 Calibration Summary',
                 )
-                # Ecal workspace modified above to include three L1 Trigger
+                # Ecal workspace modified above to include six L1 Trigger
                 # plots and one HLT plot as requested by Ecal team
 
 server.workspace('DQMContent', 31, 'Calorimeters', 'EcalPreshower', '^EcalPreshower/', '',

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -232,6 +232,7 @@ server.workspace('DQMContent', 31, 'Calorimeters', 'EcalPreshower', '^EcalPresho
                  'EcalPreshower/Layouts/03-GoodRechitEnergySummary-EcalPreshower',
                  'EcalPreshower/Layouts/04-ESTimingTaskSummary-EcalPreshower',
                  'EcalPreshower/Layouts/05-ESGain-EcalPreshower',
+                 'EcalPreshower/Layouts/06-ES-Fiber-Error-Code',
                 )
 
 server.workspace('DQMContent', 32, 'Calorimeters', 'HCAL', '^(Hcal|Hcal2)/', '',

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -218,7 +218,7 @@ server.workspace('DQMContent', 21, 'Tracker', 'SiStrip', '^(SiStrip|Tracking)/',
                 )
 
 # Calorimeter workspaces:
-server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass)', 'Ecal/Layouts',
+server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccRecdEtWgt|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1|^L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0|^L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0)', 'Ecal/Layouts',
                  'Ecal/Layouts/00 Summary',
                  'Ecal/Layouts/01 Occupancy Summary',
                  'Ecal/Layouts/02 Calibration Summary',


### PR DESCRIPTION
(1) Added some new L1T plots to the Trigger folder in the ECAL workspace to monitor pre-firing and post-firing rates.

(2) Added histogram of the error codes for each ECAL Preshower integrity error to the main shifter workspace and to the top-level ECAL Preshower expert workspace. This plot now enables the DQM shifter to find out the number of events with fiber error at a glance, just by looking at the number of entries in the histogram.