### PR TITLE
Temporary switch off uGMT ZS monitoring audio alarm

### DIFF
--- a/dqmgui/layouts/shift_error_layout.py
+++ b/dqmgui/layouts/shift_error_layout.py
@@ -25,10 +25,10 @@ errorlayout(dqmitems, "06 - BeamSpot missing from online",
 ## [{ 'path': "SiStrip/MechanicalView/DataPresentInLS",
 ##    'description': "Monitoring of SiStrip activity in each LS. Audio alarm is fired during stable beams if there are no digis in either SiStrip partition for some time (red box). In case of alarm, please verify with the shift leader that SiStrip HV is ON. If HV is ON during alarm, call Tracker DOC at 165503. For more details, please refer to <a href=https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftSiStrip>DQMShiftOnlineSiStrip</a> ", 'draw': { 'withref': "no" }}])
 
-errorlayout(dqmitems, "08 - L1T Zero Suppression Error",
-  [{'path': "L1T/L1TStage2uGMT/zeroSuppression/AllEvts/mismatchRatio", 'description': "Summary of the uGMT zero suppression checks for all events. Wrongly zero suppressed raw data can only be checked for the validation events. For normal events only errors where data was not zero suppressed but should have been will be found.", 'draw': { 'withref': "no" }},
-  #{'path': "L1T/L1TStage2BMTF/zeroSuppression/AllEvts/mismatchRatio", 'description': "Summary of the BMTF zero suppression checks for all events. Wrongly zero suppressed raw data can only be checked for the validation events. For normal events only errors where data was not zero suppressed but should have been will be found.", 'draw': { 'withref': "no" }}
-  ])
+#errorlayout(dqmitems, "08 - L1T Zero Suppression Error",
+#  [{'path': "L1T/L1TStage2uGMT/zeroSuppression/AllEvts/mismatchRatio", 'description': "Summary of the uGMT zero suppression checks for all events. Wrongly zero suppressed raw data can only be checked for the validation events. For normal events only errors where data was not zero suppressed but should have been will be found.", 'draw': { 'withref': "no" }},
+#  #{'path': "L1T/L1TStage2BMTF/zeroSuppression/AllEvts/mismatchRatio", 'description': "Summary of the BMTF zero suppression checks for all events. Wrongly zero suppressed raw data can only be checked for the validation events. For normal events only errors where data was not zero suppressed but should have been will be found.", 'draw': { 'withref': "no" }}
+#  ])
 
 errorlayout(dqmitems, "09 - L1T Data Transmission Error",
   [{'path': "L1T/L1TStage2uGT/uGMToutput_vs_uGTinput/mismatchRatio", 'description': "Summary of the uGMT output to uGT input data transmission checks. The uGT must receive exactly the same objects that the uGMT sends. Mismatches are indicated in the ratio plot.", 'draw': { 'withref': "no" }},


### PR DESCRIPTION
Temporary switch off uGMT ZS monitoring audio alarm for ZS off tests.