### PR TITLE
Add monitoring of HF dual anode TDC cut for TPs

### DIFF
--- a/dqmgui/layouts/hcal-layouts.py
+++ b/dqmgui/layouts/hcal-layouts.py
@@ -2365,3 +2365,14 @@ hcallayout(dqmitems, '54 (CapId-BX)%4',
 		},
 	]
 )
+
+hcallayout(dqmitems, '55 HF TDC cut efficiency', 
+	[
+		{
+			'path':'Hcal/TPTask/TDCCutEfficiency_depth', 'description':"""Efficiency of HF dual anode TDC cut"""
+		},
+		{
+			'path':'Hcal/TPTask/TDCCutEfficiency_ieta', 'description':"""Efficiency of HF dual anode TDC cut"""
+		},
+	]
+)


### PR DESCRIPTION
For HCAL DQM layouts:

- Add plots for monitoring of HF dual anode TDC cut for TPs.