### PR TITLE
Excluding vocms0741 vocms0742 to deploy reqmgr2 crontab

### DIFF
--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -42,7 +42,7 @@ deploy_reqmgr2_sw()
 
 deploy_reqmgr2_post()
 {
-  case $host in vocms013[89] | vocms073[89] ) disable;;  * ) enable;; esac
+  case $host in vocms013[89] | vocms073[89] | vocms074[12] ) disable;;  * ) enable;; esac
 
   # ReqMgr2 and old reqmgr specific couchdb stuff
   # Tell couch to pick up reqmgr on the next restart


### PR DESCRIPTION
Accord to [1] Reqmgr2 service components only should be deployed in general propose backends
vocms01{36, 61, 63,65} and in vocms0740, nodes.

During deployments I've realized that Reqmgr2 crontab for below line:

@reboot sudo -H -u _reqmgr2 bashs -l -c '/data/srv/current/config/reqmgr2/manage sysboot'

has being deployed also into  vocms074{1,2} nodes. This is not a problem, but, it makes that below message shows up during deployment services status checking.

reqmgr2 is NOT RUNNING

And this is not true, because Reqmgr2 does not run on vocms074{1,2} nodes.







[1]https://cms-http-group.web.cern.ch/cms-http-group/activity.html