### PR TITLE
Shift layout page: add alarm for HCAL bad capid rotation.

### DIFF
--- a/dqmgui/layouts/shift_error_layout.py
+++ b/dqmgui/layouts/shift_error_layout.py
@@ -48,5 +48,10 @@ errorlayout(dqmitems, "11 - HCAL uHTR-L1T Layer1 Mismatch",
   ])
 
 errorlayout(dqmitems, "12 - HCAL LED Misfires",
-  [{'path': "Hcal/DigiTask/LED/LEDEventCount", 'description': "Number of LED misfire events", 'draw': { 'withref': "no" }},
+  [{'path': "Hcal/DigiTask/LED_CUCountvsLS/Subdet/HE", 'description': "Number of LED misfire events (HE)", 'draw': { 'withref': "no" }},
+  {'path': "Hcal/DigiTask/LED_CUCountvsLS/Subdet/HF", 'description': "Number of LED misfire events (HF)", 'draw': { 'withref': "no" }},  
+  ])
+
+errorlayout(dqmitems, "13 - HCAL Bad CapID rotation",
+  [{'path':"Hcal/DigiTask/CapID/CapID_BadvsLS", 'description': "Bad CapID values vs FED vs LS", 'draw': { 'withref': "no" }}
   ])

--- a/dqmgui/layouts/shift_error_layout.py
+++ b/dqmgui/layouts/shift_error_layout.py
@@ -46,3 +46,7 @@ errorlayout(dqmitems, "11 - HCAL uHTR-L1T Layer1 Mismatch",
   [{'path': "L1T/L1TStage2CaloLayer1/MismatchDetail/maxEvtMismatchByLumiHCAL", 'description': "Trigger primitive mismatches between HCAL uHTR and L1T", 'draw': { 'withref': "no" }},
   #{'path': "L1T/L1TStage2uGT/calol2ouput_vs_uGTinput/mismatchRatio", 'description': "Summary of the CaloLayer2 output to uGT input data transmission checks. The uGT must receive exactly the same objects that the CaloLayer2 sends. Mismatches are indicated in the ratio plot.", 'draw': { 'withref': "no" }}
   ])
+
+errorlayout(dqmitems, "12 - HCAL LED Misfires",
+  [{'path': "Hcal/DigiTask/LED/LEDEventCount", 'description': "Number of LED misfire events", 'draw': { 'withref': "no" }},
+  ])


### PR DESCRIPTION
Note: PR #661 was never merged into master, so this PR includes this one. If this PR is merged, #661 can be closed.