### PR TITLE
Remove LogDB docs older than 90 days instead of one

### DIFF
--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -95,7 +95,8 @@ if HOST.startswith("vocms0740") or HOST.startswith("vocms0731") or HOST.startswi
     logDBTasks.object = "WMCore.WMStats.CherryPyThreads.LogDBTasks.LogDBTasks"
     logDBTasks.central_logdb_url = LOG_DB_URL
     logDBTasks.log_reporter = LOG_REPORTER
-    logDBTasks.logDBCleanDuration = 60 * 60 * 24 * 1 # 1 day
+    logDBTasks.keepDocsAge = 60 * 60 * 24 * 90  # keep data newer than 90 days
+    logDBTasks.logDBCleanDuration = 60 * 60 * 12  # every 12 hours
     logDBTasks.log_file = '%s/logs/reqmon/logDBTasks-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
     
     # Cleaning up wmstats db
@@ -106,7 +107,6 @@ if HOST.startswith("vocms0740") or HOST.startswith("vocms0731") or HOST.startswi
     cleanUpTask.reqdb_couch_app = "ReqMgr"
     cleanUpTask.central_logdb_url = LOG_DB_URL
     cleanUpTask.log_reporter = LOG_REPORTER
-    cleanUpTask.DataKeepDays = 45 # 0.125 hours - unit is day
     cleanUpTask.archivedCleanUpDuration = 60 * 60 * 12  # every 12 hours
     cleanUpTask.log_file = '%s/logs/reqmon/cleanUpTask-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
     


### PR DESCRIPTION
Changes related to https://github.com/dmwm/WMCore/pull/8870 , keeping any logDB documents newer than 90 days. Cleanup `DataKeepDays` that is no longer used.
@ticoann please review