### PR TITLE
Add sysboot action and crontab entry

### DIFF
--- a/frontend/deploy
+++ b/frontend/deploy
@@ -153,6 +153,7 @@ deploy_frontend_post()
 
   case $host in * ) enable ;; esac
   (mkcrontab | { egrep -v -e '^(PATH|X509_[A-Z_]*)=' || true; }
+   sysboot
    echo "13 */3 * * * $project_config/mkvomsmap --key $certs/hostkey.pem" \
         "--cert $certs/hostcert.pem -c $project_config/mkgridmap.conf" \
         "-o $PWD/etc/voms-gridmap.txt --vo cms"

--- a/frontend/manage
+++ b/frontend/manage
@@ -8,6 +8,7 @@
 ##H   configtest  check server configuration
 ##H   restart     (re)start the service
 ##H   start       (re)start the service
+##H   sysboot     start server from crond
 ##H   graceful    restart the service gracefully
 ##H   stop        stop the service
 ##H
@@ -44,7 +45,7 @@ case ${1:-status} in
     fi
     ;;
 
-  start | restart )
+  start | restart | sysboot )
     if $groups; then
       case $(uname) in
         Linux  ) sudo /sbin/service httpd restart ;;


### PR DESCRIPTION
Since we add to frontend local environment (to support proper start-up of x509-scitoken-issuer wsgi service) we need to adjust frontend manage/deploy script to add sysboot functionality.