### PR TITLE
Validate keys in the mapping; make roles/groups lower case

### DIFF
--- a/frontend/mkauthmap
+++ b/frontend/mkauthmap
@@ -98,6 +98,29 @@ def buildSiteMap(sites):
     return sitemap
 
 
+def rolesToLower(dataDict):
+    """
+    Receives a python dictionary with all the user entries and convert
+    all group/user ROLES information to lower case, updating it in place
+    """
+    for entry in dataDict:
+        for role, groups in entry['ROLES'].items():
+            entry['ROLES'][role] = [item.lower() for item in groups]
+
+
+def validateMapKeys(dataDict):
+    """
+    Given a python dictionary with the final user information, validate
+    that each entry contains only keys supported by our frontend.
+    """
+    supportedKeys = set(['DN', 'ID', 'LOGIN', 'NAME', 'ROLES'])
+    for entry in dataDict:
+        if set(entry.keys()) != supportedKeys:
+            print >> sys.stderr, "Found keys not supported: %s" % (set(entry.keys()) != supportedKeys)
+            print >> sys.stderr, "It needs to be reported to the CRIC developers!"
+            exit(3)
+
+
 def updateFile(opts, roles, sitemap):
     """
     If sitemap argument is given, decode the CRIC roles API output, extend phedex 
@@ -125,6 +148,10 @@ def updateFile(opts, roles, sitemap):
                                 if opts.verbose:
                                     print "WARNING: role %s is missing from the sitemap" % r
                         entry['ROLES'][group] = group_roles
+            # make sure we only have the expected arguments in the mapping
+            validateMapKeys(struct)
+            # now convert all group/roles to lower
+            rolesToLower(struct)
             # Generate stable JSON representation.
             enc = json.JSONEncoder(sort_keys=True)
             jsondata = "[\n " + ",\n ".join(enc.encode(entry) for entry in struct) + "\n]\n"
@@ -141,13 +168,13 @@ def updateFile(opts, roles, sitemap):
                 # then let's write out a new file and replace the current one
                 #print "Info: json content has changed, updating it ..."
                 try:
-                  fd, tmpname= mkstemp(dir = os.path.dirname(opts.out))
-                  tmpfile = os.fdopen(fd, "w")
-                  tmpfile.write(jsondata)
-                  tmpfile.close()
+                    fd, tmpname= mkstemp(dir = os.path.dirname(opts.out))
+                    tmpfile = os.fdopen(fd, "w")
+                    tmpfile.write(jsondata)
+                    tmpfile.close()
                 except(IOError, OSError) as e: 
-                  print "An error ocurred:"
-                  pprint(e)
+                    print "An error ocurred:"
+                    pprint(e)
 
                 myumask = current_umask()
                 os.chmod(tmpname, 0666 & ~myumask)

--- a/frontend/mkauthmap
+++ b/frontend/mkauthmap
@@ -127,61 +127,61 @@ def updateFile(opts, roles, sitemap):
     related groups by adding roles with phedex node names mapped via CRIC site-names API
     and converted to headers style; then convert the data structure back to a json string.
     """
-    if roles:
-        if sitemap:
-            struct = json.loads(roles)
-            for entry in struct:
-                # Only extend the groups interesting to PhEDEx:
-                for group in ['data-manager', 'site-admin', 'phedex-contact']:
-                    group_roles = []
-                    if group in entry['ROLES']:
-                        group_roles.extend(entry['ROLES'][group])
-                        for r in entry['ROLES'][group]:
-                            if not r.startswith('site:'):
-                                continue
-                            if r in sitemap:
-                                group_roles.extend(sitemap[r])
-                                if opts.verbose:
-                                    print "Added role: %s for user %s and group %s " % \
-                                          (sitemap[r], entry['NAME'], group)
-                            else:
-                                if opts.verbose:
-                                    print "WARNING: role %s is missing from the sitemap" % r
-                        entry['ROLES'][group] = group_roles
-            # make sure we only have the expected arguments in the mapping
-            validateMapKeys(struct)
-            # now convert all group/roles to lower
-            rolesToLower(struct)
-            # Generate stable JSON representation.
-            enc = json.JSONEncoder(sort_keys=True)
-            jsondata = "[\n " + ",\n ".join(enc.encode(entry) for entry in struct) + "\n]\n"
+    if not roles or not sitemap:
+        print >> sys.stderr, "Either roles or sitemap is empty, aborting..."
+        exit(2)
 
-            # compare this against the current one (create it if it does not exist)
-            try:
-                with open(opts.out) as fp:
-                    oldjsondata = fp.read()
-            except IOError:
-                print "File %s does not exist yet." % opts.out
-                oldjsondata = ''
+    struct = json.loads(roles)
+    for entry in struct:
+        # Only extend the groups interesting to PhEDEx:
+        for group in ['data-manager', 'site-admin', 'phedex-contact']:
+            group_roles = []
+            if group in entry['ROLES']:
+                group_roles.extend(entry['ROLES'][group])
+                for r in entry['ROLES'][group]:
+                    if not r.startswith('site:'):
+                        continue
+                    if r in sitemap:
+                        group_roles.extend(sitemap[r])
+                        if opts.verbose:
+                            print "Added role: %s for user %s and group %s " % \
+                                  (sitemap[r], entry['NAME'], group)
+                    else:
+                        if opts.verbose:
+                            print "WARNING: role %s is missing from the sitemap" % r
+                entry['ROLES'][group] = group_roles
+    # make sure we only have the expected arguments in the mapping
+    validateMapKeys(struct)
+    # now convert all group/roles to lower
+    rolesToLower(struct)
+    # Generate stable JSON representation.
+    enc = json.JSONEncoder(sort_keys=True)
+    jsondata = "[\n " + ",\n ".join(enc.encode(entry) for entry in struct) + "\n]\n"
 
-            if jsondata != oldjsondata:
-                # then let's write out a new file and replace the current one
-                #print "Info: json content has changed, updating it ..."
-                try:
-                    fd, tmpname= mkstemp(dir = os.path.dirname(opts.out))
-                    tmpfile = os.fdopen(fd, "w")
-                    tmpfile.write(jsondata)
-                    tmpfile.close()
-                except(IOError, OSError) as e: 
-                    print "An error ocurred:"
-                    pprint(e)
+    # compare this against the current one (create it if it does not exist)
+    try:
+        with open(opts.out) as fp:
+            oldjsondata = fp.read()
+    except IOError:
+        print "File %s does not exist yet." % opts.out
+        oldjsondata = ''
 
-                myumask = current_umask()
-                os.chmod(tmpname, 0666 & ~myumask)
-                os.rename(tmpname, opts.out)
-                #print "Done!"
+    if jsondata != oldjsondata:
+        # then let's write out a new file and replace the current one
+        # print "Info: json content has changed, updating it ..."
+        try:
+            fd, tmpname = mkstemp(dir=os.path.dirname(opts.out))
+            tmpfile = os.fdopen(fd, "w")
+            tmpfile.write(jsondata)
+            tmpfile.close()
+        except(IOError, OSError) as e:
+            print "An error ocurred:"
+            pprint(e)
 
-##Main
+        myumask = current_umask()
+        os.chmod(tmpname, 0666 & ~myumask)
+        os.rename(tmpname, opts.out)
+        # print "Done!"  ##Main
 # Getting command line options
 opt = OptionParser(__doc__)
 opt.add_option("-c", "--conf", dest="conf", metavar="FILE", help="configuration file")
@@ -204,6 +204,6 @@ roles = request(uri)
 sites = request(uri.replace('roles', 'site-names&rcsite_state=ANY'))
 sitemap = buildSiteMap(sites)
 updateFile(opts, roles, sitemap)
-#content = request(uri)
-#updateFile(opts, content)
+# content = request(uri)
+# updateFile(opts, content)
 exit(0)


### PR DESCRIPTION
Possibly superseeding #719

Real changes are in the 1st commit. 2nd commit only contains aesthetic changes to make the code a bit more readable.

As discussed with Lina, this PR contains the following:
* convert group and roles information to lower case (even though CRIC is supposed to return it already in lower case)
* make sure the json content only contains supported attributed, so validate all the keys before persisting it.

@h4d4 besides checking whether this works or not, can you also check whether the order of attributes matter or not?
