### PR TITLE
Workaround/fix for "libGL.so.1 missing" problem

### DIFF
--- a/Deploy
+++ b/Deploy
@@ -246,7 +246,7 @@ inrepo()
      rm -fr $swarea
      mkdir -p $swarea
      cd $swarea
-     curl -sO http://$rpmhost/cmssw/repos/bootstrap.sh
+     curl -sO http://$rpmhost/cmssw/bootstrap.sh
      sh -x ./bootstrap.sh -architecture $arch -path $PWD -repository $repo \
        -server $rpmhost setup > $PWD/bootstrap-$arch.log 2>&1
      touch .bootstrapped)


### PR DESCRIPTION
Recently, we found that DQMGUI fails to deploy using CMSWEB tooling. This problem was tirggerd by a CC7 update:
https://hypernews.cern.ch/HyperNews/CMS/get/webInterfaces/1645.html

This a workaround suggested in the thread, which works for DQMGUI on lxplus7. Since the problem now also hit the production systems, we might consider uisng it there as well.

I am not sure about the implications of this change; we only tested it for DQMGUI on lxplus7.