### PR TITLE
Fix to properly restart frontends

### DIFF
--- a/frontend/manage
+++ b/frontend/manage
@@ -51,7 +51,15 @@ case ${1:-status} in
         Darwin ) for a in unload load; do sudo launchctl $a -w $t; done ;;
       esac
     else
-      $STATEDIR/etc/httpd restart
+      echo "sudo /sbin/service httpd stop"
+      sudo /sbin/service httpd stop
+      echo "for i in `ipcs -s | awk '/apache/ {print $2}'`; do (sudo ipcrm -s $i); done"
+      for i in `ipcs -s | awk '/apache/ {print $2}'`; do (sudo ipcrm -s $i); done
+      sleep 2;
+      echo "sudo /sbin/service httpd status"
+      sudo /sbin/service httpd status
+      echo "sudo /sbin/service httpd start"
+      sudo /sbin/service httpd start
     fi
     ;;
 


### PR DESCRIPTION
This PR modified frontend/manage in order to restart frontend service as _frontend user once the node is rebooted an below cron entry is trigered:
`@reboot sudo bashs -l -c "/data/srv/current/config/frontend/manage restart 'I did read documentation'"`