### PR TITLE
Add option to reqmgr2 manage script to upload default auxiliar configs

### DIFF
--- a/reqmgr2/manage
+++ b/reqmgr2/manage
@@ -9,6 +9,7 @@
 ##H   sysboot           start server from crond if not running
 ##H   restart           (re)start the service
 ##H   updateversions    update database with ScramArchs/CMSSW releases
+##H   postdefaultconfig post the default configuration to ReqMgr Auxiliary DB
 ##H   start             (re)start the service
 ##H   stop              stop the service
 ##H
@@ -40,6 +41,7 @@ AUTHDIR=$TOP/current/auth/reqmgr2
 COLOR_OK="\\033[0;32m"
 COLOR_WARN="\\033[0;31m"
 COLOR_NORMAL="\\033[0;39m"
+WMCORE_BIN=$ROOT/apps/$ME/bin
 
 . $ROOT/apps/$ME/etc/profile.d/init.sh
 
@@ -97,10 +99,13 @@ check()
 
 updateversions()
 {
-  cd $STATEDIR
-  reqmgr-sw-update $CFGFILE
+  ${WMCORE_BIN}/reqmgr-sw-update $CFGFILE
 }
 
+postdefaultconfig()
+{
+  ${WMCORE_BIN}/reqmgr-put-default-config $1
+}
 
 # Main routine, perform action requested on command line.
 case ${1:-status} in
@@ -126,6 +131,11 @@ case ${1:-status} in
   updateversions )
     check "$2"
     updateversions
+    ;;
+
+  postdefaultconfig )
+    check "$3"
+    postdefaultconfig $2
     ;;
 
   help )


### PR DESCRIPTION
New option required for reqmgr_aux updates. Whenever we change one of these default data structures:
https://github.com/dmwm/WMCore/tree/master/src/python/WMCore/ReqMgr/DataStructs/DefaultConfig

we need to make sure to push those changes to couchdb as well, otherwise it might keep using outdated data/parameters.

It can be used like:
```
amaltaro@alancc7-cloud1:/data/srv/current $ ./config/reqmgr2/manage postdefaultconfig BLAH.cern.ch 'I did read documentation'
```