### PR TITLE
Remove layouts from development DQM GUI for bin by bin comparison vis…

### DIFF
--- a/dqmgui/server-conf-dev.py
+++ b/dqmgui/server-conf-dev.py
@@ -41,7 +41,9 @@ server.source('DQMStripChart')
 server.source('DQMCertification')
 server.source('DQMLive', "127.0.0.1:8061")
 server.source('DQMArchive', "%s/ix128" % STATEDIR, '^/Global/')
-server.source('DQMLayout')
+# Layouts are disabled because dev gui is used for visualising PR test bin by bin comparison output.
+# Uncomment the following line to enable layouts:
+# server.source('DQMLayout')
 
 execfile(CONFIGDIR + "/dqm-services.py")
 execfile(CONFIGDIR + "/workspaces-dev.py")


### PR DESCRIPTION
This PR removes all layouts from development version of DQM GUI because it is used for visualising PR test bin by bin comparison results. In bin by bin comparison results some folders will be empty and, therefore, shouldn't be rendered in the GUI.