### PR TITLE
frontend manage patch provided by vkuznet

### DIFF
--- a/frontend/manage
+++ b/frontend/manage
@@ -23,44 +23,29 @@ STATEDIR=$TOP/state/$ME
 export X509_SCITOKENS_ISSUER_CONFIG=$STATEDIR/x509_scitokens_issuer/x509_scitokens_issuer_app.json
 export X509_SCITOKENS_ISSUER_INSTANCE_PATH=$STATEDIR/x509_scitokens_issuer
 
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$STATEDIR/libs:/usr/lib64
 . $ROOT/apps/$ME/etc/profile.d/init.sh
 
-# Detect if we're in single user mode
-case $(uname) in
-  Linux ) t="/etc/rc.d/init.d/httpd";;
-  Darwin) t="/Library/LaunchDaemons/ch.cern.cms.httpd.plist";;
-esac
-[ "$t" -ef "$STATEDIR/etc/httpd" ] && groups=true || groups=false
+# Detect if we have system httpd daemon
+if [ -f /usr/sbin/apachectl ]; then
+    sudo /usr/sbin/apachectl stop
+fi
 
 case ${1:-status} in
   status | graceful | stop | configtest )
-    if $groups; then
-      case $(uname) in
-        Linux  ) sudo /sbin/service httpd $1 ;;
-        Darwin ) sudo $STATEDIR/etc/httpd $1 ;;
-      esac
-    else
-      $STATEDIR/etc/httpd $1
-    fi
+    $STATEDIR/etc/httpd $1
     ;;
 
   start | restart )
-    if $groups; then
-      case $(uname) in
-        Linux  ) sudo /sbin/service httpd restart ;;
-        Darwin ) for a in unload load; do sudo launchctl $a -w $t; done ;;
-      esac
-    else
-      echo "sudo /sbin/service httpd stop"
-      sudo /sbin/service httpd stop
-      echo "for i in `ipcs -s | awk '/apache/ {print $2}'`; do (sudo ipcrm -s $i); done"
-      for i in `ipcs -s | awk '/apache/ {print $2}'`; do (sudo ipcrm -s $i); done
-      sleep 30;
-      echo "sudo /sbin/service httpd status"
-      sudo /sbin/service httpd status
-      echo "sudo /sbin/service httpd start"
-      $STATEDIR/etc/httpd restart
+    echo "stopping httpd service ..."
+    $STATEDIR/etc/httpd stop
+    ipids=`ipcs -s | awk '/apache|frontend/ {print $2}'`
+    if [ -n "$ipids" ]; then
+        echo "for i in $ipids; do (sudo ipcrm -s $i); done"
+        for i in `ipcs -s | awk '/apache/ {print $2}'`; do (sudo ipcrm -s $i); done
     fi
+    echo "restarting httpd service ..."
+    $STATEDIR/etc/httpd restart
     ;;
 
   help )


### PR DESCRIPTION
This PR provides a improved version for `fronted manage` script that was provided with [PR#725](https://github.com/dmwm/deployment/pull/725)
Code's changes in the script are necessary in order to have a success fronted reboot, including modifications introduced in [HG190 release](https://github.com/dmwm/deployment/releases/tag/HG1901a).

