### PR TITLE
Parse Rucio parameters for WMAgent deployment

### DIFF
--- a/wmagent/deploy
+++ b/wmagent/deploy
@@ -19,17 +19,17 @@ deploy_wmagent_sw()
 
   mkdir -p $root/$cfgversion/config/reqmgr
   mkdir -p $root/$cfgversion/config/workqueue
-
+  mkdir -p $root/$cfgversion/config/mysql
+  mkdir -p $root/$cfgversion/config/couchdb
+  mkdir -p $root/$cfgversion/config/rucio/etc
 
   local couchdb_ini=$root/$cfgversion/config/wmagent/local.ini
-  local mysql_config=$root/$cfgversion/config/wmagent/my.cnf
   perl -p -i -e "s{deploy_project_root}{$root/$cfgversion/install}g" $couchdb_ini
+  cp -f $couchdb_ini $root/$cfgversion/config/couchdb/
 
-  mkdir -p $root/$cfgversion/config/couchdb
-  cp -f $couchdb_ini $root/$cfgversion/config/couchdb
-  mkdir -p $root/$cfgversion/config/mysql
-  cp -f $mysql_config $root/$cfgversion/config/mysql
+  local mysql_config=$root/$cfgversion/config/wmagent/my.cnf
+  cp -f $mysql_config $root/$cfgversion/config/mysql/
 
-
-
+  local rucio_config=$root/$cfgversion/config/wmagent/rucio.cfg
+  cp -f $rucio_config $root/$cfgversion/config/rucio/etc/
 }

--- a/wmagent/manage
+++ b/wmagent/manage
@@ -17,6 +17,7 @@ CONFIG_COUCH="$ROOT_DIR/config/couchdb"
 CONFIG_MYSQL="$ROOT_DIR/config/mysql"
 CONFIG_AG="$ROOT_DIR/config/wmagent"
 CONFIG_WQ="$ROOT_DIR/config/workqueue"
+CONFIG_RUCIO="$ROOT_DIR/config/rucio/etc/rucio.cfg"
 
 USING_AG=0
 USING_WQ=0
@@ -78,6 +79,9 @@ REQUESTCOUCH_URL=
 CENTRAL_LOGDB_URL=
 WMARCHIVE_URL=
 AMQ_CREDENTIALS=
+RUCIO_HOST=
+RUCIO_AUTH=
+RUCIO_ACCOUNT=
 
 #
 # Init checks
@@ -96,11 +100,6 @@ if [ -e $INSTALL_COUCH/.init ]; then COUCH_INIT_DONE=1; else COUCH_INIT_DONE=0; 
 activate_agent(){
     touch $INSTALL_AG/.using
     cp $WMCORE_ROOT/etc/WMAgentConfig.py $CONFIG_AG/config-template.py
-}
-
-activate_crabserver(){
-    touch $INSTALL_AG/.using
-    cp $WMCORE_ROOT/etc/CrabServerConfig.py $CONFIG_AG/config-template.py
 }
 
 activate_workqueue(){
@@ -168,6 +167,10 @@ load_secrets_file(){
     local MATCH_CENTRAL_LOGDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep CENTRAL_LOGDB_URL | sed s/CENTRAL_LOGDB_URL=//`
     local MATCH_WMARCHIVE_URL=`cat $WMAGENT_SECRETS_LOCATION | grep WMARCHIVE_URL | sed s/WMARCHIVE_URL=//`
     local MATCH_AMQ_CREDENTIALS=`cat $WMAGENT_SECRETS_LOCATION | grep AMQ_CREDENTIALS | sed s/AMQ_CREDENTIALS=//`
+    local MATCH_RUCIO_HOST=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_HOST | sed s/RUCIO_HOST=//`
+    local MATCH_RUCIO_AUTH=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_AUTH | sed s/RUCIO_AUTH=//`
+    local MATCH_RUCIO_ACCOUNT=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_ACCOUNT | sed s/RUCIO_ACCOUNT=//`
+
     # database settings (mysql or oracle)
     if [ "x$MATCH_ORACLE_USER" == "x" ]; then
         MYSQL_USER=${MATCH_MYSQL_USER:-wmagentmysql};
@@ -243,6 +246,9 @@ load_secrets_file(){
     WMARCHIVE_URL=${MATCH_WMARCHIVE_URL:-$WMARCHIVE_URL}
 
     AMQ_CREDENTIALS=${MATCH_AMQ_CREDENTIALS:-$AMQ_CREDENTIALS}
+    RUCIO_HOST=${MATCH_RUCIO_HOST:-$RUCIO_HOST}
+    RUCIO_AUTH=${MATCH_RUCIO_AUTH:-$RUCIO_AUTH}
+    RUCIO_ACCOUNT=${MATCH_RUCIO_ACCOUNT:-$RUCIO_ACCOUNT}
 }
 
 print_settings(){
@@ -288,6 +294,9 @@ print_settings(){
     echo "CENTRAL_LOGDB_URL=         $CENTRAL_LOGDB_URL         "
     echo "WMARCHIVE_URL=             $WMARCHIVE_URL             "
     echo "AMQ_CREDENTIALS=           $AMQ_CREDENTIALS           "
+    echo "RUCIO_HOST=                $RUCIO_HOST           "
+    echo "RUCIO_AUTH=                $RUCIO_AUTH           "
+    echo "RUCIO_ACCOUNT=             $RUCIO_ACCOUNT           "
 
 }
 
@@ -614,11 +623,16 @@ stop_services(){
 #  Agent stuff               #
 ##############################
 
-
+# update the rucio.cfg file with the proper parameters from the secrets file
+init_rucio(){
+    sed -i "s+RUCIO_HOST_OVERWRITE+$RUCIO_HOST+" $CONFIG_RUCIO
+    sed -i "s+RUCIO_AUTH_OVERWRITE+$RUCIO_AUTH+" $CONFIG_RUCIO
+}
 
 # generate the agent config from the basic template
 init_wmagent(){
     load_secrets_file;
+    init_rucio;
     if [ "x$MYSQL_USER" != "x" ]; then
 	wmagent-mod-config --input=$CONFIG_AG/config-template.py \
                        --output=$CONFIG_AG/config.py \
@@ -639,8 +653,9 @@ init_wmagent(){
 	                   --requestcouch_url=$REQUESTCOUCH_URL \
 	                   --central_logdb_url=$CENTRAL_LOGDB_URL \
 	                   --wmarchive_url=$WMARCHIVE_URL \
-	                   --amq_credentials=$AMQ_CREDENTIALS
-	                   
+	                   --amq_credentials=$AMQ_CREDENTIALS \
+	                   --rucio_account=$RUCIO_ACCOUNT
+
     elif [ "x$ORACLE_USER" != "x" ]; then
 	wmagent-mod-config --input=$CONFIG_AG/config-template.py \
                        --output=$CONFIG_AG/config.py \
@@ -660,7 +675,8 @@ init_wmagent(){
 	                   --requestcouch_url=$REQUESTCOUCH_URL \
 	                   --central_logdb_url=$CENTRAL_LOGDB_URL \
 	                   --wmarchive_url=$WMARCHIVE_URL \
-	                   --amq_credentials=$AMQ_CREDENTIALS
+	                   --amq_credentials=$AMQ_CREDENTIALS \
+	                   --rucio_account=$RUCIO_ACCOUNT
 
 
     else
@@ -828,6 +844,7 @@ execute_command_agent(){
     echo "Executing $RUNTHIS $@ ..."
     $RUNTHIS $@;
 }
+
 execute_command_wq(){
     shift;
     local RUNTHIS=$1

--- a/wmagent/rucio.cfg
+++ b/wmagent/rucio.cfg
@@ -1,0 +1,20 @@
+# Copyright European Organization for Nuclear Research (CERN)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Vincent Garonne, <vgaronne@gmail.com>, 2017
+# - Eric Vaandering, <ewv@fnal.gov>, 2018
+
+[common]
+[client]
+rucio_host = RUCIO_HOST_OVERWRITE
+auth_host = RUCIO_AUTH_OVERWRITE
+auth_type = x509
+ca_cert = /etc/grid-security/certificates/
+client_cert = $X509_USER_CERT
+client_key = $X509_USER_KEY
+client_x509_proxy = $X509_USER_PROXY
+request_retries = 3


### PR DESCRIPTION
Created a basic rucio config based on:
https://github.com/dmwm/CMSRucio/blob/master/docker/CMSRucioClient/rucio-testbed.cfg

and parse a few parameters from the secrets file and overwrite those default values, as well as add an account parameter to the agent config file.