### PR TITLE
Setup Rucio for WorkQueue and ReqMgr2MS; updat AMQ broker/port

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -16,7 +16,7 @@ DBS_INS = "@@DBS_INS@@"
 COUCH_URL = "%s/couchdb" % BASE_URL
 LOG_DB_URL = "%s/wmstats_logdb" % COUCH_URL
 LOG_REPORTER = "reqmgr2"
-AMQ_HOST_PORT = [('dashb-mb.cern.ch', 61113)]
+AMQ_HOST_PORT = [('cms-mb.cern.ch', 61313)]
 
 ROOTDIR = __file__.rsplit('/', 3)[0]
 # load AMQ credentials
@@ -80,11 +80,7 @@ data.tag_collector_url = "https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML"
 # keys are not present at easy item but defined in a dedicated item ...)
 # https://cmssdt.cern.ch/tc/getReleasesInformation?release_state=Announced
 
-# request related settings (e.g. default injection arguments)
-data.default_sw_version = "CMSSW_5_2_5"
-data.default_sw_scramarch = "slc5_amd64_gcc434"
-data.dqm_url = "%s/dqm/dev" % BASE_URL
-#use dbs testbed for private vm test
+# used for the StepChainParentageFixTask; use dbs testbed for private vm test
 if DBS_INS == "private_vm":
     data.dbs_url = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSWriter"
 else:

--- a/reqmgr2ms/config.py
+++ b/reqmgr2ms/config.py
@@ -2,7 +2,6 @@
 MicroService configuration file.
 """
 
-import os
 import socket
 from WMCore.Configuration import Configuration
 
@@ -11,6 +10,12 @@ HOST = socket.gethostname().lower()
 BASE_URL = "@@BASE_URL@@"
 LOG_REPORTER = "reqmgr2-ms"
 ROOTDIR = __file__.rsplit('/', 3)[0]
+
+if BASE_URL == "https://cmsweb.cern.ch":
+    RUCIO_ACCT = "production"
+else:
+    RUCIO_ACCT="wmagent_testing"
+
 config = Configuration()
 
 main = config.section_("main")
@@ -32,8 +37,8 @@ sec.key_file = "%s/auth/wmcore-auth/header-auth-key" % ROOTDIR
 # is reachable and this features in CMS web frontend rewrite rules
 app = config.section_(main.application)
 app.admin = "cms-service-webtools@cern.ch"
-app.description = "CMS data operations MicroService"
-app.title = "CMS MicroService"
+app.description = "CMS Workload Management MicroServices"
+app.title = "CMS MicroServices"
 
 # define different views for our application
 views = config.section_("views")
@@ -47,3 +52,4 @@ data = views.section_('data')
 data.object = 'WMCore.MicroService.Service.RestApiHub.RestApiHub'
 data.manager = 'WMCore.MicroService.Unified.Transferor.UnifiedTransferorManager'
 data.reqmgr2_url = "%s/reqmgr2" % BASE_URL
+data.rucioAccount = RUCIO_ACCT

--- a/reqmgr2ms/deploy
+++ b/reqmgr2ms/deploy
@@ -23,21 +23,40 @@ deploy_reqmgr2ms_sw()
     note "WARNING: replace certificates in $project_auth with real ones"
   else :; fi
 
+  # use rucio testbed for anything that is not production
+  rucio_host_url=http://cms-rucio-testbed.cern.ch
+  rucio_auth_url=https://cms-rucio-tb-authz.cern.ch
   case $variant in
-    prod )    base_url="https://cmsweb.cern.ch"         dbs_ins="prod";;
-    preprod ) base_url="https://cmsweb-testbed.cern.ch" dbs_ins="int";;
-    dev )     base_url="https://cmsweb-dev.cern.ch"     dbs_ins="dev";;
-    * )       base_url="https://`hostname -f`"          dbs_ins="private_vm";;
+    prod )
+        base_url="https://cmsweb.cern.ch"
+        rucio_host_url=http://cms-rucio.cern.ch
+        rucio_auth_url=https://cms-rucio-authz.cern.ch
+        ;;
+    preprod )
+        base_url="https://cmsweb-testbed.cern.ch"
+        ;;
+    dev )
+        base_url="https://cmsweb-dev.cern.ch"
+        ;;
+    * )
+        base_url="https://`hostname -f`"
+        ;;
   esac
-  perl -p -i -e "s{\"\@\@BASE_URL\@\@\"}{\"$base_url\"}g; \
-                 s{\"\@\@DBS_INS\@\@\"}{\"$dbs_ins\"}g"   \
+  perl -p -i -e "s{\"\@\@BASE_URL\@\@\"}{\"$base_url\"}g" \
        $root/$cfgversion/config/$project/config.py
+
+  # setup rucio configuration file
+  mkdir -p $root/$cfgversion/config/$project/etc
+  mv $root/$cfgversion/config/$project/rucio.cfg $root/$cfgversion/config/$project/etc/
+  perl -p -i -e "s{RUCIO_HOST_OVERWRITE}{$rucio_host_url}g; \
+                 s{RUCIO_AUTH_OVERWRITE}{$rucio_auth_url}g" \
+       $root/$cfgversion/config/$project/etc/rucio.cfg
 }
 
 deploy_reqmgr2ms_post()
 {
-  # enable crons only on prod/testbed nodes and no more
-  case $host in vocms0740 | vocms0731 ) enable;;  * ) disable;; esac
+  # in practice, enabled on private VMs, vocms0731 (preprod) and vocms0740 (prod)
+  case $host in vocms013[2689] | vocms073[89] | vocms074[12] | vocms016[135] ) disable;; * ) enable;; esac
   (mkcrontab; sysboot) | crontab -
 }
 

--- a/reqmgr2ms/manage
+++ b/reqmgr2ms/manage
@@ -49,6 +49,7 @@ export WMCORE_CACHE_DIR=$STATEDIR
 export UNIFIED_CONFIG_JSON=$CFGDIR/unifiedConfiguration.json
 export UNIFIED_CAMPAIGNS=$CFGDIR/campaigns.json
 export UNIFIED_CAMPAIGNS_RELVAL=$CFGDIR/campaigns.relval.json
+export RUCIO_HOME=$CFGDIR
 if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then
   export X509_USER_CERT=$AUTHDIR/dmwm-service-cert.pem
   export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem

--- a/reqmgr2ms/rucio.cfg
+++ b/reqmgr2ms/rucio.cfg
@@ -1,0 +1,20 @@
+# Copyright European Organization for Nuclear Research (CERN)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Vincent Garonne, <vgaronne@gmail.com>, 2017
+# - Eric Vaandering, <ewv@fnal.gov>, 2018
+
+[common]
+[client]
+rucio_host = RUCIO_HOST_OVERWRITE
+auth_host = RUCIO_AUTH_OVERWRITE
+auth_type = x509
+ca_cert = /etc/grid-security/certificates/
+client_cert = $X509_USER_CERT
+client_key = $X509_USER_KEY
+client_x509_proxy = $X509_USER_PROXY
+request_retries = 3

--- a/workqueue/config.py
+++ b/workqueue/config.py
@@ -25,7 +25,7 @@ REQMGR2 = "%s/reqmgr2" % BASE_URL
 WEBURL = "%s/%s" % (COUCH_URL, workqueueDBName)
 LOG_DB_URL = "%s/wmstats_logdb" % COUCH_URL
 LOG_REPORTER = "global_workqueue"
-AMQ_HOST_PORT = [('dashb-mb.cern.ch', 61113)]
+AMQ_HOST_PORT = [('cms-mb.cern.ch', 61313)]
 
 root = __file__.rsplit('/', 4)[0]
 cache_dir = os.path.join(root, 'state', 'workqueue', 'cache')
@@ -42,6 +42,11 @@ except ImportError:
     USER_AMQ=None
     PASS_AMQ=None
     AMQ_TOPIC=None
+
+if BASE_URL == "https://cmsweb.cern.ch":
+    RUCIO_ACCT = "production"
+else:
+    RUCIO_ACCT="wmagent_testing"
 
 config = Configuration()
 
@@ -71,13 +76,13 @@ sec.key_file = "%s/auth/wmcore-auth/header-auth-key" % ROOTDIR
 # is reachable and this features in CMS web frontend rewrite rules
 app = config.section_(main.application) # string containing "globalworkqueue"
 app.admin = "cms-service-webtools@cern.ch"
-app.description = "CMS data operations Global WorkQueue"
+app.description = "CMS Workload Management Global WorkQueue"
 app.title = " Global WorkQueue (GQ)"
 
 views = config.section_("views")
 
 def setWorkQueueCommonConfig(config):    
-    # actual params need to creaating global queue
+    # actual params needed to creating global queue
     config.queueParams = {}
     config.queueParams['CouchUrl'] = COUCH_URL
     config.queueParams['DbName'] = workqueueDBName
@@ -88,7 +93,8 @@ def setWorkQueueCommonConfig(config):
     config.queueParams['RequestDBURL'] = "%s/%s" % (COUCH_URL, reqmgrCouchDB)
     config.queueParams['central_logdb_url'] = LOG_DB_URL
     config.queueParams['log_reporter'] = LOG_REPORTER
-    
+    config.queueParams['rucioAccount'] = RUCIO_ACCT
+
     config.reqMgrConfig = {}
     config.reqMgrConfig['reqmgr2_endpoint'] = REQMGR2
     config.reqMgrConfig['central_logdb_url'] = LOG_DB_URL

--- a/workqueue/deploy
+++ b/workqueue/deploy
@@ -26,14 +26,35 @@ deploy_workqueue_sw()
     note "WARNING: replace certificates in $project_auth with real ones"
   else :; fi
 
+  # use rucio testbed for anything that is not production
+  rucio_host_url=http://cms-rucio-testbed.cern.ch
+  rucio_auth_url=https://cms-rucio-tb-authz.cern.ch
   case $variant in
-    prod )    base_url="https://cmsweb.cern.ch"         ;;
-    preprod ) base_url="https://cmsweb-testbed.cern.ch" ;;
-    dev )     base_url="https://cmsweb-dev.cern.ch"     ;;
-    * )       base_url="https://`hostname -f`"          ;;
+    prod )
+        base_url="https://cmsweb.cern.ch"
+        rucio_host_url=http://cms-rucio.cern.ch
+        rucio_auth_url=https://cms-rucio-authz.cern.ch
+        ;;
+    preprod )
+        base_url="https://cmsweb-testbed.cern.ch"
+        ;;
+    dev )
+        base_url="https://cmsweb-dev.cern.ch"
+        ;;
+    * )
+        base_url="https://`hostname -f`"
+        ;;
   esac
   perl -p -i -e "s{\"\@\@BASE_URL\@\@\"}{\"$base_url\"}g;" \
        $root/$cfgversion/config/$project/config.py
+
+  # setup rucio configuration file
+  mkdir -p $root/$cfgversion/config/$project/etc
+  mv $root/$cfgversion/config/$project/rucio.cfg $root/$cfgversion/config/$project/etc/
+  perl -p -i -e "s{RUCIO_HOST_OVERWRITE}{$rucio_host_url}g; \
+                 s{RUCIO_AUTH_OVERWRITE}{$rucio_auth_url}g" \
+       $root/$cfgversion/config/$project/etc/rucio.cfg
+
 }
 
 deploy_workqueue_post()

--- a/workqueue/manage
+++ b/workqueue/manage
@@ -47,6 +47,7 @@ export WMCORE_USE_CRIC=true
 export YUI_ROOT
 export WMAGENT_CONFIG=${CFGFILE}
 export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH
+export RUCIO_HOME=$CFGDIR
 
 export WMCORE_ROOT=$WORKQUEUE_ROOT/lib/python*/site-packages
 if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then

--- a/workqueue/rucio.cfg
+++ b/workqueue/rucio.cfg
@@ -1,0 +1,20 @@
+# Copyright European Organization for Nuclear Research (CERN)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Vincent Garonne, <vgaronne@gmail.com>, 2017
+# - Eric Vaandering, <ewv@fnal.gov>, 2018
+
+[common]
+[client]
+rucio_host = RUCIO_HOST_OVERWRITE
+auth_host = RUCIO_AUTH_OVERWRITE
+auth_type = x509
+ca_cert = /etc/grid-security/certificates/
+client_cert = $X509_USER_CERT
+client_key = $X509_USER_KEY
+client_x509_proxy = $X509_USER_PROXY
+request_retries = 3


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9067

Changes go beyond what was reported in the issue though, summary of changes is:
* updated the StompAMQ broker and port
* define rucio account during deployment of workqueue and reqmgr2ms
* point testbed services to a testbed rucio instance, production services to a production rucio service (the production one does NOT exist yet AFAIK)
* enable reqmgr2ms on private VMs, vocms0731 (preprod) and vocms0740 (prod)
* set RUCIO_HOME in the manage scripts (still checking whether this is the best choice though)