### PR TITLE
Prod and pre-prod rules for ReqMgr2 Microservices

### DIFF
--- a/frontend/backends-preprod.txt
+++ b/frontend/backends-preprod.txt
@@ -11,6 +11,7 @@
 ^/auth/complete/das(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/das2go(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/wmarchive(?:/|$) vocms0181.cern.ch
+^/auth/complete/microservice(?:/|$) vocms0731.cern.ch
 ^/auth/complete/scheddmon/0106/ vocms0106.cern.ch
 ^/auth/complete/scheddmon/0109/ vocms0109.cern.ch
 ^/auth/complete/scheddmon/0114/ vocms0114.cern.ch
@@ -29,6 +30,5 @@
 ^/auth/complete/scheddmon/0197/ vocms0197.cern.ch
 ^/auth/complete/scheddmon/0198/ vocms0198.cern.ch
 ^/auth/complete/scheddmon/0199/ vocms0199.cern.ch
-^/auth/complete/wmagent/cern0231 vocms0231.cern.ch
 ^/overview(?:/|$) vocms0132.cern.ch
 ^ vocms0132.cern.ch|vocms0731.cern.ch

--- a/frontend/backends-prod.txt
+++ b/frontend/backends-prod.txt
@@ -11,6 +11,7 @@
 ^/auth/complete/crabcache(?:/|$) vocms0741.cern.ch
 ^/auth/complete/confdb(?:/|$) vocms0741.cern.ch|vocms0742.cern.ch :affinity
 ^/auth/complete/wmarchive(?:/|$) vocms0182.cern.ch
+^/auth/complete/microservice(?:/|$) vocms0740.cern.ch
 ^/auth/complete/scheddmon/0106/ vocms0106.cern.ch
 ^/auth/complete/scheddmon/0109/ vocms0109.cern.ch
 ^/auth/complete/scheddmon/0114/ vocms0114.cern.ch


### PR DESCRIPTION
Added frontend rules for the ReqMgr2 Microservices. As per the deployment, it's enabled in:
* vocms0731 for pre-prod
* vocms0740 for prod

@vkuznet can you please review.
@h4d4 Lina, as we discussed on chat. Since you're going to redeploy testbed soon, it might be worth it to test these changes before merging it.