### PR TITLE
Remove CRIC env var for the WMCore central services

### DIFF
--- a/reqmgr2/manage
+++ b/reqmgr2/manage
@@ -45,7 +45,6 @@ WMCORE_BIN=$ROOT/apps/$ME/bin
 
 . $ROOT/apps/$ME/etc/profile.d/init.sh
 
-export WMCORE_USE_CRIC=true
 export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH
 export WMCORE_ROOT=$REQMGR2_ROOT/lib/python*/site-packages
 export REQMGR_CACHE_DIR=$STATEDIR

--- a/workqueue/manage
+++ b/workqueue/manage
@@ -43,7 +43,6 @@ COLOR_NORMAL="\\033[0;39m"
 
 . $ROOT/apps/$ME/etc/profile.d/init.sh
 
-export WMCORE_USE_CRIC=true
 export YUI_ROOT
 export WMAGENT_CONFIG=${CFGFILE}
 export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH


### PR DESCRIPTION
Making CRIC the default resource information system as of HG1905. 
Not ready to be merged yet.