### PR TITLE
New gp 766

### DIFF
--- a/admin/CmswebReport
+++ b/admin/CmswebReport
@@ -69,7 +69,7 @@ variant=$1
 case $variant in
   prod)
     frontends="vocms0158,vocms0160,vocms0162,vocms0164,vocms0760"
-    backends="vocms0136,vocms0161,vocms0163,vocms0165,vocms0738,vocms0739,vocms0740,vocms0741,vocms0742"
+    backends="vocms0136,vocms0161,vocms0163,vocms0165,vocms0738,vocms0739,vocms0740,vocms0741,vocms0742,vocms0766"
     couches="vocms0740,vocms0741,vocms0742"
     ;;
   preprod|dev)

--- a/admin/SyncLogs
+++ b/admin/SyncLogs
@@ -8,7 +8,7 @@ for h in vocms0{117,127,134,734,135,158,160,760,162,164}; do
 done
 
 # Back-ends in the AI infrastructure
-for h in vocms0{731,132,136,161,163,165,738,739,740,741,742}; do
+for h in vocms0{731,132,136,161,163,165,738,739,740,741,742,766}; do
   #Add new cipher aes128-ctr
   rsync -rm -e "ssh -c aes128-ctr -i $HOME/.ssh/id_dsa_backend" --append -f '+s */' -f '+s *.txt' -f '+s *.log*' -f '-s /***/*' cmsweb@$h:/data/srv/logs/ /build/srv-logs/$h/
 done

--- a/admin/deploy
+++ b/admin/deploy
@@ -35,7 +35,7 @@ deploy_admin_post()
 
   local pxlabel pxskip certs
   case $host in
-    vocms0117 | vocms0127 | vocms013[245689] | vocms0734| vocms073[189] | vocms0143 | vocms074[012] | vocms016[01235] | vocms0760 | vocms030[67] | vocms0318 | vocms0766)
+    vocms0117 | vocms0127 | vocms013[245689] | vocms0734| vocms073[189] | vocms0143 | vocms074[012] | vocms016[01235] | vocms076[06] | vocms030[67] | vocms0318 )
       pxlabel=cmsweb_backends ;;
     * )
       pxlabel=devvm_$(echo $host | tr - _) ;;

--- a/admin/deploy
+++ b/admin/deploy
@@ -35,7 +35,7 @@ deploy_admin_post()
 
   local pxlabel pxskip certs
   case $host in
-    vocms0117 | vocms0127 | vocms013[245689] | vocms0734| vocms073[189] | vocms0143 | vocms074[012] | vocms016[01235] | vocms0760 | vocms030[67] | vocms0318 )
+    vocms0117 | vocms0127 | vocms013[245689] | vocms0734| vocms073[189] | vocms0143 | vocms074[012] | vocms016[01235] | vocms0760 | vocms030[67] | vocms0318 | vocms0766)
       pxlabel=cmsweb_backends ;;
     * )
       pxlabel=devvm_$(echo $host | tr - _) ;;

--- a/confdb/deploy
+++ b/confdb/deploy
@@ -18,7 +18,7 @@ deploy_confdb_sw()
 
 deploy_confdb_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab; sysboot) | crontab -
 }
 

--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -43,7 +43,7 @@ deploy_couchdb_post()
 {
   (mkcrontab
    case $host in
-     vocms013[689] | vocms073[89] |vocms016[135] )
+     vocms013[689] | vocms073[89] |vocms016[135] | vocms0766 )
        disable ;;
      * )
        enable

--- a/crabcache/deploy
+++ b/crabcache/deploy
@@ -17,7 +17,7 @@ deploy_crabcache_sw()
 
 deploy_crabcache_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
 
   local cmd="$project_config/manage clean 3"
   $nogroups || cmd="sudo -H -u _crabcache bashs -l -c '$cmd'"

--- a/das/deploy
+++ b/das/deploy
@@ -33,7 +33,7 @@ deploy_das_sw()
 
 deploy_das_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0740 | vocms0766) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0740 | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
    for action in das_cleanup:'0 0-23/2 * * *'; do

--- a/das/deploy
+++ b/das/deploy
@@ -33,7 +33,7 @@ deploy_das_sw()
 
 deploy_das_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0740) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0740 | vocms0766) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
    for action in das_cleanup:'0 0-23/2 * * *'; do

--- a/dcafpilot/deploy
+++ b/dcafpilot/deploy
@@ -20,7 +20,7 @@ deploy_dcafpilot_sw()
 
 deploy_dcafpilot_post()
 {
-  case $host in vocms013[689] |vocms073[89] | vocms0143 | vocms074[012] | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] |vocms073[89] | vocms0143 | vocms074[012] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
    for action in dataframe:'50 20 * * 5' models:'15 18 * * *' verify:'10 3 * * *'; do

--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -35,7 +35,7 @@ deploy_dqmgui_sw()
 deploy_dqmgui_post()
 {
   case $host in
-    vocms013[26] |vocms0143 | vocms074[012] | vocms016[135] | vocms0307 | vocms0318 )
+    vocms013[26] |vocms0143 | vocms074[012] | vocms016[135] | vocms0307 | vocms0318 | vocms0766 )
       disable
       ;;
     * )

--- a/exporters/manage
+++ b/exporters/manage
@@ -82,7 +82,7 @@ start()
     # production nodes
     #
     # DBS on production nodes
-    vocms0136 | vocms0161 | vocms0163 | vocms0165 )
+    vocms0136 | vocms0161 | vocms0163 | vocms0165 | vocms0766 )
         # start process_exporter for DBS server
         wait4proc "DBSGlobalReader" # check for pattern that DBS is running
         process_monitor.sh ".*DBSGlobalReader" dbs_global_exporter ":18252" 15 \
@@ -120,7 +120,7 @@ start()
       ;;
 
     # Apache exporter on production nodes
-    vocms0158 | vocms0760 | vocms0162 | vocms0164 )
+    vocms0158 | vocms0760 | vocms0162 | vocms0164  | vocms0766 )
         # start apache_exporter for frontend
         wait4proc "httpd" # check for pattern that httpd is running
         apache_exporter -telemetry.address ":18443" \
@@ -208,7 +208,7 @@ status()
     local host=`hostname -s`
     case $host in
     # production nodes
-    vocms0136 | vocms0161 | vocms0163 | vocms0165 )
+    vocms0136 | vocms0161 | vocms0163 | vocms0165  | vocms0766 )
         # process exporter
         process_status "process_exporter"
       ;;
@@ -225,7 +225,7 @@ status()
         process_status "couchdb_exporter"
       ;;
 
-    vocms0158 | vocms0760 | vocms0162 | vocms0164 )
+    vocms0158 | vocms0760 | vocms0162 | vocms0164  | vocms0766 )
         # apache exporter
         process_status "apache_exporter"
       ;;

--- a/exporters/manage
+++ b/exporters/manage
@@ -120,7 +120,7 @@ start()
       ;;
 
     # Apache exporter on production nodes
-    vocms0158 | vocms0760 | vocms0162 | vocms0164  | vocms0766 )
+    vocms0158 | vocms0760 | vocms0162 | vocms0164 )
         # start apache_exporter for frontend
         wait4proc "httpd" # check for pattern that httpd is running
         apache_exporter -telemetry.address ":18443" \
@@ -225,7 +225,7 @@ status()
         process_status "couchdb_exporter"
       ;;
 
-    vocms0158 | vocms0760 | vocms0162 | vocms0164  | vocms0766 )
+    vocms0158 | vocms0760 | vocms0162 | vocms0164 )
         # apache exporter
         process_status "apache_exporter"
       ;;

--- a/filemover/deploy
+++ b/filemover/deploy
@@ -30,7 +30,7 @@ deploy_filemover_post()
 {
   (mkcrontab
    case $host in
-     vocms013[2689] | vocms073[89] | vocms016[135])
+     vocms013[2689] | vocms073[89] | vocms016[135] | vocms0766 )
        disable ;;
      * )
        enable

--- a/mongodb/deploy
+++ b/mongodb/deploy
@@ -16,6 +16,6 @@ deploy_mongodb_sw()
 
 deploy_mongodb_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab; sysboot) | crontab -
 }

--- a/overview/deploy
+++ b/overview/deploy
@@ -16,7 +16,7 @@ deploy_overview_sw()
 
 deploy_overview_post()
 {
-  case $host in vocms013[689] | vocms073[189] | vocms0143 | vocms074[012] | vocms016[15] | vocms030[67] | vocms0318 ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[189] | vocms0143 | vocms074[012] | vocms016[15] | vocms030[67] | vocms0318 | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab; sysboot
    cmd="$project_config/daily"
    $nogroups || cmd="sudo -H -u _overview bashs -l -c '$cmd'"

--- a/phedexreplicamonitoring/deploy
+++ b/phedexreplicamonitoring/deploy
@@ -18,7 +18,7 @@ deploy_phedexreplicamonitoring_sw()
 
 deploy_phedexreplicamonitoring_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms0740 | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms0740 | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
   for action in prmonitor:'0 0 * * *'; do

--- a/reqmgr2ms/deploy
+++ b/reqmgr2ms/deploy
@@ -56,7 +56,7 @@ deploy_reqmgr2ms_sw()
 deploy_reqmgr2ms_post()
 {
   # in practice, enabled on private VMs, vocms0731 (preprod) and vocms0740 (prod)
-  case $host in vocms013[2689] | vocms073[89] | vocms074[12] | vocms016[135] ) disable;; * ) enable;; esac
+  case $host in vocms013[2689] | vocms073[89] | vocms074[12] | vocms016[135] | vocms0766 ) disable;; * ) enable;; esac
   (mkcrontab; sysboot) | crontab -
 }
 

--- a/system/deploy
+++ b/system/deploy
@@ -380,7 +380,7 @@ deploy_system_post()
 
           note "IMPORTANT: run the following to update /root/.ssh/known_hosts"
           note "   sudo cfg/admin/ImageKey start"
-          note "   for h in vocms0{306,307,318,12{6,7,8},13{2,4,5,6,8,9},143,74{0,1,2},16{0,1,2,3,4,5},73{1,8,9}}{,.cern.ch}; do"
+          note "   for h in vocms0{306,307,318,12{6,7,8},13{2,4,5,6,8,9},143,74{0,1,2},16{0,1,2,3,4,5},73{1,8,9},766}{,.cern.ch}; do"
           note "     echo \$h; sudo cfg/admin/ImageKey run ssh cmsweb@\$h uptime"
           note "   done"
           note "   sudo cfg/admin/ImageKey stop"

--- a/tfaas/deploy
+++ b/tfaas/deploy
@@ -23,7 +23,7 @@ deploy_tfaas_sw()
 
 deploy_tfaas_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
   ) | crontab -

--- a/wmarchive/deploy
+++ b/wmarchive/deploy
@@ -22,7 +22,7 @@ deploy_wmarchive_sw()
 
 deploy_wmarchive_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms0143 | vocms074[012] | vocms016[135] ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms0143 | vocms074[012] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
    for action in migrate2hdfs:'*/10 0-23 * * *' aggregate-fwjr:'0 1,3,5,7,9,11,13,15,17,19,21,23 * * *' aggregate-crab:'0 0,2,4,6,8,10,12,14,16,18,20,22 * * *' cleanup:'0 2 * * *'; do

--- a/workqueue/deploy
+++ b/workqueue/deploy
@@ -59,7 +59,7 @@ deploy_workqueue_sw()
 
 deploy_workqueue_post()
 {
-  case $host in vocms013[2689] |vocms073[89] | vocms074[12] | vocms016[135] ) disable;; * ) enable;; esac
+  case $host in vocms013[2689] |vocms073[89] | vocms074[12] | vocms016[135] | vocms0766 ) disable;; * ) enable;; esac
   
   # Do cache cleanup
   local cmd="rm -rf $root/state/workqueue/cache/*"


### PR DESCRIPTION
This PR updates deployments scripts to include new general propose backend(gp) that will be called vocms0766

- Regarding commit '[648f895](https://github.com/dmwm/deployment/commit/648f895c685c469cdeec47dd25cd37e74aafb135) '  below is the list of `services*/deployment` where general propose backends are `'disable'`, therefore on those scripts the new gp need to be included:

```
#gps ARE LISTED TO BE 'disable' =>  below services are NOT DEPLOYED in gps nodes
confdb
couchdb
crabcache
das
dcafpilot (no deployed anymore in the cluster)
dqmgui
filemover
mongodb
overview (no deployed anymore in the cluster)
phedexreplicamonitoring
reqmgr2ms (until now just in testbed nodes)
tfaas
wmarchive (##updating their deployment script even when this is not deployed into cluster)
```
In that commit I've also included `exporters/manage`, the script made a explicity list of nodes where exporters runs, and there gps are listed.

-  I've not modified below  `services*/deployment` scripts due to gps are not listed to be  'disable', it means that those services are deployed into gps, then is not necessary update it:
```
###SERVICES WHERE GPS ARE no LISTED TO BE 'disable' => below services are DEPLOYED in GPS nodes ##deployment updates, is not necessary
crabserver
dbs
dbsmigration
dbsweb (no deployed anymore in the cluster)
dmwmmon
exporters
gitweb (no deployed anymore in the cluster)
phedex
popdbweb
reqmgr2 
reqmon
sitedb
t0_reqmon = CMS T0 WMStats (T0ReqMon)
t0wmadatasvc
victorweb
```
`NOTE: ` 
In the end, what decides if x deployed service process queries or no, are `fronted-rules` [(backends-prod.txt)](https://github.com/dmwm/deployment/blob/master/frontend/backends-prod.txt). So, there are cases where one service is deployed in several cmsweb's nodes but service's requests are redirected to certain of those nodes  by `fronted-rules`  
Looks like that configuration of deploy services in nodes where finally request will no be handled is part of the way in which the cluster was designed.

- I've not included the commit for `frontends-backends rules` because, it need to be done once the node is complete functionally. 
