### PR TITLE
Enable strict mode in MariaDB; change file format to Barracuda; enable large prefix; other tweaks

### DIFF
--- a/wmagent/my.cnf
+++ b/wmagent/my.cnf
@@ -1,18 +1,18 @@
 [mysqld]
-max_allowed_packet=128M
-transaction-isolation = READ-COMMITTED
+# only STRICT_TRANS_TABLES mode is not default in MariaDB 10.1.x
+sql_mode="NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"
+transaction-isolation=READ-COMMITTED
 
+max_heap_table_size=2048M
+max_allowed_packet=128M
 max_connections = 200
 connect_timeout = 60
 
-innodb_log_file_size=512M
-innodb_log_buffer_size=8M
-innodb_buffer_pool_size=2G
-innodb_additional_mem_pool_size=50M
-#set-variable = transaction-isolation = READ-COMMITTED
 binlog_format=row
+tmp_table_size=2048M
+long_query_time=5
 
-key_buffer=4000M
+key_buffer_size=4000M
 
 query_cache_type=1
 query_cache_limit=10M
@@ -21,32 +21,19 @@ query_cache_size=128M
 # threading
 thread_cache_size = 64
 thread_cache_size = 16
-thread_concurrency = 4
 thread_stack = 192K
 
-# inodb
+# innodb
 innodb_thread_concurrency=0
 innodb_concurrency_tickets=10000
 innodb_commit_concurrency=0
 innodb_flush_method=O_DIRECT
 innodb_file_io_threads = 4
-innodb_checksums=0
+innodb_checksum_algorithm=NONE
 innodb_doublewrite=0
-innodb_locks_unsafe_for_binlog = true
-
-max_heap_table_size=2048M
-tmp_table_size=2048M
-
-long_query_time=5
+innodb_log_file_size=512M
+innodb_log_buffer_size=8M
+innodb_buffer_pool_size=2G
 innodb_sync_spin_loops=60
-
 innodb_force_recovery = 0
 innodb_lock_wait_timeout = 100
-
-[mysql.server]
-STRICT_TRANS_TABLES=1
-transaction-isolation = READ-COMMITTED
-tx_isolation=READ-COMMITTED
-
-
-

--- a/wmagent/my.cnf
+++ b/wmagent/my.cnf
@@ -37,3 +37,15 @@ innodb_buffer_pool_size=2G
 innodb_sync_spin_loops=60
 innodb_force_recovery = 0
 innodb_lock_wait_timeout = 100
+
+# Changes to support DYNAMIC / COMPRESSED row format
+innodb_file_format=Barracuda
+innodb_file_per_table=ON
+# supports prefix index larger than 767 bytes (might be already implicit in the DYNAMIC mode?)
+innodb_large_prefix=ON
+innodb_strict_mode=ON
+#innodb_page_size=32k  # default is 16k
+
+# Introduced in MariaDB 10.1.32, COMP is currently using 10.1.21
+# If COMPRESSED is used, it cannot be set globally and has to be passed in the CREATE TABLE statement
+#innodb_default_row_format=DYNAMIC


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9242

Apparently we were not using the strict mode in MariaDB since the migration from MySQL (different syntax in the config file).
Option `tx_isolation` was completely removed, apparently we only depend on `transaction-isolation`.

A few other options were removed/updated according to the MariaDB logs:
```
2019-06-04 18:07:24 140249885366400 [Warning] No argument was provided to --log-bin and neither --log-basename or --log-bin-index where used;  This may cause repliction to break when this server acts as a master and has its hostname changed! Please use '--log-basename=vocms0260.cern.ch' or '--log-bin=mysqld-bin' to avoid this problem.
2019-06-04 18:07:24 140249885366400 [Note] Using unique option prefix 'key_buffer' is error-prone and can break in the future. Please use the full name 'key_buffer_size' instead.
2019-06-04 18:07:24 140249885366400 [Warning] 'THREAD_CONCURRENCY' is deprecated and will be removed in a future release.
2019-06-04 18:07:25 7f8e7898d880 InnoDB: Warning: Using innodb_additional_mem_pool_size is DEPRECATED. This option may be removed in future releases, together with the option innodb_use_sys_malloc and with the InnoDB's internal memory allocator.
2019-06-04 18:07:25 7f8e7898d880 InnoDB: Warning: Setting innodb_checksums to OFF is DEPRECATED. This option may be removed in future releases. You should set innodb_checksum_algorithm=NONE instead.
2019-06-04 18:07:25 7f8e7898d880 InnoDB: Warning: Using innodb_locks_unsafe_for_binlog is DEPRECATED. This option may be removed in future releases. Please use READ COMMITTED transaction isolation level instead, see http://dev.mysql.com/doc/refman/5.6/en/set-transaction.html.
```