### PR TITLE
Move ReqMgr2 CherryPy thread to 0731 in testbed

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -123,7 +123,7 @@ ui_main.application = ui.index
 
 extentions = config.section_("extensions")
 # Production instance of wmdatamining, must be a production back-end
-if HOST.startswith("vocms0766") or HOST.startswith("vocms0132") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
+if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
 #     wmdatamining = extentions.section_("wmdatamining")
 #     wmdatamining.object = "WMCore.ReqMgr.CherryPyThreads.WMDataMining.WMDataMining"
 #     wmdatamining.wmstats_url = "%s/%s" % (data.couch_host, data.couch_wmstats_db)


### PR DESCRIPTION
Same as https://github.com/dmwm/deployment/pull/784 , but for pre-production.
Lina, same procedure applies.
1. Patch vocms0132 and restart reqmgr2
2. patch vocms0731 and restart reqmgr2

Make sure to deploy the new backend with these changes in `cfg`.
Can you please also update the wiki page: https://cms-http-group.web.cern.ch/cms-http-group/activity.html

Thanks