### PR TITLE
Update entry point for the ReqMgr2 MS; added more configuration param

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -181,6 +181,7 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswi
     auxCacheUpdateTasks.tagCollectDuration = 60 * 60  # every 1 hour
     auxCacheUpdateTasks.tagcollect_url = "https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML"
     auxCacheUpdateTasks.tagcollect_args = {"anytype": 1, "anyarch": 1}
+    auxCacheUpdateTasks.unified_url = "https://raw.githubusercontent.com/CMSCompOps/WmAgentScripts/master/unifiedConfiguration.json"
     auxCacheUpdateTasks.log_file = '%s/logs/reqmgr2/auxCacheUpdateTasks-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
     auxCacheUpdateTasks.central_logdb_url = LOG_DB_URL
     auxCacheUpdateTasks.log_reporter = LOG_REPORTER

--- a/reqmgr2ms/config.py
+++ b/reqmgr2ms/config.py
@@ -51,12 +51,13 @@ ui.static = ROOTDIR
 # REST interface
 data = views.section_('data')
 data.object = 'WMCore.MicroService.Service.RestApiHub.RestApiHub'
-data.manager = 'WMCore.MicroService.Unified.Transferor.UnifiedTransferorManager'
+data.manager = 'WMCore.MicroService.Unified.MSManager.MSManager'
 data.reqmgr2Url = "%s/reqmgr2" % BASE_URL
 data.readOnly = True
 data.verbose = True
 data.interval = 600
 data.rucioAccount = RUCIO_ACCT
+data.phedexUrl = "https://cmsweb.cern.ch/phedex/datasvc/json/prod"
 # if private_vm, just fallback to preprod DBS
 if DBS_INS == "private_vm":
     data.dbsUrl = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"


### PR DESCRIPTION
New configuration parameters used for:
* automatically fetch the unified configuration from the ReqMgr2 cherrypy thread
* additional ReqMgr2MS configuration (instead of using it from the unified config)