### PR TITLE
Removing frontend rules for victorweb decommissioning

### DIFF
--- a/frontend/app_victorweb_nossl.conf
+++ b/frontend/app_victorweb_nossl.conf
@@ -1,1 +1,0 @@
-RewriteRule ^(/victor(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]

--- a/frontend/app_victorweb_ssl.conf
+++ b/frontend/app_victorweb_ssl.conf
@@ -1,2 +1,0 @@
-RewriteRule ^(/victor(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
-RewriteRule ^/auth/complete(/victor(/.*)?)$ http://%{ENV:BACKEND}:8320${escape:$1} [QSA,P,L,NE]

--- a/frontend/htdocs/index.html
+++ b/frontend/htdocs/index.html
@@ -33,9 +33,6 @@
             <a href="/dqm/relval">RelVal</a>,
             <a href="/dqm/dev">Development</a>
           </li>
-	  <li class="box">Data Popularity:
-	    <a href="/victor/accounting">Victor - The Cleaner</a>
-	  </li>
           <li class="box">Site systems:
              <a href="/sitedb/">SiteDB</a>,
              <a href="https://hammercloud.cern.ch/hc/app/cms/">HammerCloud</a>,


### PR DESCRIPTION
This PR is to get rid off of victorweb frontend accessing, as part of their decommissioning.