### PR TITLE
Update WQ location update polling cycle; update Rucio testbed url

### DIFF
--- a/reqmgr2ms/deploy
+++ b/reqmgr2ms/deploy
@@ -25,13 +25,13 @@ deploy_reqmgr2ms_sw()
 
   # use rucio testbed for anything that is not production
   rucio_host_url=http://cms-rucio-testbed.cern.ch
-  rucio_auth_url=https://cms-rucio-tb-authz.cern.ch
+  rucio_auth_url=https://cms-rucio-auth-testbed.cern.ch
   case $variant in
     prod )
         base_url="https://cmsweb.cern.ch"
         dbs_ins="prod"
         rucio_host_url=http://cms-rucio.cern.ch
-        rucio_auth_url=https://cms-rucio-authz.cern.ch
+        rucio_auth_url=https://cms-rucio-auth.cern.ch
         ;;
     preprod )
         base_url="https://cmsweb-testbed.cern.ch"

--- a/workqueue/config.py
+++ b/workqueue/config.py
@@ -115,7 +115,7 @@ if HOST.startswith("vocms0740") or HOST.startswith("vocms0731") or HOST.startswi
     locationUpdateTask = extentions.section_("locationUpdateTask")
     locationUpdateTask.object = "WMCore.GlobalWorkQueue.CherryPyThreads.LocationUpdateTask.LocationUpdateTask"
     setWorkQueueCommonConfig(locationUpdateTask)
-    locationUpdateTask.locationUpdateDuration = 60 * 20 # every 20 minutes
+    locationUpdateTask.locationUpdateDuration = 60 * 60 * 6 # every 6 hours
     locationUpdateTask.log_file = '%s/logs/workqueue/locationUpdateTask-%s.log' % (__file__.rsplit('/', 4)[0], time.strftime("%Y%m%d"))
     locationUpdateTask.central_logdb_url = LOG_DB_URL
     locationUpdateTask.log_reporter = LOG_REPORTER

--- a/workqueue/deploy
+++ b/workqueue/deploy
@@ -28,12 +28,12 @@ deploy_workqueue_sw()
 
   # use rucio testbed for anything that is not production
   rucio_host_url=http://cms-rucio-testbed.cern.ch
-  rucio_auth_url=https://cms-rucio-tb-authz.cern.ch
+  rucio_auth_url=https://cms-rucio-auth-testbed.cern.ch
   case $variant in
     prod )
         base_url="https://cmsweb.cern.ch"
         rucio_host_url=http://cms-rucio.cern.ch
-        rucio_auth_url=https://cms-rucio-authz.cern.ch
+        rucio_auth_url=https://cms-rucio-auth.cern.ch
         ;;
     preprod )
         base_url="https://cmsweb-testbed.cern.ch"


### PR DESCRIPTION
Fix Rucio testbed URL; increase the workqueue polling cycle for the `locationUpdateTask` cherrypy thread to 6 hours.