### PR TITLE
Added quota parameters for MSTransferor/ReqMgr2MS

### DIFF
--- a/reqmgr2ms/config-transferor.py
+++ b/reqmgr2ms/config-transferor.py
@@ -70,6 +70,9 @@ data.readOnly = True
 data.verbose = True
 data.interval = 600
 data.services = ['transferor']
+data.quotaUsage = 0.8
+data.quotaAccount = "DataOps"
+data.minimumThreshold = 1 * (1000 ** 4)  # 1 TB (terabyte)
 data.rucioAccount = RUCIO_ACCT
 data.phedexUrl = "https://cmsweb.cern.ch/phedex/datasvc/json/prod"
 # if private_vm, just fallback to preprod DBS


### PR DESCRIPTION
Changes are needed for WMCore >= 1.2.9.pre2, where we use Detox and PhEDEx/Rucio for data management (quota + usage).
These are the same defaults put in in the code, but better adding it to the config as well to make sure we are aware that we can configure those.