### PR TITLE
Use a single stdout log file

### DIFF
--- a/couchdb/manage
+++ b/couchdb/manage
@@ -60,7 +60,7 @@ start()
 {
   cd $STATEDIR
   couchdb -A $CFGDIR/ -a $KEYFILE -b \
-    -o $LOGDIR/$(date +%Y%m%d-%H%M%S).stdout \
+    -o /dev/null \
     -e $LOGDIR/$(date +%Y%m%d-%H%M%S).stderr \
     -p $STATEDIR/couchdb.pid </dev/null >/dev/null 2>&1
 

--- a/wmagent/manage
+++ b/wmagent/manage
@@ -572,7 +572,7 @@ start_couch(){
     couchdb -b -a $CONFIG_COUCH/local.ini \
             -p $INSTALL_COUCH/logs/couchdb.pid \
             -e $INSTALL_COUCH/logs/stderr.log \
-            -o $INSTALL_COUCH/logs/stdout.log
+            -o /dev/null
     if [ $COUCH_INIT_DONE -eq 0 ]; then
 	echo "CouchDB has not been initialised... running post initialisation"
 	init_couch_post;


### PR DESCRIPTION
I have always noticed that we keep 3 logs for CouchDB:
* couch.log (as defined in the local.ini configuration file)
* ###.stdout (standard stdout defined by the manage script)
* ###.stderr (standard stdout defined by the manage script)

where the *only* difference between couch.log and the stdout one, is a timestamp!!

Given that the Couch logs are huge, let's reduce it by half!