### PR TITLE
Removing already decommisioned nodes vocms0{127 134} from the list

### DIFF
--- a/admin/SyncLogs
+++ b/admin/SyncLogs
@@ -3,7 +3,7 @@
 # Rsync append only .txt and .log files
 
 # Front-ends in the AI infrastructure
-for h in vocms0{117,127,134,734,135,158,160,760,162,164}; do
+for h in vocms0{117,734,135,158,760,162,164}; do
   rsync -rm -e "ssh -c aes128-ctr" --append -f '+s */' -f '+s *.txt' -f '+s *.log' -f '-s /***/*' cmsweb@$h:/data/srv/logs/ /build/srv-logs/$h/
 done
 


### PR DESCRIPTION
This PR update the list, removing already decommissioned nodes, those are  vocms0{127 134} 
