### PR TITLE
Further changes necessary to start using new CouchDB backends

### DIFF
--- a/admin/SplitCouchLogs
+++ b/admin/SplitCouchLogs
@@ -2,7 +2,7 @@
 
 #Split CouchDB logs according to the rules defined in couchdb-logrotate.conf
 
-for host in vocms0{117,127,731,132,740,741,742,743,744}; do
+for host in vocms0{117,127,731,132,740,742,743,744}; do
   OUT=$(ssh $host "sudo logrotate /data/srv/current/config/couchdb/couchdb-logrotate.conf")
   if [ "$OUT" == "ROTATE" ]; then
     mv /build/srv-logs/$host/couchdb/{couch.log,couch-$(date +%Y%m%d).log}

--- a/admin/SyncLogs
+++ b/admin/SyncLogs
@@ -10,7 +10,7 @@ done
 # Back-ends in the AI infrastructure
 for h in vocms0{731,132,136,161,163,165,738,739,740,741,742,766,743,744}; do
   #Add new cipher aes128-ctr
-  rsync -rm -e "ssh -c aes128-ctr -i $HOME/.ssh/id_dsa_backend" --append -f '+s */' -f '+s *.txt' -f '+s *.log*' -f '-s /***/*' --exclude='couch.log' cmsweb@$h:/data/srv/logs/ /build/srv-logs/$h/
+  rsync -rm -e "ssh -c aes128-ctr -i $HOME/.ssh/id_dsa_backend" --append -f '+s */' -f '+s *.txt' -f '+s *.log*' -f '-s /***/*' cmsweb@$h:/data/srv/logs/ /build/srv-logs/$h/
 done
 
 # Delete files not modified in the last 7 days

--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -43,7 +43,7 @@ deploy_couchdb_post()
 {
   (mkcrontab
    case $host in
-     vocms013[689] | vocms073[89] |vocms016[135] | vocms0766 )
+     vocms013[689] | vocms073[89] |vocms016[135] | vocms0741 | vocms0766 )
        disable ;;
      * )
        enable
@@ -62,11 +62,10 @@ deploy_couchdb_post()
          vocms0127 ) tohost=vocms0127 hour=1;;
          vocms0132 ) tohost=vocms0731 hour=1;;
          vocms0731 ) tohost=vocms0132 hour=2;;
-         vocms0740 ) tohost=vocms0731 hour=3;;
-         vocms0740 ) tohost=vocms0743 hour=12;;
-         vocms0742 ) tohost=vocms0744 hour=12;;
-         vocms0743 ) tohost=vocms0740 hour=12;;
-         vocms0744 ) tohost=vocms0742 hour=12;;
+         vocms0740 ) tohost=vocms0742 hour=2;;
+         vocms0742 ) tohost=vocms0743 hour=3;;
+         vocms0743 ) tohost=vocms0744 hour=4;;
+         vocms0744 ) tohost=vocms0740 hour=5;;
                  * ) tohost=;;
        esac
        [ -z "$tohost" ] ||
@@ -76,7 +75,7 @@ deploy_couchdb_post()
 
   # Weekly archive backups to castor
   case $host in
-    vocms012[67] | vocms0132 | vocms0731 | vocms0143 | vocms074[012] | vocms0307 | vocms0318 )
+    vocms0127 | vocms0132 | vocms0731 | vocms074[0234] )
       klist -s # must have afs kerberos token
       (acrontab -l | { fgrep -v -e " $host $project_config/" || true; }
        echo "#30 4 * * 0 $host $project_config/manage archive /castor/cern.ch/cms/archive/cmsweb/backups 'I did read documentation'") | acrontab

--- a/dmwmmon/deploy
+++ b/dmwmmon/deploy
@@ -29,7 +29,7 @@ deploy_dmwmmon_sw()
 deploy_dmwmmon_post()
 {
   case $host in
-    vocms013[89] | vocms073[89] |vocms0143 | vocms074[012] | vocms0307 | vocms0318 )
+    vocms013[89] | vocms073[89] |vocms0143 | vocms074[01234] | vocms0307 | vocms0318 )
       disable
       opts="" ;;
     * )

--- a/exporters/deploy
+++ b/exporters/deploy
@@ -17,7 +17,7 @@ deploy_exporters_sw()
 
 deploy_exporters_post()
 {
-  case $host in vocms073[89]) disable ;; * ) enable ;; esac
+  case $host in vocms073[89] ) disable ;; * ) enable ;; esac
   (mkcrontab
    echo "@reboot sudo bashs -l -c \"$project_config/manage sysboot 'I did read documentation'\""
   ) | crontab -

--- a/exporters/manage
+++ b/exporters/manage
@@ -123,14 +123,10 @@ start()
               </dev/null 2>&1 | rotatelogs $LOGDIR/das_exporter-%Y%m%d.log 86400 >/dev/null 2>&1 &
         mongodb_exporter -mongodb.uri mongodb://localhost:8230 --web.listen-address ":18230" \
               </dev/null 2>&1 | rotatelogs $LOGDIR/mongodb_exporter-%Y%m%d.log 86400 >/dev/null 2>&1 &
-        wait4proc "couchdb" # check for pattern that couchdb is running
-        couchdb_exporter -couchdb.uri="http://localhost:5984" \
-            -databases="_all_dbs" -databases.views=true -telemetry.address=":15984" \
-              </dev/null 2>&1 | rotatelogs $LOGDIR/couchdb_exporter-%Y%m%d.log 86400 >/dev/null 2>&1 &
       ;;
 
     # CouchDB on production nodes
-    vocms0740 | vocms0743 | vocms0744)
+    vocms0740 | vocms0742 | vocms0743 | vocms0744)
         wait4proc "couchdb" # check for pattern that couchdb is running
         couchdb_exporter -couchdb.uri="http://localhost:5984" \
             -databases="_all_dbs" -databases.views=true -telemetry.address=":15984" \

--- a/frontend/backends-preprod.txt
+++ b/frontend/backends-preprod.txt
@@ -3,15 +3,17 @@
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|relval-test)(?:/|$) vocms0731.cern.ch
-^/auth/complete/(?:couchdb2)(?:/|$) vocms0132.cern.ch  :affinity
-^/auth/complete/(?:couchdb|workqueue|wmstats|workloadsummary|alertscollector|tier0_wmstats|t0_workloadsummary|acdcserver)(?:/|$) vocms0731.cern.ch :affinity
-^/auth/complete/(?:c)(?:couchdb|workqueue|wmstats|workloadsummary|alertscollector|tier0_wmstats|t0_workloadsummary|acdcserver)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:c?)(?:couchdb/workqueue|workqueue)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats|wmstats|workloadsummary|wmstats_logdb)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats|t0_workloadsummary|t0_request|t0_logdb)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:c?)(?:couchdb|acdcserver)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/crabcache(?:/|$) vocms0731.cern.ch
 ^/auth/complete/confdb(?:/|$) vocms0731.cern.ch|vocms0132.cern.ch
 ^/auth/complete/das(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/das2go(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/wmarchive(?:/|$) vocms0181.cern.ch
-^/auth/complete/microservice(?:/|$) vocms0731.cern.ch
+^/auth/complete/ms-transferor(?:/|$) vocms0731.cern.ch
+^/auth/complete/ms-monitor(?:/|$) vocms0731.cern.ch
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch
 ^/auth/complete/scheddmon/0106/ vocms0106.cern.ch

--- a/frontend/backends-prod.txt
+++ b/frontend/backends-prod.txt
@@ -3,14 +3,17 @@
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|relval-test)(?:/|$) vocms0731.cern.ch
-^/auth/complete/(?:couchdb/wmstats|wmstats)(?:/|$) vocms0742.cern.ch :affinity
-^/auth/complete/(?:c?)(?:couchdb|workqueue|workloadsummary|alertscollector|analysis_workqueue|analysis_wmstats|tier0_wmstats|t0_workloadsummary|acdcserver)(?:/|$) vocms0740.cern.ch :affinity
+^/auth/complete/(?:c?)(?:couchdb/workqueue|workqueue)(?:/|$) vocms0740.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats|wmstats|workloadsummary|wmstats_logdb)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats|t0_workloadsummary|t0_request|t0_logdb)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:c?)(?:couchdb|acdcserver)(?:/|$) vocms0742.cern.ch :affinity
 ^/auth/complete/das(?:/|$) vocms0741.cern.ch|vocms0742.cern.ch :affinity
 ^/auth/complete/das2go(?:/|$) vocms0741.cern.ch|vocms0742.cern.ch :affinity
 ^/auth/complete/crabcache(?:/|$) vocms0741.cern.ch
 ^/auth/complete/confdb(?:/|$) vocms0741.cern.ch|vocms0742.cern.ch :affinity
 ^/auth/complete/wmarchive(?:/|$) vocms0182.cern.ch
-^/auth/complete/microservice(?:/|$) vocms0740.cern.ch
+^/auth/complete/ms-transferor(?:/|$) vocms0742.cern.ch
+^/auth/complete/ms-monitor(?:/|$) vocms0742.cern.ch
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch
 ^/auth/complete/scheddmon/0106/ vocms0106.cern.ch

--- a/frontend/backends-prod.txt
+++ b/frontend/backends-prod.txt
@@ -3,7 +3,6 @@
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|relval-test)(?:/|$) vocms0731.cern.ch
-^/auth/complete/(?:couchdb2)(?:/|$) vocms0741.cern.ch :affinity
 ^/auth/complete/(?:couchdb/wmstats|wmstats)(?:/|$) vocms0742.cern.ch :affinity
 ^/auth/complete/(?:c?)(?:couchdb|workqueue|workloadsummary|alertscollector|analysis_workqueue|analysis_wmstats|tier0_wmstats|t0_workloadsummary|acdcserver)(?:/|$) vocms0740.cern.ch :affinity
 ^/auth/complete/das(?:/|$) vocms0741.cern.ch|vocms0742.cern.ch :affinity

--- a/mongodb/deploy
+++ b/mongodb/deploy
@@ -16,6 +16,6 @@ deploy_mongodb_sw()
 
 deploy_mongodb_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 |vocms074[34]) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 |vocms074[034] ) disable ;; * ) enable ;; esac
   (mkcrontab; sysboot) | crontab -
 }

--- a/phedexreplicamonitoring/deploy
+++ b/phedexreplicamonitoring/deploy
@@ -18,7 +18,7 @@ deploy_phedexreplicamonitoring_sw()
 
 deploy_phedexreplicamonitoring_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms074[034] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms074[01234] | vocms016[135] | vocms0766 ) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
   for action in prmonitor:'0 0 * * *'; do

--- a/popdbweb/deploy
+++ b/popdbweb/deploy
@@ -28,7 +28,7 @@ deploy_popdbweb_sw()
 deploy_popdbweb_post()
 {
   case $host in
-    vocms013[89] | vocms073[89] | vocms014[0123] | vocms0307 | vocms0318 | vocms074[34])
+    vocms013[89] | vocms073[89] | vocms014[0123] | vocms0307 | vocms0318 | vocms074[01234] )
       disable
       ;;
     * )

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -42,8 +42,9 @@ deploy_reqmgr2_sw()
 
 deploy_reqmgr2_post()
 {
+  # in practice, general purpose backends and vocms0742 (prod, for couchapps)
   case $host in
-    vocms013[89] | vocms073[89] | vocms074[1234] )
+    vocms013[89] | vocms073[89] | vocms074[0134] )
       disable;;
     * )
       enable;;

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -42,7 +42,12 @@ deploy_reqmgr2_sw()
 
 deploy_reqmgr2_post()
 {
-  case $host in vocms013[89] | vocms073[89] | vocms074[12] ) disable;;  * ) enable;; esac
+  case $host in
+    vocms013[89] | vocms073[89] | vocms074[1234] )
+      disable;;
+    * )
+      enable;;
+    esac
 
   # ReqMgr2 and old reqmgr specific couchdb stuff
   # Tell couch to pick up reqmgr on the next restart

--- a/reqmgr2ms/deploy
+++ b/reqmgr2ms/deploy
@@ -64,9 +64,9 @@ deploy_reqmgr2ms_sw()
 
 deploy_reqmgr2ms_post()
 {
-  # in practice, enabled on private VMs, vocms0731 (preprod) and vocms0740 (prod)
+  # in practice, enabled on private VMs, vocms0731 (preprod) and vocms0742 (prod)
   case $host in
-    vocms013[2689] | vocms073[89] | vocms074[1234] | vocms016[135] | vocms0766 )
+    vocms013[2689] | vocms073[89] | vocms074[0134] | vocms016[135] | vocms0766 )
       disable;;
     * )
       enable;;

--- a/reqmgr2ms/deploy
+++ b/reqmgr2ms/deploy
@@ -65,7 +65,12 @@ deploy_reqmgr2ms_sw()
 deploy_reqmgr2ms_post()
 {
   # in practice, enabled on private VMs, vocms0731 (preprod) and vocms0740 (prod)
-  case $host in vocms013[2689] | vocms073[89] | vocms074[1234] | vocms016[135] | vocms0766 ) disable;; * ) enable;; esac
+  case $host in
+    vocms013[2689] | vocms073[89] | vocms074[1234] | vocms016[135] | vocms0766 )
+      disable;;
+    * )
+      enable;;
+    esac
   (mkcrontab; sysboot) | crontab -
 }
 

--- a/reqmon/deploy
+++ b/reqmon/deploy
@@ -42,7 +42,13 @@ deploy_reqmon_sw()
 
 deploy_reqmon_post()
 {
-  case $host in vocms013[89] | vocms073[89] ) disable;;  * ) enable;; esac
+  # in practice, general purpose backends and vocms0743 (prod, for couchapps)
+  case $host in
+    vocms013[89] | vocms073[89] | vocms074[0124] )
+      disable;;
+    * )
+      enable;;
+    esac
 
   # Tell couch to push the reqmon app on the next restart
   for couch in couchdb:5984; do

--- a/t0_reqmon/deploy
+++ b/t0_reqmon/deploy
@@ -40,7 +40,13 @@ deploy_t0_reqmon_sw()
 
 deploy_t0_reqmon_post()
 {
-  case $host in vocms013[89] | vocms073[89] ) disable;;  * ) enable;; esac
+  # in practice, general purpose backends and vocms0744 (prod, for couchapps)
+  case $host in
+    vocms013[89] | vocms073[89] | vocms074[0123] )
+      disable;;
+    * )
+      enable;;
+    esac
   
   # Tell couch to push the t0_reqmon app on the next restart
   for couch in couchdb:5984; do

--- a/tfaas/deploy
+++ b/tfaas/deploy
@@ -23,7 +23,7 @@ deploy_tfaas_sw()
 
 deploy_tfaas_post()
 {
-  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 | vocms074[34]) disable ;; * ) enable ;; esac
+  case $host in vocms013[689] | vocms073[89] | vocms016[135] | vocms0766 | vocms074[01234] ) disable ;; * ) enable ;; esac
   (mkcrontab
    sysboot
   ) | crontab -

--- a/workqueue/deploy
+++ b/workqueue/deploy
@@ -59,7 +59,12 @@ deploy_workqueue_sw()
 
 deploy_workqueue_post()
 {
-  case $host in vocms013[2689] |vocms073[89] | vocms074[12] | vocms016[135] | vocms0766 ) disable;; * ) enable;; esac
+  case $host in
+    vocms013[2689] | vocms073[89] | vocms074[1234] | vocms016[135] | vocms0766 )
+      disable;;
+    * )
+      enable;;
+    esac
   
   # Do cache cleanup
   local cmd="rm -rf $root/state/workqueue/cache/*"

--- a/workqueue/deploy
+++ b/workqueue/deploy
@@ -59,6 +59,7 @@ deploy_workqueue_sw()
 
 deploy_workqueue_post()
 {
+  # in practice, enabled it on private VMs, vocms0731 (preprod) and vocms0740 (prod)
   case $host in
     vocms013[2689] | vocms073[89] | vocms074[1234] | vocms016[135] | vocms0766 )
       disable;;


### PR DESCRIPTION
Follow up of this PR:
https://github.com/dmwm/deployment/pull/822

In short, the first commit contains:
* removal of couchdb service from vocms0741
* and deployment (or not) of services into the two new backends (vocms0743 and vocms0744)
* spread the backup load of couch backups as much as possible

and the second commit does:
* redistribution of the couchdb databases to different backends (which means services are enabled/disabled in different backends)
* thus, new frontend rules (FIXME: `preprod` has some rules from `prod`, such that we can test them before going to production - and rollback)
* fix to the reqmgr2ms/microservices frontend rules
* enable reqmgr2ms on vocms0742

NOTE 1: when merging this PR, do not squash the commits. They address different issues
NOTE 2: before starting services by the end of the deployment (or re-enabling them in the frontends), we need to make sure that the original couch database (the one with meaningful content) has been copied over to the new backend.
NOTE 3: later during the validation phase, I need to create another PR to rollback changes to the preprod backend maps.

@muhammadimranfarooqi @vkuznet you might want to have a first look at it.

For the record, **summary** of the couch databases:
* vocms0740 (workqueue): workqueue and workqueue_inbox
* vocms0742 (reqmgr2, reqmgr2ms and acdcserver): reqmgr_auxiliary, wmdatamining, reqmgr_workload_cache and reqmgr_config_cache
* vocms0743 (reqmon): wmstats, workloadsummary and wmstats_logdb
* vocms0744 (t0_reqmon): tier0_wmstats, t0_request, t0_workloadsummary and t0_logdb