### PR TITLE
Update frontend rules for prod/preprod; keep testing new couch backends

### DIFF
--- a/frontend/backends-preprod.txt
+++ b/frontend/backends-preprod.txt
@@ -3,10 +3,19 @@
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|relval-test)(?:/|$) vocms0731.cern.ch
-^/auth/complete/(?:c?)(?:couchdb/workqueue|workqueue)(?:/|$) vocms0731.cern.ch :affinity
-^/auth/complete/(?:couchdb/wmstats|wmstats|workloadsummary|wmstats_logdb)(?:/|$) vocms0743.cern.ch :affinity
-^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats|t0_workloadsummary|t0_request|t0_logdb)(?:/|$) vocms0744.cern.ch :affinity
-^/auth/complete/(?:c?)(?:couchdb|acdcserver)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/workqueue|workqueue)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:couchdb/workqueue_inbox|workqueue_inbox)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats|wmstats)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/workloadsummary|workloadsummary)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats_logdb|wmstats_logdb)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_workloadsummary|t0_workloadsummary)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_request|t0_request)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_logdb|t0_logdb)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmdatamining|wmdatamining)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/reqmgr_workload_cache|reqmgr_workload_cache)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/reqmgr_config_cache|reqmgr_config_cache)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/acdcserver|acdcserver)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/crabcache(?:/|$) vocms0731.cern.ch
 ^/auth/complete/confdb(?:/|$) vocms0731.cern.ch|vocms0132.cern.ch
 ^/auth/complete/das(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity

--- a/frontend/backends-prod.txt
+++ b/frontend/backends-prod.txt
@@ -3,10 +3,19 @@
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|relval-test)(?:/|$) vocms0731.cern.ch
-^/auth/complete/(?:c?)(?:couchdb/workqueue|workqueue)(?:/|$) vocms0740.cern.ch :affinity
-^/auth/complete/(?:couchdb/wmstats|wmstats|workloadsummary|wmstats_logdb)(?:/|$) vocms0743.cern.ch :affinity
-^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats|t0_workloadsummary|t0_request|t0_logdb)(?:/|$) vocms0744.cern.ch :affinity
-^/auth/complete/(?:c?)(?:couchdb|acdcserver)(?:/|$) vocms0742.cern.ch :affinity
+^/auth/complete/(?:couchdb/workqueue|workqueue)(?:/|$) vocms0740.cern.ch :affinity
+^/auth/complete/(?:couchdb/workqueue_inbox|workqueue_inbox)(?:/|$) vocms0740.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats|wmstats)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/workloadsummary|workloadsummary)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats_logdb|wmstats_logdb)(?:/|$) vocms0743.cern.ch :affinity
+^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_workloadsummary|t0_workloadsummary)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_request|t0_request)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_logdb|t0_logdb)(?:/|$) vocms0744.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmdatamining|wmdatamining)(?:/|$) vocms0742.cern.ch :affinity
+^/auth/complete/(?:couchdb/reqmgr_workload_cache|reqmgr_workload_cache)(?:/|$) vocms0742.cern.ch :affinity
+^/auth/complete/(?:couchdb/reqmgr_config_cache|reqmgr_config_cache)(?:/|$) vocms0742.cern.ch :affinity
+^/auth/complete/(?:couchdb/acdcserver|acdcserver)(?:/|$) vocms0742.cern.ch :affinity
 ^/auth/complete/das(?:/|$) vocms0741.cern.ch|vocms0742.cern.ch :affinity
 ^/auth/complete/das2go(?:/|$) vocms0741.cern.ch|vocms0742.cern.ch :affinity
 ^/auth/complete/crabcache(?:/|$) vocms0741.cern.ch


### PR DESCRIPTION
Fixes broken couchdb rules inserted with this PR: https://github.com/dmwm/deployment/pull/831

Summary of changes as follows:
* fixes broken rules for couchdb services/databases
* removed the `ccouchdb` tweak from the rules (apparently everything works fine in testbed with `couchdb` only, no double `c`)
* keep using vocms0743 and vocms0744 for further tests in testbed (FIXME: remove it by the beginning of the next week)

