### PR TITLE
Push couchapps only to specific CouchDB nodes

### DIFF
--- a/acdcserver/deploy
+++ b/acdcserver/deploy
@@ -25,7 +25,7 @@ deploy_acdcserver_sw()
   else :; fi
 }
 
-deploy_acdcserver_post()
+setup_acdcserver_couch()
 {
   # Tell couch to push acdcserver apps on the next restart
   local manage=$project_config/acdcserver_manage
@@ -35,6 +35,24 @@ deploy_acdcserver_post()
     echo "couchapp push $root/current/apps/acdcserver/data/couchapps/GroupUser" \
          "http://localhost:${couch##*:}/acdcserver" >> $root/state/${couch%%:*}/stagingarea/acdcserver
   done
+}
+
+deploy_acdcserver_post()
+{
+  case $host in
+    vocms0117 | vocms0132 | vocms0740 )
+      enable
+      setup_acdcserver_couch
+      ;;
+    * )
+      if [ "$host" != vocms* ]; then
+        enable
+        setup_acdcserver_couch
+      else
+        disable
+      fi
+      ;;
+  esac
 }
 
 deploy_acdcserver_auth()

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -40,33 +40,43 @@ deploy_reqmgr2_sw()
        $root/$cfgversion/config/$project/config.py
 }
 
-deploy_reqmgr2_post()
+setup_reqmgr2_couch()
 {
-  # in practice, general purpose backends and vocms0742 (prod, for couchapps)
-  case $host in
-    vocms013[89] | vocms073[89] | vocms074[0134] )
-      disable;;
-    * )
-      enable;;
-    esac
-
   # ReqMgr2 and old reqmgr specific couchdb stuff
   # Tell couch to pick up reqmgr on the next restart
   local reqmgrapp=$root/current/apps/reqmgr2
   for couch in couchdb:5984; do
-    echo "couchapp push $reqmgrapp/data/couchapps/ReqMgrAux" \
-         "http://localhost:${couch##*:}/reqmgr_auxiliary" \
+    echo "couchapp push $reqmgrapp/data/couchapps/ReqMgrAux http://localhost:${couch##*:}/reqmgr_auxiliary" \
          > $root/state/${couch%%:*}/stagingarea/reqmgr2
-    echo "couchapp push $reqmgrapp/data/couchapps/WMDataMining" \
-         "http://localhost:${couch##*:}/wmdatamining" \
+    echo "couchapp push $reqmgrapp/data/couchapps/WMDataMining http://localhost:${couch##*:}/wmdatamining" \
          >> $root/state/${couch%%:*}/stagingarea/reqmgr2
-    echo "couchapp push $reqmgrapp/data/couchapps/ReqMgr" \
-         "http://localhost:${couch##*:}/reqmgr_workload_cache" \
+    echo "couchapp push $reqmgrapp/data/couchapps/ReqMgr http://localhost:${couch##*:}/reqmgr_workload_cache" \
          >> $root/state/${couch%%:*}/stagingarea/reqmgr2
-    echo "couchapp push $reqmgrapp/data/couchapps/ConfigCache" \
-         "http://localhost:${couch##*:}/reqmgr_config_cache" \
+    echo "couchapp push $reqmgrapp/data/couchapps/ConfigCache http://localhost:${couch##*:}/reqmgr_config_cache" \
          >> $root/state/${couch%%:*}/stagingarea/reqmgr2
   done
+}
+
+deploy_reqmgr2_post()
+{
+  # in practice, general purpose backends and vocms0742 (prod, for couchapps)
+  case $host in
+    vocms0117 | vocms0132 | vocms0742 )
+      enable
+      setup_reqmgr2_couch
+      ;;
+    vocms0731 | vocms0136 | vocms016[135] | vocms0766 )
+      enable
+      ;;
+    * )
+      if [ "$host" != vocms* ]; then
+        enable
+        setup_reqmgr2_couch
+      else
+        disable
+      fi
+      ;;
+  esac
 
   (mkcrontab; sysboot) | crontab -
 }

--- a/reqmon/deploy
+++ b/reqmon/deploy
@@ -40,16 +40,8 @@ deploy_reqmon_sw()
        $root/$cfgversion/config/$project/config.py
 }
 
-deploy_reqmon_post()
+setup_reqmon_couch()
 {
-  # in practice, general purpose backends and vocms0743 (prod, for couchapps)
-  case $host in
-    vocms013[89] | vocms073[89] | vocms074[0124] )
-      disable;;
-    * )
-      enable;;
-    esac
-
   # Tell couch to push the reqmon app on the next restart
   for couch in couchdb:5984; do
     echo "couchapp push $root/$cfgversion/apps.$glabel/reqmon/data/couchapps/WMStats" \
@@ -59,8 +51,32 @@ deploy_reqmon_post()
     echo "couchapp push $root/$cfgversion/apps.$glabel/reqmon/data/couchapps/WorkloadSummary" \
          "http://localhost:${couch##*:}/workloadsummary" >> $root/state/${couch%%:*}/stagingarea/reqmon
     echo "couchapp push $root/$cfgversion/apps.$glabel/reqmon/data/couchapps/LogDB" \
-         "http://localhost:${couch##*:}/wmstats_logdb" >> $root/state/${couch%%:*}/stagingarea/reqmon  
+         "http://localhost:${couch##*:}/wmstats_logdb" >> $root/state/${couch%%:*}/stagingarea/reqmon
   done
+}
+
+deploy_reqmon_post()
+{
+  # in practice, general purpose backends and vocms0743 (prod, for couchapps)
+  case $host in
+    # fix this line to: vocms0117 | vocms0731 | vocms0743 )
+    vocms0117 | vocms0743 )
+      enable
+      setup_reqmon_couch
+      ;;
+    # fix this line to:     vocms0132 | vocms0136 | vocms016[135] | vocms0766 )
+    vocms0132 | vocms0731 | vocms0136 | vocms016[135] | vocms0766 )
+      enable
+      ;;
+    * )
+      if [ "$host" != vocms* ]; then
+        enable
+        setup_reqmon_couch
+      else
+        disable
+      fi
+      ;;
+  esac
 
   (mkcrontab; sysboot) | crontab -
 }

--- a/t0_reqmon/deploy
+++ b/t0_reqmon/deploy
@@ -38,16 +38,8 @@ deploy_t0_reqmon_sw()
        $root/$cfgversion/config/$project/config.py
 }
 
-deploy_t0_reqmon_post()
+setup_t0_reqmon_couch()
 {
-  # in practice, general purpose backends and vocms0744 (prod, for couchapps)
-  case $host in
-    vocms013[89] | vocms073[89] | vocms074[0123] )
-      disable;;
-    * )
-      enable;;
-    esac
-  
   # Tell couch to push the t0_reqmon app on the next restart
   for couch in couchdb:5984; do
     echo "couchapp push $root/$cfgversion/apps.$glabel/t0_reqmon/data/couchapps/WMStats" \
@@ -61,7 +53,31 @@ deploy_t0_reqmon_post()
     echo "couchapp push $root/$cfgversion/apps.$glabel/t0_reqmon/data/couchapps/LogDB" \
          "http://localhost:${couch##*:}/t0_logdb" >> $root/state/${couch%%:*}/stagingarea/t0_reqmon
   done
-  
+}
+
+deploy_t0_reqmon_post()
+{
+  # in practice, general purpose backends and vocms0744 (prod, for couchapps)
+  case $host in
+    # fix this line to: vocms0117 | vocms0731 | vocms0744 )
+    vocms0117 | vocms0744 )
+      enable
+      setup_t0_reqmon_couch
+      ;;
+    # fix this line to:     vocms0132 | vocms0136 | vocms016[135] | vocms0766 )
+    vocms0132 | vocms0731 | vocms0136 | vocms016[135] | vocms0766 )
+      enable
+      ;;
+    * )
+      if [ "$host" != vocms* ]; then
+        enable
+        setup_t0_reqmon_couch
+      else
+        disable
+      fi
+      ;;
+  esac
+
   (mkcrontab; sysboot) | crontab -
 }
 

--- a/workqueue/deploy
+++ b/workqueue/deploy
@@ -57,27 +57,38 @@ deploy_workqueue_sw()
 
 }
 
-deploy_workqueue_post()
+setup_workqueue_couch()
 {
-  # in practice, enabled it on private VMs, vocms0731 (preprod) and vocms0740 (prod)
-  case $host in
-    vocms013[2689] | vocms073[89] | vocms074[1234] | vocms016[135] | vocms0766 )
-      disable;;
-    * )
-      enable;;
-    esac
-  
-  # Do cache cleanup
-  local cmd="rm -rf $root/state/workqueue/cache/*"
-  $nogroups || cmd="sudo -H -u _workqueue bashs -l -c \"${cmd}\""
-  eval $cmd
-
   # Tell couch to push workqueue apps on the next restart
   for couch in couchdb:5984; do
     echo "$project_config/manage pushcouchapp http://localhost:${couch##*:}" \
       > $root/state/${couch%%:*}/stagingarea/workqueue
   done
-  
+}
+
+deploy_workqueue_post()
+{
+  # in practice, enabled it on private VMs, vocms0731 (preprod) and vocms0740 (prod)
+  case $host in
+    vocms0117 | vocms0731 | vocms0740 )
+      enable
+      setup_workqueue_couch
+      ;;
+    * )
+      if [ "$host" != vocms* ]; then
+        enable
+        setup_workqueue_couch
+      else
+        disable
+      fi
+      ;;
+  esac
+
+  # Do cache cleanup
+  local cmd="rm -rf $root/state/workqueue/cache/*"
+  $nogroups || cmd="sudo -H -u _workqueue bashs -l -c \"${cmd}\""
+  eval $cmd
+
   (mkcrontab; sysboot) | crontab -
 }
 


### PR DESCRIPTION
With this patch, I changed the model which relies on disabling the service on specific nodes and **enabling** it everywhere else. Now, the service will only be **enabled** on specific nodes, everything else will have it disabled.

It also assumes that if the node hostname does NOT start with `vocms`, then it's a private node and service/couchapps are enabled by default.

In addition to that, we only write to the `stagingarea` in very specific nodes (those running CouchDB as well).

Still to be tested