### PR TITLE
Properly compare hostname for couchapps

### DIFF
--- a/acdcserver/deploy
+++ b/acdcserver/deploy
@@ -45,7 +45,7 @@ deploy_acdcserver_post()
       setup_acdcserver_couch
       ;;
     * )
-      if [ "$host" != vocms* ]; then
+      if [[ "$host" != vocms* ]]; then
         enable
         setup_acdcserver_couch
       else

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -69,7 +69,7 @@ deploy_reqmgr2_post()
       enable
       ;;
     * )
-      if [ "$host" != vocms* ]; then
+      if [[ "$host" != vocms* ]]; then
         enable
         setup_reqmgr2_couch
       else

--- a/reqmon/deploy
+++ b/reqmon/deploy
@@ -69,7 +69,7 @@ deploy_reqmon_post()
       enable
       ;;
     * )
-      if [ "$host" != vocms* ]; then
+      if [[ "$host" != vocms* ]]; then
         enable
         setup_reqmon_couch
       else

--- a/t0_reqmon/deploy
+++ b/t0_reqmon/deploy
@@ -69,7 +69,7 @@ deploy_t0_reqmon_post()
       enable
       ;;
     * )
-      if [ "$host" != vocms* ]; then
+      if [[ "$host" != vocms* ]]; then
         enable
         setup_t0_reqmon_couch
       else

--- a/workqueue/deploy
+++ b/workqueue/deploy
@@ -75,7 +75,7 @@ deploy_workqueue_post()
       setup_workqueue_couch
       ;;
     * )
-      if [ "$host" != vocms* ]; then
+      if [[ "$host" != vocms* ]]; then
         enable
         setup_workqueue_couch
       else


### PR DESCRIPTION
Fix broken changes provided in #835 

It looks like we need to use the "new test" operator for these string comparisons, so I added a new pair of brackets to those commands.

Here is a test on one of the vo boxes (WRONG results):
```
amaltaro@vocms0192:/data/amaltaro/Jan2020_Val $ cat a.sh 
#!/bin/sh
host=vocms0743
echo $host
case $host in
    vocms0117 | vocms0731 | vocms0740 )
      echo "enable 1"
      ;;
    * )
      if [ "$host" != vocms* ]; then
        echo "enable 2"
      else
        echo "disable"
      fi
      ;;
esac
amaltaro@vocms0192:/data/amaltaro/Jan2020_Val $ sh a.sh 
vocms0743
enable 2
```

and now the correct results:
```
amaltaro@vocms0192:/data/amaltaro/Jan2020_Val $ cat a.sh 
#!/bin/sh
host=vocms0743
echo $host
case $host in
    vocms0117 | vocms0731 | vocms0740 )
      echo "enable 1"
      ;;
    * )
      if [[ "$host" != vocms* ]]; then
        echo "enable 2"
      else
        echo "disable"
      fi
      ;;
esac
amaltaro@vocms0192:/data/amaltaro/Jan2020_Val $ sh a.sh 
vocms0743
disable
```

We can add this one to the next testbed deployment. No need  to rush with this right now.
@muhammadimranfarooqi FYI