### PR TITLE
Stop using new CouchDB backends in preprod; update frontend rules

### DIFF
--- a/frontend/backends-preprod.txt
+++ b/frontend/backends-preprod.txt
@@ -3,20 +3,20 @@
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|relval-test)(?:/|$) vocms0731.cern.ch
-^/auth/complete/(?:couchdb/workqueue|workqueue)(?:/|$) vocms0731.cern.ch :affinity
-^/auth/complete/(?:couchdb/workqueue_inbox|workqueue_inbox)(?:/|$) vocms0731.cern.ch :affinity
-^/auth/complete/(?:couchdb/wmstats|wmstats)(?:/|$) vocms0743.cern.ch :affinity
-^/auth/complete/(?:couchdb/workloadsummary|workloadsummary)(?:/|$) vocms0743.cern.ch :affinity
-^/auth/complete/(?:couchdb/wmstats_logdb|wmstats_logdb)(?:/|$) vocms0743.cern.ch :affinity
-^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats)(?:/|$) vocms0744.cern.ch :affinity
-^/auth/complete/(?:couchdb/t0_workloadsummary|t0_workloadsummary)(?:/|$) vocms0744.cern.ch :affinity
-^/auth/complete/(?:couchdb/t0_request|t0_request)(?:/|$) vocms0744.cern.ch :affinity
-^/auth/complete/(?:couchdb/t0_logdb|t0_logdb)(?:/|$) vocms0744.cern.ch :affinity
 ^/auth/complete/(?:couchdb/wmdatamining|wmdatamining)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/reqmgr_workload_cache|reqmgr_workload_cache)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/reqmgr_config_cache|reqmgr_config_cache)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/acdcserver|acdcserver)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/reqmgr_auxiliary|couchdb)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/tier0_wmstats|tier0_wmstats)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_workloadsummary|t0_workloadsummary)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_request|t0_request)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/t0_logdb|t0_logdb)(?:/|$) vocms0132.cern.ch :affinity
+^/auth/complete/(?:couchdb/workqueue|workqueue)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:couchdb/workqueue_inbox|workqueue_inbox)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats|wmstats)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:couchdb/workloadsummary|workloadsummary)(?:/|$) vocms0731.cern.ch :affinity
+^/auth/complete/(?:couchdb/wmstats_logdb|wmstats_logdb)(?:/|$) vocms0731.cern.ch :affinity
 ^/auth/complete/crabcache(?:/|$) vocms0731.cern.ch
 ^/auth/complete/confdb(?:/|$) vocms0731.cern.ch|vocms0132.cern.ch
 ^/auth/complete/das(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity

--- a/reqmgr2/deploy
+++ b/reqmgr2/deploy
@@ -42,7 +42,7 @@ deploy_reqmgr2_sw()
 
 deploy_reqmgr2_post()
 {
-  # in practice, general purpose backends and vocms0742 (prod, for couchapps)
+  # in practice, general purpose backends, couchapps on vocms0132 (preprod) and vocms0742 (prod)
   case $host in
     vocms013[89] | vocms073[89] | vocms074[0134] )
       disable;;

--- a/reqmon/deploy
+++ b/reqmon/deploy
@@ -42,7 +42,7 @@ deploy_reqmon_sw()
 
 deploy_reqmon_post()
 {
-  # in practice, general purpose backends and vocms0743 (prod, for couchapps)
+  # in practice, general purpose backends, couchapps on vocms0731 (preprod) and vocms0743 (prod)
   case $host in
     vocms013[89] | vocms073[89] | vocms074[0124] )
       disable;;

--- a/t0_reqmon/deploy
+++ b/t0_reqmon/deploy
@@ -40,7 +40,7 @@ deploy_t0_reqmon_sw()
 
 deploy_t0_reqmon_post()
 {
-  # in practice, general purpose backends and vocms0744 (prod, for couchapps)
+  # in practice, general purpose backends, couchapps on vocms0132 (preprod) and vocms0744 (prod)
   case $host in
     vocms013[89] | vocms073[89] | vocms074[0123] )
       disable;;


### PR DESCRIPTION
As a follow up of the changes applied here:
https://github.com/dmwm/deployment/pull/831
and here:
https://github.com/dmwm/deployment/pull/833

switch couchdb databases back to the original two pre-production nodes. Now that all tests have been performed and we know which setup works.

During the intervention we need to make sure to copy the correct databases/views to the correct backends. I'll list them in the gitlab ticket.