### PR TITLE
Move ReqMon CherryPy threads from vocms0740 to vocms0743

### DIFF
--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -88,7 +88,7 @@ dataCacheTasks.central_logdb_url = LOG_DB_URL
 dataCacheTasks.log_reporter = "%s-%s" % (LOG_REPORTER, HOST)
 
 # Production/testbed instance of logdb, must be a production/testbed back-end
-if HOST.startswith("vocms0740") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
+if HOST.startswith("vocms0743") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
     
     # LogDB task (update and clean up)
     logDBTasks = extentions.section_("logDBTasks")


### PR DESCRIPTION
Imran, Todor,

this configuration detail was missed when I was working on the deployment changes required for the two new couchdb instances: https://github.com/dmwm/deployment/pull/831

Besides merging it for the March release, we need to update the reqmon configuration on both vocms0740 and vocms0743 and restart the `reqmon` service.