### PR TITLE
ReqMon configuration for a new CherryPy thread for input parentage

### DIFF
--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -89,7 +89,16 @@ dataCacheTasks.log_reporter = "%s-%s" % (LOG_REPORTER, HOST)
 
 # Production/testbed instance of logdb, must be a production/testbed back-end
 if HOST.startswith("vocms0740") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
-    
+    # construct list of locked parent datasets
+    parentTask = extentions.section_("parentLock")
+    parentTask.object = "WMCore.WMStats.CherryPyThreads.BuildParentLock.BuildParentLock"
+    parentTask.dbs_url = data.dbs_url
+    parentTask.central_logdb_url = LOG_DB_URL
+    parentTask.log_reporter = LOG_REPORTER
+    parentTask.updateParentsInterval = 60 * 10  # every 10 minutes
+    parentTask.log_file = '%s/logs/reqmon/parentTask-%s-%s.log' % (
+    __file__.rsplit('/', 4)[0], HOST.split('.', 1)[0], time.strftime("%Y%m%d"))
+
     # LogDB task (update and clean up)
     logDBTasks = extentions.section_("logDBTasks")
     logDBTasks.object = "WMCore.WMStats.CherryPyThreads.LogDBTasks.LogDBTasks"


### PR DESCRIPTION
This provides configuration parameter for a new CherryPy thread to be executed with the `reqmon` application (in a single instance).