### PR TITLE
Setup automatic couch database/views compaction

### DIFF
--- a/couchdb/local.ini
+++ b/couchdb/local.ini
@@ -12,7 +12,17 @@ validate_hmac = true
 database_dir = {ROOT}/state/couchdb/database
 view_index_dir = {ROOT}/state/couchdb/database
 uri_file = {ROOT}/state/couchdb/couch.uri
-os_process_timeout=240000 ; increase the timeout from 5 seconds to 4 minutes
+; increase the timeout from 5 seconds to 4 minutes
+os_process_timeout=240000
+
+[compactions]
+_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]
+
+[compaction_daemon]
+; check for databases and views every hour
+check_interval = 3600
+; ~200 MB
+min_file_size = 209715200
 
 [log]
 file = {ROOT}/logs/couchdb/couch.log


### PR DESCRIPTION
Define CouchDB parameters to automatically trigger database and views compaction based on their fragmentation and minimum size. Further info at:
http://docs.couchdb.org/en/1.6.1/config/compaction.html

It still needs to be properly tested, do not merge it yet.

Note, if this goes in into CMSWEB. We need to remember to disable the cronjobs triggering couch compactions. Apparently these lines:
https://github.com/dmwm/deployment/blob/master/couchdb/deploy#L51-L57