### PR TITLE
Starting the DQM sound alarm manager in the online P5 DQM GUI

### DIFF
--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -336,7 +336,13 @@ start_agents_dqm_prod_local()
     http://localhost:8030/dqm/online \
     daq-expert.cms \
     50555 600 2 \
-    cms-dqm-oncall@cern.ch
+    cms-dqm-oncall@cern.ch \
+    http://localhost:8031/disabled
+    
+  startagent $D/agent-sound-manager \
+    visDQMSoundAlarmManager \
+    http://localhost:8030/dqm/online \
+    8031
 }
 
 start_agents_dqm_prod_offsite()


### PR DESCRIPTION
Starting a recently added DQM sound alarm manager that allows to enable/disable alarms for certain plots. The manager was added here: https://github.com/rovere/dqmgui/pull/53