### PR TITLE
Fix issue with internal dummy connection issue

### DIFF
--- a/frontend/frontend.conf
+++ b/frontend/frontend.conf
@@ -14,35 +14,8 @@ Header set CMS-Server-Time "%D %t"
 @INCLUDE backends.conf@
 #@INCLUDE mod_evasive.conf@
 
-# Define server virtual host.
-Listen 80
-<VirtualHost *:80>
-  SSLEngine off
-
-  # Disable all request methods except GET. Anything else must come
-  # over HTTPS. GET needs to be supported so people can type URLs in
-  # web browser location bar, and get a redirect to HTTPS.
-  RewriteEngine on
-  RewriteCond %{REQUEST_METHOD} !^GET$
-  RewriteRule ^ - [F]
-
-  # Capture the URI for the backend; need mod_rewrite to grab it.
-  RewriteCond %{ENV:REDIRECT_REQUEST_URI} !^$
-  RewriteRule ^ - [E=CMS_REQUEST_URI:%{ENV:REDIRECT_REQUEST_URI}]
-  RewriteCond %{ENV:REDIRECT_REQUEST_URI} ^$
-  RewriteRule ^ - [E=CMS_REQUEST_URI:%{REQUEST_URI}]
-  RequestHeader set CMS-Request-URI %{CMS_REQUEST_URI}e
-
-  # Add 'escape' rewrite map to name space.  Extract query for redirects.
-  RewriteMap escape int:escape
-  RewriteCond %{QUERY_STRING} ^$
-  RewriteRule ^ - [E=CMS_QUERY:]
-  RewriteCond %{QUERY_STRING} !^$
-  RewriteRule ^ - [E=CMS_QUERY:?%{QUERY_STRING}]
-
-  # Application configurations.
-  @INCLUDE app_*_nossl.conf@
-</VirtualHost>
+### Configuration for x509-scitokens-issuer
+@INCLUDE x509_scitokens_issuer/x509_scitokens_issuer_http.conf@
 
 # This is the configuration file for the HTTPS web server, listening
 # on the port 443.  It defines the basic SSL server, then includes
@@ -149,5 +122,36 @@ Listen 8443
   @INCLUDE app_*_ssl.conf@
 </VirtualHost>
 
-### Configuration for x509-scitokens-issuer
-@INCLUDE x509_scitokens_issuer/x509_scitokens_issuer_http.conf@
+# Define server virtual host.
+# Keep this section last to avoid internal dummy connection issues like
+# SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol -- speaking not SSL to HTTPS port!
+# for more information please see this document
+# https://cwiki.apache.org/confluence/display/httpd/InternalDummyConnection#SSL_Considerations
+Listen 80
+<VirtualHost *:80>
+  SSLEngine off
+
+  # Disable all request methods except GET. Anything else must come
+  # over HTTPS. GET needs to be supported so people can type URLs in
+  # web browser location bar, and get a redirect to HTTPS.
+  RewriteEngine on
+  RewriteCond %{REQUEST_METHOD} !^GET$
+  RewriteRule ^ - [F]
+
+  # Capture the URI for the backend; need mod_rewrite to grab it.
+  RewriteCond %{ENV:REDIRECT_REQUEST_URI} !^$
+  RewriteRule ^ - [E=CMS_REQUEST_URI:%{ENV:REDIRECT_REQUEST_URI}]
+  RewriteCond %{ENV:REDIRECT_REQUEST_URI} ^$
+  RewriteRule ^ - [E=CMS_REQUEST_URI:%{REQUEST_URI}]
+  RequestHeader set CMS-Request-URI %{CMS_REQUEST_URI}e
+
+  # Add 'escape' rewrite map to name space.  Extract query for redirects.
+  RewriteMap escape int:escape
+  RewriteCond %{QUERY_STRING} ^$
+  RewriteRule ^ - [E=CMS_QUERY:]
+  RewriteCond %{QUERY_STRING} !^$
+  RewriteRule ^ - [E=CMS_QUERY:?%{QUERY_STRING}]
+
+  # Application configurations.
+  @INCLUDE app_*_nossl.conf@
+</VirtualHost>


### PR DESCRIPTION
Re-position Listen sections to avoid internal dummy connection issues like this error:
SSL23_GET_CLIENT_HELLO:unknown protocol -- speaking not SSL to HTTPS port!

In particular, re-ordering section with this order: first HTTPs ports, followed by HTTP one, allows to force apache daemon to use HTTPs port first.