### PR TITLE
Replace dashboard url by the grafana token in wmagent

### DIFF
--- a/wmagent/manage
+++ b/wmagent/manage
@@ -43,6 +43,8 @@ else
     MYSQL_SOCK=$DBSOCK
 fi
 
+GRAFANA_TOKEN=
+
 COUCH_USER=
 COUCH_PASS=
 
@@ -74,7 +76,6 @@ ACDC_URL=
 DBS3_URL=
 PHEDEX_URL=
 DQM_URL=
-DASHBOARD_URL=
 REQUESTCOUCH_URL=
 CENTRAL_LOGDB_URL=
 WMARCHIVE_URL=
@@ -136,6 +137,7 @@ load_secrets_file(){
     local MATCH_ORACLE_USER=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_USER | sed s/ORACLE_USER=//`
     local MATCH_ORACLE_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_PASS | sed s/ORACLE_PASS=//`
     local MATCH_ORACLE_TNS=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_TNS | sed s/ORACLE_TNS=//`
+    local MATCH_GRAFANA_TOKEN=`cat $WMAGENT_SECRETS_LOCATION | grep GRAFANA_TOKEN | sed s/GRAFANA_TOKEN=//`
     local MATCH_MYSQL_USER=`cat $WMAGENT_SECRETS_LOCATION | grep MYSQL_USER | sed s/MYSQL_USER=//`
     local MATCH_MYSQL_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep MYSQL_PASS | sed s/MYSQL_PASS=//`
     local MATCH_COUCH_USER=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_USER | sed s/COUCH_USER=//`
@@ -162,7 +164,6 @@ load_secrets_file(){
     local MATCH_DBS3_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DBS3_URL | sed s/DBS3_URL=//`
     local MATCH_PHEDEX_URL=`cat $WMAGENT_SECRETS_LOCATION | grep PHEDEX_URL | sed s/PHEDEX_URL=//`
     local MATCH_DQM_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DQM_URL | sed s/DQM_URL=//`
-    local MATCH_DASHBOARD_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DASHBOARD_URL | sed s/DASHBOARD_URL=//`
     local MATCH_REQUESTCOUCH_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQUESTCOUCH_URL | sed s/REQUESTCOUCH_URL=//`
     local MATCH_CENTRAL_LOGDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep CENTRAL_LOGDB_URL | sed s/CENTRAL_LOGDB_URL=//`
     local MATCH_WMARCHIVE_URL=`cat $WMAGENT_SECRETS_LOCATION | grep WMARCHIVE_URL | sed s/WMARCHIVE_URL=//`
@@ -187,6 +188,12 @@ load_secrets_file(){
             echo "Secrets file doesnt contain ORACLE_PASS or ORACLE_TNS";
             exit 1
         fi
+    fi
+
+    GRAFANA_TOKEN=${MATCH_GRAFANA_TOKEN:-$GRAFANA_TOKEN};
+    if [ "x$GRAFANA_TOKEN" == "x" ]; then
+        echo "Secrets file doesnt contain GRAFANA_TOKEN";
+        exit 1
     fi
 
     # basic couch settings
@@ -237,8 +244,6 @@ load_secrets_file(){
     
     DQM_URL=${MATCH_DQM_URL:-$DQM_URL}
 
-    DASHBOARD_URL=${MATCH_DASHBOARD_URL:-$DASHBOARD_URL}
-    
     REQUESTCOUCH_URL=${MATCH_REQUESTCOUCH_URL:-$REQUESTCOUCH_URL}
     
     CENTRAL_LOGDB_URL=${MATCH_CENTRAL_LOGDB_URL:-$CENTRAL_LOGDB_URL}
@@ -263,6 +268,7 @@ print_settings(){
     echo "ORACLE_USER=               $ORACLE_USER               "
     echo "ORACLE_PASS=               $ORACLE_PASS               "
     echo "ORACLE_TNS=                $ORACLE_TNS                "
+    echo "GRAFANA_TOKEN=             $GRAFANA_TOKEN                "
     echo "MYSQL_USER=                $MYSQL_USER                "
     echo "MYSQL_PASS=                $MYSQL_PASS                "
     echo "COUCH_USER=                $COUCH_USER                "
@@ -289,7 +295,6 @@ print_settings(){
     echo "DBS3_URL=                  $DBS3_URL                  "
     echo "PHEDEX_URL=                $PHEDEX_URL                "
     echo "DQM_URL=                   $DQM_URL                   "
-    echo "DASHBOARD_URL=             $DASHBOARD_URL             "
     echo "REQUESTCOUCH_URL=          $REQUESTCOUCH_URL          "
     echo "CENTRAL_LOGDB_URL=         $CENTRAL_LOGDB_URL         "
     echo "WMARCHIVE_URL=             $WMARCHIVE_URL             "
@@ -643,13 +648,13 @@ init_wmagent(){
                        --global_workqueue_url=$GLOBAL_WORKQUEUE_URL \
                        --workqueue_db_name=$LOCAL_WORKQUEUE_DBNAME \
                        --workload_summary_url=$WORKLOAD_SUMMARY_URL \
+                       --grafana_token=$GRAFANA_TOKEN \
                        --wmstats_url=$WMSTATS_URL \
                        --reqmgr2_url=$REQMGR2_URL \
 	                   --acdc_url=$ACDC_URL \
 	                   --dbs3_url=$DBS3_URL \
 	                   --phedex_url=$PHEDEX_URL \
 	                   --dqm_url=$DQM_URL \
-	                   --dashboard_url=$DASHBOARD_URL \
 	                   --requestcouch_url=$REQUESTCOUCH_URL \
 	                   --central_logdb_url=$CENTRAL_LOGDB_URL \
 	                   --wmarchive_url=$WMARCHIVE_URL \
@@ -665,13 +670,13 @@ init_wmagent(){
                        --global_workqueue_url=$GLOBAL_WORKQUEUE_URL \
                        --workqueue_db_name=$LOCAL_WORKQUEUE_DBNAME \
                        --workload_summary_url=$WORKLOAD_SUMMARY_URL \
+                       --grafana_token=$GRAFANA_TOKEN \
                        --wmstats_url=$WMSTATS_URL \
                        --reqmgr2_url=$REQMGR2_URL \
 	                   --acdc_url=$ACDC_URL \
 	                   --dbs3_url=$DBS3_URL \
 	                   --phedex_url=$PHEDEX_URL \
 	                   --dqm_url=$DQM_URL \
-	                   --dashboard_url=$DASHBOARD_URL \
 	                   --requestcouch_url=$REQUESTCOUCH_URL \
 	                   --central_logdb_url=$CENTRAL_LOGDB_URL \
 	                   --wmarchive_url=$WMARCHIVE_URL \


### PR DESCRIPTION
Remove dashboard_url (service deprecated, no longer used by AgentStatusWatcher), and add a grafana token placeholder.