### PR TITLE
Remove cron entries for couch compactions

### DIFF
--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -48,13 +48,6 @@ deploy_couchdb_post()
      * )
        enable
        sysboot
-       # Set cronjobs to compact databases and views at selected times
-       for task in "0:compact wmstats" "12:compactviews wmstats WMStats" "12:compactviews wmstats WMStatsErl" \
-                   "18:compact all_but_exceptions" "3:compactviews all_but_exceptions all"; do
-         local cmd="$project_config/manage ${task#*:} 'I did read documentation'"
-         $nogroups || cmd="sudo -H -u _couchdb bashs -l -c \"${cmd}\""
-         echo "1 ${task%%:*} * * * $cmd"
-       done
 
        # Daily backup the databases to other cluster machines
        case $host in

--- a/wmagent/local.ini
+++ b/wmagent/local.ini
@@ -57,3 +57,12 @@ http_connections = 10
 worker_batch_size = 2000
 max_replication_retry_count = infinity
 socket_options = [{keepalive, true}, {nodelay, true}]
+
+[compactions]
+_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]
+
+[compaction_daemon]
+; check for databases and views every hour
+check_interval = 3600
+; ~200 MB
+min_file_size = 209715200


### PR DESCRIPTION
Complement to https://github.com/dmwm/deployment/pull/851

With this patch:
* it no longer creates the couchdb cron entries for database and view compaction
* it enables the compaction_daemon couchdb element in the WMAgent CouchDB configuration

Fragmentation value might have to be adjusted as we learn from these changes.