### PR TITLE
Move parent dataset lock thread from reqmon to reqmgr

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -187,6 +187,18 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswi
     auxCacheUpdateTasks.central_logdb_url = LOG_DB_URL
     auxCacheUpdateTasks.log_reporter = LOG_REPORTER
 
+    # construct list of locked parent datasets
+    parentTask = extentions.section_("parentLock")
+    parentTask.object = "WMCore.ReqMgr.CherryPyThreads.BuildParentLock.BuildParentLock"
+    parentTask.dbs_url = data.dbs_url
+    parentTask.reqmgrdb_url = "%s/%s" % (data.couch_host, data.couch_reqmgr_db)
+    parentTask.reqmgr2_url = "%s/reqmgr2" % BASE_URL
+    parentTask.central_logdb_url = LOG_DB_URL
+    parentTask.log_reporter = LOG_REPORTER
+    parentTask.updateParentsInterval = 60 * 10  # every 10 minutes
+    parentTask.log_file = '%s/logs/reqmgr2/parentTask-%s-%s.log' % (
+    __file__.rsplit('/', 4)[0], HOST.split('.', 1)[0], time.strftime("%Y%m%d"))
+
     # heartbeat monitor task
     heartbeatMonitor = extentions.section_("heartbeatMonitor")
     heartbeatMonitor.object = "WMCore.ReqMgr.CherryPyThreads.HeartbeatMonitor.HeartbeatMonitor"

--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -87,16 +87,6 @@ dataCacheTasks.log_file = '%s/logs/reqmon/dataCacheTasks-%s-%s.log' % (__file__.
 dataCacheTasks.central_logdb_url = LOG_DB_URL
 dataCacheTasks.log_reporter = "%s-%s" % (LOG_REPORTER, HOST)
 
-# construct list of locked parent datasets
-parentTask = extentions.section_("parentLock")
-parentTask.object = "WMCore.WMStats.CherryPyThreads.BuildParentLock.BuildParentLock"
-parentTask.dbs_url = data.dbs_url
-parentTask.central_logdb_url = LOG_DB_URL
-parentTask.log_reporter = LOG_REPORTER
-parentTask.updateParentsInterval = 60 * 10  # every 10 minutes
-parentTask.log_file = '%s/logs/reqmon/parentTask-%s-%s.log' % (
-__file__.rsplit('/', 4)[0], HOST.split('.', 1)[0], time.strftime("%Y%m%d"))
-
 # Production/testbed instance of logdb, must be a production/testbed back-end
 if HOST.startswith("vocms0743") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
     


### PR DESCRIPTION
Moving the thread to lock parent datasets from reqmon to reqmgr. Running this in reqmon required running the same thread on multiple backends, which could create issues. Moved to reqmgr2 where a single instance can manage parent dataset locking.

Needed to support changes from this PR:
https://github.com/dmwm/WMCore/pull/9567
