### PR TITLE
ReqMon argument to fetch or not job-level data from wmstats

### DIFF
--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -80,6 +80,8 @@ extentions = config.section_("extensions")
 # wmstats data cache update (This need to be updated for all backend since this is memory cache)
 dataCacheTasks = extentions.section_("dataCacheTasks")
 dataCacheTasks.object = "WMCore.WMStats.CherryPyThreads.DataCacheUpdate.DataCacheUpdate"
+
+dataCacheTasks.getJobInfo = False  # does not get job-level information from wmstats
 dataCacheTasks.wmstats_url = "%s/%s" % (data.couch_host, data.couch_wmstats_db)
 dataCacheTasks.reqmgrdb_url = "%s/%s" % (data.couch_host, data.couch_reqmgr_db)
 dataCacheTasks.dataCacheUpdateDuration = 60 * 5 # every 5 min


### PR DESCRIPTION
To go together with: https://github.com/cms-sw/cmsdist/pull/5833

For now, we do not want to fetch job-level information in the DataCacheUpdate thread, so keep it False in production for the moment (for testbed, we should manually change this value to True, if possible)