### PR TITLE
Adding new R9 plots to ECAL

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -419,42 +419,42 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/09 Basic Cluster Size',
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/10 Basic Cluster Size Trend',
 	   [{'path': 'Ecal/Trends/ClusterTask EB size of basic clusters', 'description': 'Trend of the mean size of the basic clusters.'}],
 	   [{'path': 'Ecal/Trends/ClusterTask EE size of basic clusters', 'description': 'Trend of the mean size of the basic clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11-1 Super Cluster Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11 Super Cluster Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy', 'description': 'Super cluster energy distribution.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy', 'description': 'Super cluster energy distribution.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11-2 Super Cluster Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12-1 Super Cluster Energy Low',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/13 Super Cluster Energy Low',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12-2 Super Cluster Energy Low',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster Energy Low',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/13 Super Cluster Seed Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Seed Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-1 Super Cluster R9',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/16 Super Cluster R9',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-2 Super Cluster R9 Raw',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/17 Super Cluster R9 Raw',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-3 Super Cluster R9 Full',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/18 Super Cluster R9 Full',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Full', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Full', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-4 Super Cluster R9 Full Raw',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/19 Super Cluster R9 Full Raw',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Full Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Full Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Size',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/20 Super Cluster Size',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC size', 'description': 'Distribution of the super cluster size (number of basic clusters)'},
 	    {'path': 'EcalBarrel/EBClusterTask/EBCLT SC size (crystal)', 'description': 'Distribution of the super cluster size (number of crystals).'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC size', 'description': 'Distribution of the super cluster size (number of basic clusters)'},
 	    {'path': 'EcalEndcap/EEClusterTask/EECLT SC size (crystal)', 'description': 'Distribution of the super cluster size (number of crystals).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/16 Cluster Energy vs Seed Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/21 Cluster Energy vs Seed Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/17 di-Electron Mass',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/22 di-Electron Mass',
 	   [{'path': 'HLT/ObjectMonitor/MainShifter/di-Electron_Mass', 'description': 'HLT di-electron mass [from HLT DQM].'}])
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE

--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -422,13 +422,13 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/10 Basic Cluster Size Trend',
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11 Super Cluster Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy', 'description': 'Super cluster energy distribution.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy', 'description': 'Super cluster energy distribution.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Raw Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/13 Super Cluster Energy Low',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster Energy Low',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster Raw Energy Low',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Seed Energy',

--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -419,18 +419,33 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/09 Basic Cluster Size',
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/10 Basic Cluster Size Trend',
 	   [{'path': 'Ecal/Trends/ClusterTask EB size of basic clusters', 'description': 'Trend of the mean size of the basic clusters.'}],
 	   [{'path': 'Ecal/Trends/ClusterTask EE size of basic clusters', 'description': 'Trend of the mean size of the basic clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11 Super Cluster Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11-1 Super Cluster Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy', 'description': 'Super cluster energy distribution.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy', 'description': 'Super cluster energy distribution.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Energy Low',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11-2 Super Cluster Energy',
+	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}],
+	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12-1 Super Cluster Energy Low',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12-2 Super Cluster Energy Low',
+	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}],
+	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/13 Super Cluster Seed Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster R9',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-1 Super Cluster R9',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-2 Super Cluster R9 Raw',
+	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
+	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-3 Super Cluster R9 Full',
+	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Full', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
+	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Full', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14-4 Super Cluster R9 Full Raw',
+	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Full Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
+	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Full Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Size',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC size', 'description': 'Distribution of the super cluster size (number of basic clusters)'},
 	    {'path': 'EcalBarrel/EBClusterTask/EBCLT SC size (crystal)', 'description': 'Distribution of the super cluster size (number of crystals).'}],

--- a/dqmgui/layouts/ecal_T0_layouts.py
+++ b/dqmgui/layouts/ecal_T0_layouts.py
@@ -420,23 +420,38 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/10 Basic Cluster Size Trend',
 	   [{'path': 'Ecal/Trends/ClusterTask EB size of basic clusters', 'description': 'Trend of the mean size of the basic clusters.'}],
 	   [{'path': 'Ecal/Trends/ClusterTask EE size of basic clusters', 'description': 'Trend of the mean size of the basic clusters.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11 Super Cluster Energy',
-	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy', 'description': 'Super cluster energy distribution.'}],
-	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy', 'description': 'Super cluster energy distribution.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Energy Low',
-	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}],
-	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/13 Super Cluster Seed Energy',
-	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}],
-	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster R9',
-	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
-	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Size',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy', 'description': 'Super cluster energy distribution.'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy', 'description': 'Super cluster energy distribution.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Energy',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/13 Super Cluster Energy Low',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster Energy Low',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Seed Energy',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC seed crystal energy', 'description': 'Energy distribution of the crystals that seeded super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/16 Super Cluster R9',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/17 Super Cluster R9 Raw',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/18 Super Cluster R9 Full',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Full', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Full', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/19 Super Cluster R9 Full Raw',
+       [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC R9 Full Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}],
+       [{'path': 'EcalEndcap/EEClusterTask/EECLT SC R9 Full Raw', 'description': 'Distribution of E_seed / E_3x3 of the super clusters.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/20 Super Cluster Size',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC size', 'description': 'Distribution of the super cluster size (number of basic clusters)'},
 	    {'path': 'EcalBarrel/EBClusterTask/EBCLT SC size (crystal)', 'description': 'Distribution of the super cluster size (number of crystals).'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC size', 'description': 'Distribution of the super cluster size (number of basic clusters)'},
 	    {'path': 'EcalEndcap/EEClusterTask/EECLT SC size (crystal)', 'description': 'Distribution of the super cluster size (number of crystals).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/16 Cluster Energy vs Seed Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/21 Cluster Energy vs Seed Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}])
 # By SuperModule _______________

--- a/dqmgui/layouts/ecal_T0_layouts.py
+++ b/dqmgui/layouts/ecal_T0_layouts.py
@@ -422,13 +422,13 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/10 Basic Cluster Size Trend',
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/11 Super Cluster Energy',
        [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy', 'description': 'Super cluster energy distribution.'}],
        [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy', 'description': 'Super cluster energy distribution.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Energy',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/12 Super Cluster Raw Energy',
        [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}],
        [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy', 'description': 'Super cluster raw energy distribution.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/13 Super Cluster Energy Low',
        [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}],
        [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy (low scale)', 'description': 'Energy distribution of the super clusters (low scale).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster Energy Low',
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/14 Super Cluster Raw Energy Low',
        [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}],
        [{'path': 'EcalEndcap/EEClusterTask/EECLT SC raw energy (low scale)', 'description': 'Energy distribution (raw) of the super clusters (low scale).'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/15 Super Cluster Seed Energy',


### PR DESCRIPTION
Since some sections of the current ECAL DQM code were written originally, there have been some minor changes in how variables important to the monitoring are commonly understood by ECAL experts. Specifically, there are a few ways of defining R9, all of which might give slightly different values for the variable -- whether to use the zero-suppressed energy, whether to use the raw values for the energy, and so on. And so the current plots are sometimes a little difficult to interpret -- for example, there was an inconsistency noted in the R9 1D distributions between UL and EOY rereco for some samples, and we are investigating whether this has to do with the old definition. This PR adds these new R9 plots to the Ecal workspace.