### PR TITLE
Check presence of config before starting the service

### DIFF
--- a/reqmgr2ms/manage
+++ b/reqmgr2ms/manage
@@ -62,7 +62,7 @@ fi
 # Start service conditionally on crond restart.
 sysboot()
 {
-if [ -f $CFGDIR/$CFGFILETR ]; then
+if [ -f $CFGFILETR ]; then
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -v -d $STATEDIR -l "|rotatelogs $LOGDIR/$LOG_TRANS-%Y%m%d-`hostname -s`.log 86400" $CFGFILETR
 fi
 if [ -f $CFGFILEMON ]; then

--- a/reqmgr2ms/manage
+++ b/reqmgr2ms/manage
@@ -62,9 +62,15 @@ fi
 # Start service conditionally on crond restart.
 sysboot()
 {
+if [ -f $CFGDIR/$CFGFILETR ]; then
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -v -d $STATEDIR -l "|rotatelogs $LOGDIR/$LOG_TRANS-%Y%m%d-`hostname -s`.log 86400" $CFGFILETR
+fi
+if [ -f $CFGFILEMON ]; then
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -v -d $STATEDIR -l "|rotatelogs $LOGDIR/$LOG_MON-%Y%m%d-`hostname -s`.log 86400" $CFGFILEMON
+fi
+if [ -f $CFGFILEOUT ]; then
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -v -d $STATEDIR -l "|rotatelogs $LOGDIR/$LOG_OUT-%Y%m%d-`hostname -s`.log 86400" $CFGFILEOUT
+fi
 }
 
 
@@ -72,9 +78,14 @@ sysboot()
 start()
 {
   echo "starting $ME"
+if [ -f $CFGFILETR ]; then
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$LOG_TRANS-%Y%m%d-`hostname -s`.log 86400" $CFGFILETR
+if [ -f $CFGFILEMON ]; then
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$LOG_MON-%Y%m%d-`hostname -s`.log 86400" $CFGFILEMON
+fi
+if [ -f $CFGFILEOUT ]; then
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$LOG_OUT-%Y%m%d-`hostname -s`.log 86400" $CFGFILEOUT
+fi
 }
 
 
@@ -82,18 +93,30 @@ start()
 stop()
 {
   echo "stopping $ME"
+if [ -f $CFGFILETR ]; then
   wmc-httpd -k -d $STATEDIR $CFGFILETR
+fi
+if [ -f $CFGFILEMON ]; then
   wmc-httpd -k -d $STATEDIR $CFGFILEMON
+fi
+if [ -f $CFGFILEOUT ]; then
   wmc-httpd -k -d $STATEDIR $CFGFILEOUT
+fi
 }
 
 
 # Check if the server is running.
 status()
 {
+if [ -f $CFGFILETR ]; then
   wmc-httpd -s -d $STATEDIR $CFGFILETR
+fi
+if [ -f $CFGFILEMON ]; then
   wmc-httpd -s -d $STATEDIR $CFGFILEMON
+fi
+if [ -f $CFGFILEOUT ]; then
   wmc-httpd -s -d $STATEDIR $CFGFILEOUT
+fi
 }
 
 


### PR DESCRIPTION
This change is required to separate services in k8s, i.e. if service config is present the service will be started, otherwise, no action will be done.