### PR TITLE
Enable T0 CherryPy threads on the correct backend: vocms0744

### DIFF
--- a/t0_reqmon/config.py
+++ b/t0_reqmon/config.py
@@ -71,7 +71,7 @@ dataCacheTasks.dataCacheUpdateDuration = 60 * 5 # every 5 min
 dataCacheTasks.log_file = '%s/logs/t0_reqmon/dataCacheTasks-%s-%s.log' % (__file__.rsplit('/', 4)[0], HOST.split('.', 1)[0], time.strftime("%Y%m%d"))
 
 # Production/testbed instance of logdb, must be a production/testbed back-end
-if HOST.startswith("vocms0740") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
+if HOST.startswith("vocms0744") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117") or HOST.startswith("vocms0127"):
     
     # LogDB task (update and clean up)
     logDBTasks = extentions.section_("logDBTasks")


### PR DESCRIPTION
I guess we missed this configuration when the extra 2 backends were commissioned 6 months ago. These cherrypy threads have not been running since then.