### PR TITLE
Adding new services for DQM

### DIFF
--- a/frontend/app_dqm_nossl.conf
+++ b/frontend/app_dqm_nossl.conf
@@ -2,6 +2,9 @@
 RewriteRule ^(/dqm/online(/.*)?)$          https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/online-playback(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/online-test(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/online-new(/.*)?)$          https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/online-playback-new(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/online-test-new(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/hcal-online(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 
 # Redirect rules for offline DQM, back to the https interface.

--- a/frontend/app_dqm_ssl.conf
+++ b/frontend/app_dqm_ssl.conf
@@ -1,5 +1,5 @@
 RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie;limited-proxy;cert;host]
-RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|hcal-online)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/(relval|relval-test)(/.*)?)$ http://%{ENV:BACKEND}:8081${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/(offline|offline-test)(/.*)?)$ http://%{ENV:BACKEND}:8080${escape:$1} [QSA,P,L,NE]

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -1,6 +1,6 @@
 ^/auth/complete/phedex(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch

--- a/frontend/backends-k8s-prod.txt
+++ b/frontend/backends-k8s-prod.txt
@@ -1,6 +1,6 @@
 ^/auth/complete/phedex(?:/|$) vocms0136.cern.ch|vocms0161.cern.ch|vocms0163.cern.ch|vocms0165.cern.ch|vocms0766.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0136.cern.ch|vocms0161.cern.ch|vocms0163.cern.ch|vocms0165.cern.ch|vocms0766.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch

--- a/frontend/backends-k8s.txt
+++ b/frontend/backends-k8s.txt
@@ -1,6 +1,6 @@
 ^/auth/complete/phedex(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch

--- a/frontend/backends-preprod.txt
+++ b/frontend/backends-preprod.txt
@@ -1,4 +1,4 @@
-^/auth/complete/dqm/(?:online|online-playback|online-test)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch

--- a/frontend/backends-prod.txt
+++ b/frontend/backends-prod.txt
@@ -1,4 +1,4 @@
-^/auth/complete/dqm/(?:online|online-playback|online-test)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/relval(?:/|$) vocms0739.cern.ch

--- a/frontend/htdocs/index.html
+++ b/frontend/htdocs/index.html
@@ -29,6 +29,11 @@
           </li>
           <li class="box">DQM:
             <a href="/dqm/online/">Online</a>,
+            <a href="/dqm/online-new/">Online-new</a>,
+            <a href="/dqm/online-playback/">Online-playback</a>,
+            <a href="/dqm/online-playback-new/">Online-playback-new</a>,
+            <a href="/dqm/online-test/">Online-test</a>,
+            <a href="/dqm/online-test-new/">Online-test-new</a>,
             <a href="/dqm/offline/">Offline</a>,
             <a href="/dqm/relval/">RelVal</a>,
             <a href="/dqm/dev/">Development</a>


### PR DESCRIPTION
This PR is for adding 3 new services for DQM in CMSWEB which are `online-new`, `online-playback-new` and `online-test-new`. These are deployed in P5 network similar to other services. 