### PR TITLE
Added GEM Offline DQM GUI

### DIFF
--- a/dqmgui/layouts/gem_T0_layouts.py
+++ b/dqmgui/layouts/gem_T0_layouts.py
@@ -1,0 +1,93 @@
+def gemlayout(i, p, *rows): i["GEM/Layouts/" + p] = DQMItem(layout=rows)
+
+_GEM_OFF_LINK = '<a href="https://twiki.cern.ch/twiki/bin/view/CMS/GEMPPDOfflineDQM">Link to TWiki</a>'
+
+# Occupancy
+gemlayout(dqmitems, "01 DIGI Occupancy",
+    [{ "path": "GEM/GEMOfflineMonitor/Digi/digi_det_ge-11",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMOfflineMonitor/Digi/digi_det_ge+11",    
+       "description": _GEM_OFF_LINK }])
+
+gemlayout(dqmitems, "02 RecHit Occupancy",
+    [{ "path": "GEM/GEMOfflineMonitor/RecHit/hit_det_ge-11",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMOfflineMonitor/RecHit/hit_det_ge+11",
+       "description": _GEM_OFF_LINK }])
+
+# Detector
+gemlayout(dqmitems, "03 Efficiency - Tight GLB Muon",
+    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_detector_ge-11",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_detector_ge+11",
+       "description": _GEM_OFF_LINK }])
+
+gemlayout(dqmitems, "04 Efficiency - STA Muon",
+    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_detector_ge-11",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_detector_ge+11",
+       "description": _GEM_OFF_LINK }])
+
+# Efficiency vs. PT
+gemlayout(dqmitems, "05 Efficiency vs Tight GLB Muon PT",
+    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge-11_odd",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge+11_odd",
+       "description": _GEM_OFF_LINK }],
+    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge-11_even",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge+11_even",
+       "description": _GEM_OFF_LINK }])
+
+gemlayout(dqmitems, "06 Efficiency vs STA Muon PT",
+    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge-11_odd",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge+11_odd",
+       "description": _GEM_OFF_LINK }],
+    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge-11_even",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge+11_even",
+       "description": _GEM_OFF_LINK }])
+
+# Efficiency vs. Eta
+gemlayout(dqmitems, "07 Efficiency vs Tight GLB Muon Eta",
+    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge-11_odd",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge+11_odd",
+       "description": _GEM_OFF_LINK }],
+    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge-11_even",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge+11_even",
+       "description": _GEM_OFF_LINK }])
+
+
+gemlayout(dqmitems, "08 Efficiency vs STA Muon Eta",
+    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge-11_odd",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge+11_odd",
+       "description": _GEM_OFF_LINK }],
+    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge-11_even",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge+11_even",
+       "description": _GEM_OFF_LINK }])
+
+# Phi Residual Histogram Parammeters
+gemlayout(dqmitems, "09 Phi Residual - Tight GLB Muon",
+    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge-11_odd",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge+11_odd",
+       "description": _GEM_OFF_LINK }],
+    [ { "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge-11_even",
+        "description": _GEM_OFF_LINK },
+      { "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge+11_even",
+        "description": _GEM_OFF_LINK }])
+
+gemlayout(dqmitems, "10 Phi Residual - STA Muon",
+    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge-11_odd",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge+11_odd",
+       "description": _GEM_OFF_LINK }],
+    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge-11_even",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge+11_even",
+       "description": _GEM_OFF_LINK }])

--- a/dqmgui/style/GEMRenderPlugin.cc
+++ b/dqmgui/style/GEMRenderPlugin.cc
@@ -4,7 +4,9 @@
 
 #include "TH1F.h"
 #include "TH2F.h"
+#include "TProfile.h"
 #include "TCanvas.h"
+#include "TPaveStats.h"
 
 #include <cassert>
 
@@ -12,166 +14,282 @@
 
 class GEMRenderPlugin : public DQMRenderPlugin
 {
-  private: 
-    SummaryChamber summaryCh;
-    
-    int drawTimeHisto(TH2F *h2Curr) {
-      std::string strNewName = std::string(h2Curr->GetName()).substr(std::string("per_time_").size());
-      std::string strTmpPrefix = "tmp_";
-      
-      Int_t nNbinsX = h2Curr->GetNbinsX();
-      Int_t nNbinsY = h2Curr->GetNbinsY();
-      Int_t nNbinsXActual = 0;
-      
-      for ( nNbinsXActual = 0 ; nNbinsXActual < nNbinsX ; nNbinsXActual++ ) {
-        if ( h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0 ) break;
-      }
-      
-      std::string strTitle = std::string(h2Curr->GetTitle());
-      
-      //std::string strAxisX = h2Curr->GetXaxis()->GetTitle();
-      std::string strAxisX = "Bin per " + std::to_string((Int_t)h2Curr->GetBinContent(0, 0)) + " events";
-      std::string strAxisY = h2Curr->GetYaxis()->GetTitle();
-      //strTitle += ";" + strAxisX + ";" + strAxisY;
-      
-      strTitle = "";
-      TH2F *h2New = new TH2F(( strTmpPrefix + strNewName ).c_str(), strTitle.c_str(), 
-          nNbinsXActual, 0.0, (Double_t)nNbinsXActual, nNbinsY, 0.0, (Double_t)nNbinsY);
-      
-      h2New->GetXaxis()->SetTitle(strAxisX.c_str());
-      h2New->GetYaxis()->SetTitle(strAxisY.c_str());
-      
-      for ( Int_t i = 1 ; i <= nNbinsY ; i++ ) {
-        std::string strLabel = h2Curr->GetYaxis()->GetBinLabel(i);
-        if ( !strLabel.empty() ) h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
-      }
-      
-      for ( Int_t j = 0 ; j <= nNbinsY ; j++ ) 
-      for ( Int_t i = 1 ; i <= nNbinsXActual ; i++ ) {
-        h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
-      }
-      
-      h2New->Draw("colz");
-      
-      return 0;
-    };
-  
-  public:
-    virtual bool applies(const VisDQMObject &o, const VisDQMImgInfo &) override
-    {
-      if ((o.name.find( "GEM/" ) != std::string::npos))
-        return true;
 
-      return false;
+public:
+  virtual bool applies(const VisDQMObject &o, const VisDQMImgInfo &) override
+  {
+    if ((o.name.find( "GEM/" ) != std::string::npos))
+      return true;
+    return false;
+  }
+
+  virtual void preDraw(TCanvas *c, const VisDQMObject &o, const VisDQMImgInfo &, VisDQMRenderInfo &) override
+  {
+    if (o.object == nullptr)
+      return;
+
+    c->cd();
+
+    gStyle->SetOptStat(10);
+
+    if (dynamic_cast<TH1F*>(o.object))
+    {
+      preDrawTH1F(c, o);
     }
-
-    virtual void preDraw(TCanvas *c, const VisDQMObject &o, const VisDQMImgInfo &, VisDQMRenderInfo & ) override
+    else if (dynamic_cast<TH2F*>(o.object))
     {
-      c->cd();
-      
-      gStyle->SetOptStat(10);
-
-      if (dynamic_cast<TH1F*>(o.object))
-        preDrawTH1F(c, o);
-
-      if (dynamic_cast<TH2F*>(o.object))
-        preDrawTH2F(c, o);
+      preDrawTH2F(c, o);
     }
+  }
 
-    virtual void postDraw( TCanvas *c, const VisDQMObject &o, const VisDQMImgInfo & ) override
+  virtual void postDraw( TCanvas *c, const VisDQMObject &o, const VisDQMImgInfo & ) override
+  {
+    if (o.object == nullptr)
+      return;
+
+    c->cd();
+
+    gStyle->SetOptStat(10);
+
+    if (o.name.rfind("summary_statusChamber") != std::string::npos ||
+        o.name.rfind("reportSummaryMap")      != std::string::npos)
     {
-      c->cd();
+      TH2* obj2 = dynamic_cast<TH2*>(o.object);
+      if (obj2 == nullptr) return;
       
-      gStyle->SetOptStat(10);
+      summaryCh.drawStats(obj2);
       
-      if ( o.name.rfind("summary_statusChamber") != std::string::npos ||
-           o.name.rfind("reportSummaryMap")      != std::string::npos ) {
-        TH2* obj2 = dynamic_cast<TH2*>(o.object);
-        //assert(obj2);
-        if ( obj2 == NULL ) return;
-        
-        summaryCh.drawStats(obj2);
-        
-        //obj2->SetStats(false);
-        gStyle->SetOptStat("e");
-        obj2->SetOption("");
-        gPad->SetGridx();
-        gPad->SetGridy();
-        
-        return;
-      }
-      
-      if (dynamic_cast<TH1F*>(o.object))
-        postDrawTH1F(c, o);
-
-      if (dynamic_cast<TH2F*>(o.object))
-        postDrawTH2F(c, o);
-    }
-
-  private:
-    void preDrawTH1F(TCanvas *, const VisDQMObject &o)
-    {
-      bool setColor = true;
-      if (o.name.rfind(" U") == o.name.size() - 2)
-        setColor = false;
-      if (o.name.rfind(" V") == o.name.size() - 2)
-        setColor = false;
-      if (o.name.find("events per BX") != std::string::npos)
-        setColor = false;
-
-      TH1F* obj = dynamic_cast<TH1F*>(o.object);
-      assert(obj);
-      
-      //obj->SetStats(false);
-
-      if (setColor)
-        obj->SetLineColor(2);
-
-      obj->SetLineWidth(2);
-    }
-
-    void preDrawTH2F(TCanvas *, const VisDQMObject &o)
-    {
-      TH2F* obj = dynamic_cast<TH2F*>(o.object);
-      assert(obj);
-      
-      obj->SetOption("colz");
-      //obj->SetStats(false);
-      
+      //obj2->SetStats(false);
+      gStyle->SetOptStat("e");
+      obj2->SetOption("");
       gPad->SetGridx();
       gPad->SetGridy();
+
+      return;
+    }
+    else if (dynamic_cast<TH1F*>(o.object))
+    {
+      postDrawTH1F(c, o);
+    }
+    else if (dynamic_cast<TH2F*>(o.object))
+    {
+      postDrawTH2F(c, o);
+    }
+    else if (dynamic_cast<TProfile*>(o.object))
+    {
+      postDrawTProfile(c, o);
+    }
+  }
+
+private:
+  SummaryChamber summaryCh;
+
+  void preDrawTH1F(TCanvas *, const VisDQMObject &o)
+  {
+    if (o.object == nullptr)
+      return;
+
+    bool setColor = true;
+    if (o.name.rfind(" U") == o.name.size() - 2)
+      setColor = false;
+    if (o.name.rfind(" V") == o.name.size() - 2)
+      setColor = false;
+    if (o.name.find("events per BX") != std::string::npos)
+      setColor = false;
+
+    TH1F* obj = dynamic_cast<TH1F*>(o.object);
+    assert(obj);
+
+    if (setColor)
+      obj->SetLineColor(2);
+
+    obj->SetLineWidth(2);
+  }
+
+  void preDrawTH2F(TCanvas *, const VisDQMObject &o)
+  {
+    TH2F* obj = dynamic_cast<TH2F*>(o.object);
+    assert(obj);
+
+    obj->SetOption("colz");
+
+    gPad->SetGridx();
+    gPad->SetGridy();
+  }
+
+  void postDrawTH1F(TCanvas *c, const VisDQMObject &o)
+  {
+    TH1F* obj = dynamic_cast<TH1F*>(o.object);
+    assert(obj);
+
+    // NOTE
+    if (TPRegexp("^GEM/GEMEfficiency/\\w+Muon/Efficiency/muon_\\w+_(?:matched_)?ge(\\+|\\-)\\d1_(odd|even)$").MatchB(o.name))
+    {
+      // e.g. GEM/GEMEfficiency/StandaloneMuon/Efficiency/muon_eta_ge-11_odd
+      obj->SetOption("hist E");
+      gStyle->SetOptStat("euo");
+
+      obj->SetLineColor(602);
+      obj->SetFillColorAlpha(602, 0.3);
+
+      if (auto stats = dynamic_cast<TPaveStats*>(obj->GetListOfFunctions()->FindObject("stats")))
+      {
+        stats->SetY1NDC(0.905);
+        stats->SetY2NDC(1.0);
+      }
+
+    }
+    else if (TPRegexp("^GEM/GEMEfficiency/\\w+Muon/Resolution/(residual|pull)_\\w+_ge(\\+|\\-)\\d1_(odd|even)_ieta\\d$").MatchB(o.name))
+    {
+      // e.g. GEM/GEMEfficiency/StandaloneMuon/Resolution/pull_x_ge-11_even_ieta1
+      obj->SetOption("hist E");
+      gStyle->SetOptStat("emruos");
+
+      obj->SetLineColor(602);
+      obj->SetFillColorAlpha(602, 0.3);
+
+      if (auto stats = dynamic_cast<TPaveStats*>(obj->GetListOfFunctions()->FindObject("stats")))
+      {
+        stats->SetY1NDC(0.905);
+        stats->SetY2NDC(1.0);
+      }
+
+    }
+    else
+    {
+      gStyle->SetOptStat(10);
     }
 
-    void postDrawTH1F(TCanvas *c, const VisDQMObject &o)
+    c->SetGridx();
+    c->SetGridy();
+  }
+
+  void postDrawTH2F(TCanvas *c, const VisDQMObject &o)
+  {
+    TH2F* obj = dynamic_cast<TH2F*>(o.object);
+    assert(obj);
+
+    if (o.name.find("GEM/StatusDigi") != std::string::npos)
     {
-      TH1F* obj = dynamic_cast<TH1F*>(o.object);
-      assert(obj);
-      
-      //obj->SetStats(false);
-      c->SetGridx();
-      c->SetGridy();
+      obj->SetStats(false);
     }
 
-    void postDrawTH2F(TCanvas *c, const VisDQMObject &o)
+    if (o.name.find("GEM/StatusDigi/per_time_") != std::string::npos)
     {
-      TH2F* obj = dynamic_cast<TH2F*>(o.object);
-      assert(obj);
-      
-      if ( o.name.find("GEM/StatusDigi") != std::string::npos ) {
-        obj->SetStats(false);
-      }
-      
-      if ( o.name.find("GEM/StatusDigi/per_time_") != std::string::npos ) {
-        drawTimeHisto(dynamic_cast<TH2F*>(o.object));
-        
-      }
-      
-      //obj->SetStats(false);
-      c->SetGridx();
-      c->SetGridy();
+      drawTimeHisto(dynamic_cast<TH2F*>(o.object));
     }
+
+    if (TPRegexp("GEM/GEMEfficiency/\\w+Muon/Efficiency/detector_(?:matched_)?ge(\\+|\\-)\\d1$").MatchB(o.name))
+    {
+      // e.g. GEM/GEMEfficiency/StandaloneMuon/Efficiency/detector_matched_ge-11
+      obj->SetOption("colz");
+      gStyle->SetOptStat("e");
+    }
+    else if (TPRegexp("GEM/GEMEfficiency/\\w+Muon/Efficiency/eff_detector_ge(\\+|\\-)\\d1$").MatchB(o.name))
+    {
+      // e.g. GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_detector_ge-11
+      obj->SetOption("colz");
+      gStyle->SetOptStat(0);
+
+      obj->SetMinimum(0.80);
+      obj->SetMaximum(1.00);
+    }
+    else if (TPRegexp("GEM/GEMEfficiency/\\w+Muon/Resolution/residual_phi_ge(\\+|\\-)\\d1_(odd|even)$").MatchB(o.name))
+    {
+      // e.g. GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge-11_even
+      obj->SetOption("colz text");
+      obj->SetStats(false);
+      gStyle->SetOptStat(0);
+
+      obj->Scale(1000); // rad to mrad
+      obj->GetYaxis()->SetBinLabel(1, "#splitline{Mean}{[mrad]}");
+      obj->GetYaxis()->SetBinLabel(2, "#splitline{Std. Dev.}{[mrad]}");
+
+      obj->SetNdivisions(-obj->GetNbinsX(), "Y"); // use a negative number to turn off ndivisios optimization.
+      obj->SetNdivisions(-obj->GetNbinsY(), "X");
+
+      gStyle->SetGridStyle(1);
+      gStyle->SetGridWidth(3);
+      gStyle->SetPaintTextFormat(".3f");
+    }
+
+    c->SetGridx();
+    c->SetGridy();
+  }
+
+  void postDrawTProfile(TCanvas *c, const VisDQMObject &o)
+  {
+    TProfile* obj = dynamic_cast<TProfile*>(o.object);
+    assert(obj);
+
+    if (TPRegexp("^GEM/GEMEfficiency/\\w+Muon/Efficiency/eff_muon_\\w+_ge(\\+|\\-)\\d1_(odd|even)").MatchB(o.name))
+    {
+      obj->SetOption("E");
+      obj->SetStats(false);
+      gStyle->SetOptStat(0);
+
+      obj->SetMinimum(-0.05);
+      obj->SetMaximum(1.05);
+      obj->SetLineColor(kRed);
+      obj->SetLineWidth(2);
+    }
+    else
+    {
+      obj->SetOption("E");
+      gStyle->SetOptStat(10);
+    }
+
+    c->SetGridx();
+    c->SetGridy();
+  }
+
+  int drawTimeHisto(TH2F *h2Curr)
+  {
+    std::string strNewName = std::string(h2Curr->GetName()).substr(std::string("per_time_").size());
+    std::string strTmpPrefix = "tmp_";
+
+    Int_t nNbinsX = h2Curr->GetNbinsX();
+    Int_t nNbinsY = h2Curr->GetNbinsY();
+    Int_t nNbinsXActual = 0;
+
+    for ( nNbinsXActual = 0 ; nNbinsXActual < nNbinsX ; nNbinsXActual++ )
+    {
+      if ( h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0 ) break;
+    }
+
+    std::string strTitle = std::string(h2Curr->GetTitle());
+
+    //std::string strAxisX = h2Curr->GetXaxis()->GetTitle();
+    std::string strAxisX = "Bin per " + std::to_string((Int_t)h2Curr->GetBinContent(0, 0)) + " events";
+    std::string strAxisY = h2Curr->GetYaxis()->GetTitle();
+    //strTitle += ";" + strAxisX + ";" + strAxisY;
+
+    strTitle = "";
+    TH2F *h2New = new TH2F(( strTmpPrefix + strNewName ).c_str(), strTitle.c_str(),
+        nNbinsXActual, 0.0, (Double_t)nNbinsXActual, nNbinsY, 0.0, (Double_t)nNbinsY);
+
+    h2New->GetXaxis()->SetTitle(strAxisX.c_str());
+    h2New->GetYaxis()->SetTitle(strAxisY.c_str());
+
+    for ( Int_t i = 1 ; i <= nNbinsY ; i++ )
+    {
+      std::string strLabel = h2Curr->GetYaxis()->GetBinLabel(i);
+      if ( !strLabel.empty() ) h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
+    }
+
+    for ( Int_t j = 0 ; j <= nNbinsY ; j++ )
+    {
+      for ( Int_t i = 1 ; i <= nNbinsXActual ; i++ )
+      {
+        h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
+      }
+    }
+
+    h2New->Draw("colz");
+
+    return 0;
+  };
 };
 
 //----------------------------------------------------------------------------------------------------
 static GEMRenderPlugin instance;
-

--- a/dqmgui/workspaces-offline.py
+++ b/dqmgui/workspaces-offline.py
@@ -187,6 +187,19 @@ server.workspace('DQMContent', 41, 'Muons', 'DT', '^DT/', '')
 
 server.workspace('DQMContent', 42, 'Muons', 'RPC', '^RPC/', '')
 
+server.workspace('DQMContent', 43, 'Muons', 'GEM', '^GEM/', '',
+                 "GEM/Layouts/01 DIGI Occupancy",
+                 "GEM/Layouts/02 RecHit Occupancy",
+                 "GEM/Layouts/03 Efficiency - Tight GLB Muon",
+                 "GEM/Layouts/04 Efficiency - STA Muon",
+                 "GEM/Layouts/05 Efficiency vs Tight GLB Muon PT",
+                 "GEM/Layouts/06 Efficiency vs STA Muon PT",
+                 "GEM/Layouts/07 Efficiency vs Tight GLB Muon Eta",
+                 "GEM/Layouts/08 Efficiency vs STA Muon Eta",
+                 "GEM/Layouts/09 Phi Residual - Tight GLB Muon",
+                 "GEM/Layouts/10 Phi Residual - STA Muon",
+                )
+
 # CTPPS workspaces:
 server.workspace('DQMContent', 50, 'CTPPS', 'TrackingStrip', '^CTPPS/(TrackingStrip|common)/', 'CTPPS/TrackingStrip/Layouts')
 server.workspace('DQMContent', 51, 'CTPPS', 'TrackingPixel', '^CTPPS/(TrackingPixel|common)/', 'CTPPS/TrackingPixel/Layouts')


### PR DESCRIPTION
This is the first PR to add GEM offline DQM.

- Added a workspace to the offline flavor for GEM.
- Created gem_T0_layouts.py 
- Added pre-/post-draw methods for TProfile, which is mainly used to store the data of 1D TEfficiency, to GEMRenderPlugin.cc. Also, cleaned up code.
- Tested this PR with an `HG2010d` tag and private MC sample. [Offline Local server](https://offlinedqm.sscc.uos.ac.kr/dqm/offline) is running now.
  - Please select `/TenMuExtendedE_0_200_pythia8/Run3/DQMIO` MC dataset.
- CMSSW_11_2_0_pre2 or later include the related DQM modules and configs.
  - Related PR is [here](https://github.com/cms-sw/cmssw/pull/30468).

@jshlee @watson-ij