### PR TITLE
MSOutput: RSE expression to skip T0 Tape endpoint

### DIFF
--- a/reqmgr2ms/config-output.py
+++ b/reqmgr2ms/config-output.py
@@ -97,6 +97,8 @@ data.enableDataPlacement = False
 data.enableRelValCustodial = False
 data.excludeDataTier = ['NANOAOD', 'NANOAODSIM']
 data.rucioRSEAttribute = "ddm_quota"
+# FIXME: remove T0 Tape once CTA is ready to receive output data placement
+data.rucioTapeExpression = "rse_type=TAPE\cms_type=test\\rse=T0_CH_CERN_Tape"
 data.useRucio = False
 data.rulesLifetime = RULE_LIFETIME
 data.rucioAccount = RUCIO_ACCT


### PR DESCRIPTION
This configuration will have to change once T0_CH_CERN_Tape can start receiving custodial output data placement created from MSOutput.

Configuration change required by: https://github.com/dmwm/WMCore/pull/9957

TODO: port these changes to services_config