### PR TITLE
Remove phedex from services

### DIFF
--- a/das/das2go-config.json
+++ b/das/das2go-config.json
@@ -3,7 +3,7 @@
     "uri":"mongodb://localhost:8230",
     "base": "/das",
     "port": 8217,
-    "services": ["combined","conddb","dbs3","mcm","phedex","reqmgr2","runregistry","cric","rucio"],
+    "services": ["combined","conddb","dbs3","mcm","reqmgr2","runregistry","cric","rucio"],
     "urlQueueLimit": 1000,
     "urlRetry": 3,
     "templates": "{ROOT}/das2go/templates",


### PR DESCRIPTION
Per Nick request (L2 CompOps) we'll remove phedex from DAS lookup. This PR contains a change to DAS configuration which will remove the phedex as list of services DAS talks to.