### PR TITLE
Disable pre-prod reqmgr2 CherryPy threads

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -123,7 +123,9 @@ ui_main.application = ui.index
 
 extentions = config.section_("extensions")
 # Production instance of wmdatamining, must be a production back-end
-if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117"):
+# Disable CherryPy thread tasks from testbed (vocms0731), as this will be started
+# from k8s and only one cherrypy instance can be run at a time to avoid issues with CouchDB
+if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
 #     wmdatamining = extentions.section_("wmdatamining")
 #     wmdatamining.object = "WMCore.ReqMgr.CherryPyThreads.WMDataMining.WMDataMining"
 #     wmdatamining.wmstats_url = "%s/%s" % (data.couch_host, data.couch_wmstats_db)
@@ -163,7 +165,8 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswi
     parentageFixTask.central_logdb_url = LOG_DB_URL
     parentageFixTask.log_reporter = LOG_REPORTER
 
-if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117"):
+# Testbed VM vocms0731 removed to disable CherryPy threads for k8s migration
+if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
     # status change task 
     statusChangeTasks = extentions.section_("statusChangeTasks")
     statusChangeTasks.object = "WMCore.ReqMgr.CherryPyThreads.StatusChangeTasks.StatusChangeTasks"
@@ -211,7 +214,8 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswi
     heartbeatMonitor.central_logdb_url = LOG_DB_URL
     heartbeatMonitor.log_reporter = LOG_REPORTER
     # AMQ MonIT settings
-    if HOST.startswith("vocms0766") or HOST.startswith("vocms0731"):
+    # Testbed VM vocms0731 removed for k8s migration
+    if HOST.startswith("vocms0766"):
         heartbeatMonitor.post_to_amq = True
     else:
         heartbeatMonitor.post_to_amq = False


### PR DESCRIPTION
We are migrating reqmgr2 to the k8s testbed. We cannot run VM and k8s reqmgr2 threads at the same time so this PR will prevent the VM instances of the reqmgr2 cherrypy threads from running.