### PR TITLE
Disable production reqmon CherryPy threads

### DIFF
--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -92,7 +92,7 @@ dataCacheTasks.log_reporter = "%s-%s" % (LOG_REPORTER, HOST)
 # Production/testbed instance of logdb, must be a production/testbed back-end
 # Disable CherryPy thread tasks from testbed (vocms0731), as this will be started
 # from k8s and only one cherrypy instance can be run at a time to avoid issues with CouchDB
-if HOST.startswith("vocms0743") or HOST.startswith("vocms0117"):
+if HOST.startswith("vocms0117"):
     
     # LogDB task (update and clean up)
     logDBTasks = extentions.section_("logDBTasks")


### PR DESCRIPTION
This PR will disable reqmon production cherrypy threads in the VM infrastructure. These threads will migrate to running via a reqmon-tasks pod in production k8s on Nov 24.