### PR TITLE
Disable production t0_reqmon CherryPy threads

### DIFF
--- a/t0_reqmon/config.py
+++ b/t0_reqmon/config.py
@@ -73,7 +73,7 @@ dataCacheTasks.log_file = '%s/logs/t0_reqmon/dataCacheTasks-%s-%s.log' % (__file
 # Production/testbed instance of logdb, must be a production/testbed back-end
 # Disable CherryPy thread tasks from testbed (vocms0731), as this will be started
 # from k8s and only one cherrypy instance can be run at a time to avoid issues with CouchDB
-if HOST.startswith("vocms0744") or HOST.startswith("vocms0117"):
+if HOST.startswith("vocms0117"):
     
     # LogDB task (update and clean up)
     logDBTasks = extentions.section_("logDBTasks")


### PR DESCRIPTION
This PR will disable t0_reqmon production cherrypy threads in the VM infrastructure. These threads will migrate to running via a t0reqmon-tasks pod in production k8s on Nov 24.