### PR TITLE
Disable pre-prod reqmgr2 CherryPy threads, take2

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -121,7 +121,9 @@ ui_main.application = ui.index
 #ui_main.authz_defaults = {"role": None, "group": None, "site": None, "policy": "dangerously_insecure"}
 
 extentions = config.section_("extensions")
-if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117"):
+# Disable CherryPy thread tasks from testbed (vocms0731), as this will be started
+# from k8s and only one cherrypy instance can be run at a time to avoid issues with CouchDB
+if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
     # ACDC/workqueue cleanup threads
     couchCleanup = extentions.section_("couchCleanup")
     couchCleanup.object = "WMCore.ReqMgr.CherryPyThreads.CouchDBCleanup.CouchDBCleanup"
@@ -146,8 +148,9 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswi
     parentageFixTask.central_logdb_url = LOG_DB_URL
     parentageFixTask.log_reporter = LOG_REPORTER
 
-if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswith("vocms0117"):
-    # status change task 
+# Testbed VM vocms0731 removed to disable CherryPy threads for k8s migration
+if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
+    # status change task
     statusChangeTasks = extentions.section_("statusChangeTasks")
     statusChangeTasks.object = "WMCore.ReqMgr.CherryPyThreads.StatusChangeTasks.StatusChangeTasks"
     statusChangeTasks.reqmgr2_url = REQMGR2_URL
@@ -194,7 +197,8 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0731") or HOST.startswi
     heartbeatMonitor.central_logdb_url = LOG_DB_URL
     heartbeatMonitor.log_reporter = LOG_REPORTER
     # AMQ MonIT settings
-    if HOST.startswith("vocms0766") or HOST.startswith("vocms0731"):
+    # Testbed VM vocms0731 removed for k8s migration
+    if HOST.startswith("vocms0766"):
         heartbeatMonitor.post_to_amq = True
     else:
         heartbeatMonitor.post_to_amq = False


### PR DESCRIPTION
Superseeds https://github.com/dmwm/deployment/pull/980 (thanks to Erik!)

This disables reqmgr2 cherrypy threads in the VM testbed cluster.