### PR TITLE
Fix certificate key permissions for workqueue/reqmgr2ms

### DIFF
--- a/admin/InstallProd
+++ b/admin/InstallProd
@@ -252,6 +252,10 @@ case $STAGE in
         echo '  esac'
         echo '  chmod 750 $d'
         echo '  chmod -R 440 $d/*'
+        echo '  case $svc in'
+        echo '     workqueue ) chmod -R 400 $d/dmwm-service-key.pem;;'
+        echo '     reqmgr2ms ) chmod -R 400 $d/dmwm-service-key.pem;;'
+        echo '  esac'
         echo 'done'
         echo 'exit 0'
        ) | ssh cmsweb@$host bashs -l


### PR DESCRIPTION
With the latest version of rucio-clients, provided here:
https://github.com/cms-sw/cmsdist/pull/6447

services with key certificate permissions different than 0400 are no longer able to authenticate to the Rucio server.

This pull request enforces the key file to have 0400 permissions for `workqueue` and `reqmgr2ms` services, which depend on rucio-clients.
Changes have been tested by Imran (thanks!)