### PR TITLE
Change order of dbs redirects

### DIFF
--- a/frontend/app_dbs_nossl.conf
+++ b/frontend/app_dbs_nossl.conf
@@ -1,2 +1,2 @@
-RewriteRule ^(/dbs(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dbs2go(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dbs(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]

--- a/frontend/app_dbs_ssl.conf
+++ b/frontend/app_dbs_ssl.conf
@@ -1,3 +1,5 @@
+RewriteRule ^(/dbs2go(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
+RewriteRule ^/auth/complete(/dbs2go(/.*)?)$ http://%{ENV:BACKEND}:8258${escape:$1} [QSA,P,L,NE]
 RewriteRule ^(/dbs(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
 RewriteRule ^/auth/complete(/dbs(/.*)/global/DBSReader(/.*)?)$ http://%{ENV:BACKEND}:8252${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dbs(/.*)/global/DBSWriter(/.*)?)$ http://%{ENV:BACKEND}:8253${escape:$1} [QSA,P,L,NE]
@@ -5,5 +7,3 @@ RewriteRule ^/auth/complete(/dbs(/.*)/phys03/DBSReader(/.*)?)$ http://%{ENV:BACK
 RewriteRule ^/auth/complete(/dbs(/.*)/phys03/DBSWriter(/.*)?)$ http://%{ENV:BACKEND}:8255${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dbs(/.*)/DBSMigrate(/.*)?)$ http://%{ENV:BACKEND}:8257${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dbs(/.*)?)$ http://%{ENV:BACKEND}:8250${escape:$1} [QSA,P,L,NE]
-RewriteRule ^(/dbs2go(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
-RewriteRule ^/auth/complete(/dbs2go(/.*)?)$ http://%{ENV:BACKEND}:8258${escape:$1} [QSA,P,L,NE]

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -23,6 +23,7 @@
 ^/auth/complete/(?:couchdb/reqmgr_auxiliary|couchdb)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/crabcache(?:/|$) crabcache.crab.svc.cluster.local
 ^/auth/complete/crabserver(?:/|$) crabserver.crab.svc.cluster.local
+^/auth/complete/dbs2go(?:/|$) dbs2go.dbs.svc.cluster.local
 ^/auth/complete/dbs/(?:int/global/DBSMigrate|prod/global/DBSMigrate|dev/global/DBSMigrate)(?:/|$) dbs-migrate.dbs.svc.cluster.local
 ^/auth/complete/dbs/(?:int/global/DBSReader|prod/global/DBSReader|dev/global/DBSReader)(?:/|$) dbs-global-r.dbs.svc.cluster.local
 ^/auth/complete/dbs/(?:int/global/DBSWriter|prod/global/DBSWriter|dev/global/DBSWriter)(?:/|$) dbs-global-w.dbs.svc.cluster.local
@@ -61,4 +62,3 @@
 ^/auth/complete/scheddmon/0199/ vocms0199.cern.ch
 ^/auth/complete/httpgo(?:/|$) httpgo.http.svc.cluster.local
 ^/auth/complete/httpsgo(?:/|$) httpsgo.http.svc.cluster.local
-^/auth/complete/dbs2go(?:/|$) dbs2go.dbs.svc.cluster.local


### PR DESCRIPTION
@muhammadimranfarooqi , turns out that original rules didn't work since /dbs was picked first instead of /dbs2go. I changed the order of rules. Please merge and redeploy again FE's on k8s testbed