### PR TITLE
Disable production VM reqmgr2 CherryPy threads

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -123,7 +123,8 @@ ui_main.application = ui.index
 extentions = config.section_("extensions")
 # Disable CherryPy thread tasks from testbed (vocms0731), as this will be started
 # from k8s and only one cherrypy instance can be run at a time to avoid issues with CouchDB
-if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
+# Prod VM vocms0766 and Testbed VM vocms0731 removed to disable CherryPy threads for k8s migration
+if HOST.startswith("vocms0117"):
     # ACDC/workqueue cleanup threads
     couchCleanup = extentions.section_("couchCleanup")
     couchCleanup.object = "WMCore.ReqMgr.CherryPyThreads.CouchDBCleanup.CouchDBCleanup"
@@ -148,8 +149,8 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
     parentageFixTask.central_logdb_url = LOG_DB_URL
     parentageFixTask.log_reporter = LOG_REPORTER
 
-# Testbed VM vocms0731 removed to disable CherryPy threads for k8s migration
-if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
+# Prod VM vocms0766 and Testbed VM vocms0731 removed to disable CherryPy threads for k8s migration
+if HOST.startswith("vocms0117"):
     # status change task
     statusChangeTasks = extentions.section_("statusChangeTasks")
     statusChangeTasks.object = "WMCore.ReqMgr.CherryPyThreads.StatusChangeTasks.StatusChangeTasks"
@@ -198,10 +199,15 @@ if HOST.startswith("vocms0766") or HOST.startswith("vocms0117"):
     heartbeatMonitor.log_reporter = LOG_REPORTER
     # AMQ MonIT settings
     # Testbed VM vocms0731 removed for k8s migration
-    if HOST.startswith("vocms0766"):
-        heartbeatMonitor.post_to_amq = True
-    else:
-        heartbeatMonitor.post_to_amq = False
+    # Commenting this logic to remove prod VM vocms0766 for k8s migration
+    #if HOST.startswith("vocms0766"):
+    #    heartbeatMonitor.post_to_amq = True
+    #else:
+    #    heartbeatMonitor.post_to_amq = False
+
+    # Since no prod/testbed VMs remain, post_to_amq is always false
+    heartbeatMonitor.post_to_amq = False
+
     heartbeatMonitor.user_amq = USER_AMQ
     heartbeatMonitor.pass_amq = PASS_AMQ
     heartbeatMonitor.topic_amq = AMQ_TOPIC


### PR DESCRIPTION
This will disable the reqmgr2 CherryPy threads in the production VM infrastructure. These reqmgr2 threads should be disabled before the reqmgr2-tasks pod is enabled in k8s production on Dec. 8