### PR TITLE
Re-enable T0 Tape in MSOutput

### DIFF
--- a/reqmgr2ms/config-output.py
+++ b/reqmgr2ms/config-output.py
@@ -100,8 +100,7 @@ data.enableRelValCustodial = False
 data.excludeDataTier = []
 data.rucioRSEAttribute = "ddm_quota"
 data.rucioDiskRuleWeight = "ddm_quota"
-# FIXME: remove T0 Tape once CTA is ready to receive output data placement
-data.rucioTapeExpression = "rse_type=TAPE\cms_type=test\\rse=T0_CH_CERN_Tape"
+data.rucioTapeExpression = "rse_type=TAPE\cms_type=test"  # "rse_type=TAPE\cms_type=test\\rse=T0_CH_CERN_Tape"
 data.rulesLifetime = RULE_LIFETIME
 data.ruleLifetimeRelVal = RULE_LIFETIME_RELVAL
 data.rucioAccount = RUCIO_ACCT


### PR DESCRIPTION
As the title says, update the MSOutput configuration such that T0_CH_CERN_Tape can again be selected as destination for Tape output data placement.

services_config changes provided in:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/52
and
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/53