### PR TITLE
Make Rucio URLs configurable in Global WorkQueue

### DIFF
--- a/workqueue/config.py
+++ b/workqueue/config.py
@@ -44,6 +44,13 @@ except ImportError:
     AMQ_TOPIC=None
 
 RUCIO_ACCT = "wmcore_transferor"
+# Production service has to point to production Rucio, anything else will use pre-production
+if HOST.startswith("vocms0740") or HOST.startswith("vocms0117"):
+    RUCIO_AUTH_URL="https://cms-rucio-auth.cern.ch"
+    RUCIO_URL="http://cms-rucio.cern.ch"
+else:
+    RUCIO_AUTH_URL="https://cmsrucio-auth-int.cern.ch"
+    RUCIO_URL="http://cmsrucio-int.cern.ch"
 
 config = Configuration()
 
@@ -91,6 +98,8 @@ def setWorkQueueCommonConfig(config):
     config.queueParams['central_logdb_url'] = LOG_DB_URL
     config.queueParams['log_reporter'] = LOG_REPORTER
     config.queueParams['rucioAccount'] = RUCIO_ACCT
+    config.queueParams['rucioAuthUrl'] = RUCIO_AUTH_URL
+    config.queueParams['rucioUrl'] = RUCIO_URL
 
     config.reqMgrConfig = {}
     config.reqMgrConfig['reqmgr2_endpoint'] = REQMGR2


### PR DESCRIPTION
Define the Rucio host and authentication host in the service configuration file, instead of relying on the rucio.cfg one.
Change required by: https://github.com/dmwm/WMCore/pull/10099

TODO: create the gitlab MRs