### PR TITLE
Disable ms-output in prod and testbed VMs

### DIFF
--- a/reqmgr2ms/manage
+++ b/reqmgr2ms/manage
@@ -43,7 +43,7 @@ STATEDIR=$TOP/state/$ME
 if [[ $(hostname -s) == "vocms0731" || $(hostname -s) == "vocms0742" ]]; then
   CFGFILETR=$CFGDIR # force ms-transferor to be disabled
   CFGFILEMON=$CFGDIR # force ms-monitor to be disabled
-  CFGFILEOUT=$CFGDIR/config-output.py
+  CFGFILEOUT=$CFGDIR # force ms-output to be disabled
   CFGFILERCLEAN=$CFGDIR # force ms-ruleCleaner to be disabled
 else
   CFGFILETR=$CFGDIR/config-transferor.py


### PR DESCRIPTION
ms-output was already stopped manually in the VM testbed when ms-output was migrated to preprod k8s. This would ensure it does not start.

cc @amaltaro 