### PR TITLE
Update DBS URL in WMCore to point to cmsweb-prod

### DIFF
--- a/reqmgr2/config.py
+++ b/reqmgr2/config.py
@@ -90,6 +90,7 @@ if DBS_INS == "private_vm":
     data.dbs_url = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSWriter"
 else:
     data.dbs_url = "%s/dbs/%s/global/DBSWriter" % (BASE_URL, DBS_INS)
+    data.dbs_url = data.dbs_url.replace("cmsweb.cern.ch", "cmsweb-prod.cern.ch")
 
 # web user interface
 ui = views.section_("ui")

--- a/reqmgr2ms/config-transferor.py
+++ b/reqmgr2ms/config-transferor.py
@@ -88,6 +88,7 @@ if DBS_INS == "private_vm":
     data.dbsUrl = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
 else:
     data.dbsUrl = "%s/dbs/%s/global/DBSReader" % (BASE_URL, DBS_INS)
+    data.dbsUrl = data.dbsUrl.replace("cmsweb.cern.ch", "cmsweb-prod.cern.ch")
 
 # heartbeat monitor task
 extentions = config.section_("extensions")

--- a/reqmon/config.py
+++ b/reqmon/config.py
@@ -66,6 +66,7 @@ if DBS_INS == "private_vm":
     data.dbs_url = "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader"
 else:
     data.dbs_url = "%s/dbs/%s/global/DBSReader" % (BASE_URL, DBS_INS)
+    data.dbs_url = data.dbs_url.replace("cmsweb.cern.ch", "cmsweb-prod.cern.ch")
 
 # web user interface
 ui = views.section_("ui")

--- a/workqueue/config.py
+++ b/workqueue/config.py
@@ -18,7 +18,6 @@ reqmgrCouchDB = "reqmgr_workload_cache"
 
 HOST = socket.gethostname().lower()
 BASE_URL = "@@BASE_URL@@"
-DBS_INS = "@@DBS_INS@@"
 COUCH_URL = "%s/couchdb" % BASE_URL
 
 REQMGR2 = "%s/reqmgr2" % BASE_URL


### PR DESCRIPTION
As recently discussed, change the DBS url to use the new k8s frontends, `cmsweb-prod`.

To go in with: https://github.com/dmwm/WMCore/pull/10269