### PR TITLE
Remove phedex_url from T0/WMAgent manage script

### DIFF
--- a/tier0/manage
+++ b/tier0/manage
@@ -40,7 +40,6 @@ LOCAL_WORKQUEUE_DBNAME=workqueue
 WORKLOAD_SUMMARY_URL=
 WMSTATS_URL=
 DBS3_URL=
-PHEDEX_URL=
 DQM_URL=
 REQUESTCOUCH_URL=
 CENTRAL_LOGDB_URL=
@@ -108,7 +107,6 @@ load_secrets_file(){
 
     local MATCH_WMSTATS_URL=`cat $WMAGENT_SECRETS_LOCATION | grep WMSTATS_URL | sed s/WMSTATS_URL=//`
     local MATCH_DBS3_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DBS3_URL | sed s/DBS3_URL=//`
-    local MATCH_PHEDEX_URL=`cat $WMAGENT_SECRETS_LOCATION | grep PHEDEX_URL | sed s/PHEDEX_URL=//`
     local MATCH_DQM_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DQM_URL | sed s/DQM_URL=//`
     local MATCH_REQUESTCOUCH_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQUESTCOUCH_URL | sed s/REQUESTCOUCH_URL=//`
     local MATCH_CENTRAL_LOGDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep CENTRAL_LOGDB_URL | sed s/CENTRAL_LOGDB_URL=//`
@@ -166,8 +164,6 @@ load_secrets_file(){
 
     DBS3_URL=${MATCH_DBS3_URL:-$DBS3_URL}
 
-    PHEDEX_URL=${MATCH_PHEDEX_URL:-$PHEDEX_URL}
-
     DQM_URL=${MATCH_DQM_URL:-$DQM_URL}
     
     REQUESTCOUCH_URL=${MATCH_REQUESTCOUCH_URL:-$REQUESTCOUCH_URL}
@@ -206,7 +202,6 @@ print_settings(){
     echo "WORKLOAD_SUMMARY_URL=      $WORKLOAD_SUMMARY_URL      "
     echo "WMSTATS_URL=               $WMSTATS_URL               "
     echo "DBS3_URL=                  $DBS3_URL                  "
-    echo "PHEDEX_URL=                $PHEDEX_URL                "
     echo "DQM_URL=                   $DQM_URL                   "
     echo "DASHBOARD_URL=             $DASHBOARD_URL             "
     echo "REQUESTCOUCH_URL=          $REQUESTCOUCH_URL          "
@@ -368,7 +363,6 @@ initialize_tier0(){
                        --grafana_token=$GRAFANA_TOKEN \
                        --wmstats_url=$WMSTATS_URL \
                        --dbs3_url=$DBS3_URL \
-                       --phedex_url=$PHEDEX_URL \
                        --dqm_url=$DQM_URL \
                        --requestcouch_url=$REQUESTCOUCH_URL \
                        --central_logdb_url=$CENTRAL_LOGDB_URL \

--- a/wmagent/manage
+++ b/wmagent/manage
@@ -74,7 +74,6 @@ REQMGR_URL=
 REQMGR2_URL=
 ACDC_URL=
 DBS3_URL=
-PHEDEX_URL=
 DQM_URL=
 REQUESTCOUCH_URL=
 CENTRAL_LOGDB_URL=
@@ -162,7 +161,6 @@ load_secrets_file(){
     local MATCH_REQMGR2_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQMGR2_URL | sed s/REQMGR2_URL=//`
     local MATCH_ACDC_URL=`cat $WMAGENT_SECRETS_LOCATION | grep ACDC_URL | sed s/ACDC_URL=//`
     local MATCH_DBS3_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DBS3_URL | sed s/DBS3_URL=//`
-    local MATCH_PHEDEX_URL=`cat $WMAGENT_SECRETS_LOCATION | grep PHEDEX_URL | sed s/PHEDEX_URL=//`
     local MATCH_DQM_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DQM_URL | sed s/DQM_URL=//`
     local MATCH_REQUESTCOUCH_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQUESTCOUCH_URL | sed s/REQUESTCOUCH_URL=//`
     local MATCH_CENTRAL_LOGDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep CENTRAL_LOGDB_URL | sed s/CENTRAL_LOGDB_URL=//`
@@ -239,9 +237,7 @@ load_secrets_file(){
     ACDC_URL=${MATCH_ACDC_URL:-$ACDC_URL}
     
     DBS3_URL=${MATCH_DBS3_URL:-$DBS3_URL}
-    
-    PHEDEX_URL=${MATCH_PHEDEX_URL:-$PHEDEX_URL}
-    
+
     DQM_URL=${MATCH_DQM_URL:-$DQM_URL}
 
     REQUESTCOUCH_URL=${MATCH_REQUESTCOUCH_URL:-$REQUESTCOUCH_URL}
@@ -293,7 +289,6 @@ print_settings(){
     echo "REQMGR2_URL=               $REQMGR2_URL               "
     echo "ACDC_URL=                  $ACDC_URL                  "
     echo "DBS3_URL=                  $DBS3_URL                  "
-    echo "PHEDEX_URL=                $PHEDEX_URL                "
     echo "DQM_URL=                   $DQM_URL                   "
     echo "REQUESTCOUCH_URL=          $REQUESTCOUCH_URL          "
     echo "CENTRAL_LOGDB_URL=         $CENTRAL_LOGDB_URL         "
@@ -662,7 +657,6 @@ init_wmagent(){
                        --reqmgr2_url=$REQMGR2_URL \
 	                   --acdc_url=$ACDC_URL \
 	                   --dbs3_url=$DBS3_URL \
-	                   --phedex_url=$PHEDEX_URL \
 	                   --dqm_url=$DQM_URL \
 	                   --requestcouch_url=$REQUESTCOUCH_URL \
 	                   --central_logdb_url=$CENTRAL_LOGDB_URL \

--- a/wmagentpy3/manage
+++ b/wmagentpy3/manage
@@ -58,7 +58,6 @@ WMSTATS_URL=
 REQMGR2_URL=
 ACDC_URL=
 DBS3_URL=
-PHEDEX_URL=
 DQM_URL=
 REQUESTCOUCH_URL=
 CENTRAL_LOGDB_URL=
@@ -128,7 +127,6 @@ load_secrets_file(){
     local MATCH_REQMGR2_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQMGR2_URL | sed s/REQMGR2_URL=//`
     local MATCH_ACDC_URL=`cat $WMAGENT_SECRETS_LOCATION | grep ACDC_URL | sed s/ACDC_URL=//`
     local MATCH_DBS3_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DBS3_URL | sed s/DBS3_URL=//`
-    local MATCH_PHEDEX_URL=`cat $WMAGENT_SECRETS_LOCATION | grep PHEDEX_URL | sed s/PHEDEX_URL=//`
     local MATCH_DQM_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DQM_URL | sed s/DQM_URL=//`
     local MATCH_REQUESTCOUCH_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQUESTCOUCH_URL | sed s/REQUESTCOUCH_URL=//`
     local MATCH_CENTRAL_LOGDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep CENTRAL_LOGDB_URL | sed s/CENTRAL_LOGDB_URL=//`
@@ -190,9 +188,7 @@ load_secrets_file(){
     ACDC_URL=${MATCH_ACDC_URL:-$ACDC_URL}
     
     DBS3_URL=${MATCH_DBS3_URL:-$DBS3_URL}
-    
-    PHEDEX_URL=${MATCH_PHEDEX_URL:-$PHEDEX_URL}
-    
+
     DQM_URL=${MATCH_DQM_URL:-$DQM_URL}
 
     REQUESTCOUCH_URL=${MATCH_REQUESTCOUCH_URL:-$REQUESTCOUCH_URL}
@@ -232,7 +228,6 @@ print_settings(){
     echo "REQMGR2_URL=               $REQMGR2_URL               "
     echo "ACDC_URL=                  $ACDC_URL                  "
     echo "DBS3_URL=                  $DBS3_URL                  "
-    echo "PHEDEX_URL=                $PHEDEX_URL                "
     echo "DQM_URL=                   $DQM_URL                   "
     echo "REQUESTCOUCH_URL=          $REQUESTCOUCH_URL          "
     echo "CENTRAL_LOGDB_URL=         $CENTRAL_LOGDB_URL         "
@@ -595,7 +590,6 @@ init_wmagent(){
                        --reqmgr2_url=$REQMGR2_URL \
 	                   --acdc_url=$ACDC_URL \
 	                   --dbs3_url=$DBS3_URL \
-	                   --phedex_url=$PHEDEX_URL \
 	                   --dqm_url=$DQM_URL \
 	                   --requestcouch_url=$REQUESTCOUCH_URL \
 	                   --central_logdb_url=$CENTRAL_LOGDB_URL \


### PR DESCRIPTION
Part of the PhEDEx deprecation, no longer read it from the configuration file and no longer passes it through when deployment a (T0)WMAgent service.
Required by: https://github.com/dmwm/WMCore/pull/10366

With this PR, we no longer need to define: PHEDEX_URL in the secrets file (actually, we should delete it from there!)