### PR TITLE
An L1T DQM plot is imported to the ECAL workspace.

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -629,23 +629,25 @@ ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/14 ecalOccSent',
            [{'path': 'L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent', 'description': 'The 2D plot shows ECAL TP occupancy sent by ECAL in iEta and iPhi coordinate of the ECAL trigger tower. Each entry represents the occupancy (multiplicity) of ECAL TP in (iEta, iPhi).'}])
 ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/15 ecalOccSentAndRecd',
            [{'path': 'L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd', 'description': 'The 2D plot shows ECAL TP occupancy "sent" by ECAL and "received" at Layer-1 (fully matched), in iEta and iPhi coordinate of the ECAL trigger tower. Each entry represents the occupancy (multiplicity) of ECAL TPs in (iEta, iPhi). One can investigate the number of entries in 14 to 15 and 16 and check if the ECAL TP sent by ECAL is received at Layer-1.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/16 TT Flag-Readout Mismatch',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/16 ecalOccRecdEtWgt',
+ [{'path':'L1T/L1TStage2CaloLayer1/ecalOccRecdEtWgt','description':'Et weighted map of ECAL TPs received by L1T Layer-1.'}])
+ #Added one additional L1T plot on the request of Trigger team 
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/17 TT Flag-Readout Mismatch',
 	   [{'path': 'EcalBarrel/EBSelectiveReadoutTask/EBSRT TT flag mismatch', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'}],
 	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT flag mismatch EE -', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'},
 	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT flag mismatch EE +', 'description': 'For events with medium- and high-interest TT flags, this plot maps the occupancy for towers with a mismatch in the number of readouts between the TPs and the Digis.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/17 TT Flags vs Et',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/18 TT Flags vs Et',
 	   [{'path': 'EcalBarrel/EBSelectiveReadoutTask/EBSRT TT Flags vs Et', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'}],
 	   [{'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE -', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'},
 	    {'path': 'EcalEndcap/EESelectiveReadoutTask/EESRT TT Flags vs Et EE +', 'description': '2D histograms of of TT flags of a corresponding to a given TT vs Et measured by that tower.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/18 Ratio_L1TEGamma_BX_0',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/19 Ratio_L1TEGamma_BX_0',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0', 'description': 'Fraction of (L1T EGamma objects with pT >= 20 GeV found in BX 0) over (all L1T EGamma objects with pT >= 20 GeV found in a BX range of +/-2 BX around BX 0).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/19 Ratio_L1TEGamma_BX_minus1',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/20 Ratio_L1TEGamma_BX_minus1',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1', 'description': 'Fraction of (L1T EGamma objects with pT >= 20 GeV found in BX -1) over (all L1T EGamma objects with pT >= 20 GeV found in a BX range of +/-2 BX around BX 0).'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/20 noniso_bx_ieta_firstbunch',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/21 noniso_bx_ieta_firstbunch',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_FirstCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_FirstCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the first bunch in a bunch train.'}])
-ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/21 noniso_bx_ieta_lastbunch',
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/22 noniso_bx_ieta_lastbunch',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_LastCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_LastCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the last bunch in a bunch train.'}])
-
 
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -200,13 +200,12 @@ server.workspace('DQMContent', 21, 'Tracker', 'SiStrip', '^(SiStrip|Tracking)/',
                 )
 
 # Calorimeter workspaces:
-server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1|^L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0|^L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0)', 'Ecal/Layouts',
+server.workspace('DQMContent', 30, 'Calorimeters', 'Ecal', '(^Ecal(|Barrel|Endcap|Calibration)/|^L1T/L1TStage2CaloLayer1/ecalOccRecdEtWgt|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSent|^L1T/L1TStage2CaloLayer1/ECalDetail/ecalOccSentAndRecd|^HLT/ObjectMonitor/MainShifter/di-Electron_Mass|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_0|^L1T/L1TObjects/L1TEGamma/timing/Ratio_L1TEGamma_BX_minus1|^L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0|^L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0)', 'Ecal/Layouts',
                  'Ecal/Layouts/00 Summary',
                  'Ecal/Layouts/01 Occupancy Summary',
                  'Ecal/Layouts/02 Calibration Summary',
                 )
-                # Ecal workspace modified above to include six L1 Trigger
-                # plots and one HLT plot as requested by Ecal team
+                # Ecal workspace modified above to include one additional L1 Trigger plot as requested by Trigger team                
 
 server.workspace('DQMContent', 31, 'Calorimeters', 'EcalPreshower', '^EcalPreshower/', '',
                  'EcalPreshower/Layouts/01-IntegritySummary-EcalPreshower',


### PR DESCRIPTION
#### PR description:
At the request of the ECAL Trigger team, an existing plot from L1T DQM is being imported into the Trigger primitives folder in the ECAL workspace. This plot helps in catching the instances where the ECAL TPs written to the DAQ are Ok, but a problem exists in the link between ECAL and Layer-1.
This layout change is only for the ECAL internal layouts and not for the shifter layouts.  

#### PR validation:
Online DQM root files for ECAL and L1 from a global run were used and uploaded to a private DQM GUI. We also verified with the ECAL Trigger team and they were satisfied with it.