### PR TITLE
Update the GEM offline DQM part.

### DIFF
--- a/dqmgui/layouts/gem_T0_layouts.py
+++ b/dqmgui/layouts/gem_T0_layouts.py
@@ -2,92 +2,50 @@ def gemlayout(i, p, *rows): i["GEM/Layouts/" + p] = DQMItem(layout=rows)
 
 _GEM_OFF_LINK = '<a href="https://twiki.cern.ch/twiki/bin/view/CMS/GEMPPDOfflineDQM">Link to TWiki</a>'
 
-# Occupancy
-gemlayout(dqmitems, "01 DIGI Occupancy",
-    [{ "path": "GEM/GEMOfflineMonitor/Digi/digi_det_ge-11",
+gemlayout(dqmitems, "01 - Efficiency per Eta Partition",
+    [{ "path": "GEM/Efficiency/type1/Efficiency/eff_detector_GE-11",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMOfflineMonitor/Digi/digi_det_ge+11",    
-       "description": _GEM_OFF_LINK }])
-
-gemlayout(dqmitems, "02 RecHit Occupancy",
-    [{ "path": "GEM/GEMOfflineMonitor/RecHit/hit_det_ge-11",
-       "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMOfflineMonitor/RecHit/hit_det_ge+11",
-       "description": _GEM_OFF_LINK }])
-
-# Detector
-gemlayout(dqmitems, "03 Efficiency - Tight GLB Muon",
-    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_detector_ge-11",
-       "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_detector_ge+11",
-       "description": _GEM_OFF_LINK }])
-
-gemlayout(dqmitems, "04 Efficiency - STA Muon",
-    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_detector_ge-11",
-       "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_detector_ge+11",
-       "description": _GEM_OFF_LINK }])
-
-# Efficiency vs. PT
-gemlayout(dqmitems, "05 Efficiency vs Tight GLB Muon PT",
-    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge-11_odd",
-       "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge+11_odd",
+     { "path": "GEM/Efficiency/type1/Efficiency/eff_detector_GE+11",
        "description": _GEM_OFF_LINK }],
-    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge-11_even",
+    [{ "path": "GEM/Efficiency/type2/Efficiency/eff_detector_GE-11",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_pt_ge+11_even",
-       "description": _GEM_OFF_LINK }])
+     { "path": "GEM/Efficiency/type2/Efficiency/eff_detector_GE+11",
+       "description": _GEM_OFF_LINK }]
+)
 
-gemlayout(dqmitems, "06 Efficiency vs STA Muon PT",
-    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge-11_odd",
+gemlayout(dqmitems, "02 - Efficiency vs Muon PT",
+    [{ "path": "GEM/Efficiency/type1/Efficiency/eff_muon_pt_GE-11",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge+11_odd",
+     { "path": "GEM/Efficiency/type1/Efficiency/eff_muon_pt_GE+11",
        "description": _GEM_OFF_LINK }],
-    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge-11_even",
+    [{ "path": "GEM/Efficiency/type2/Efficiency/eff_muon_pt_GE-11",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_pt_ge+11_even",
-       "description": _GEM_OFF_LINK }])
+     { "path": "GEM/Efficiency/type2/Efficiency/eff_muon_pt_GE+11",
+       "description": _GEM_OFF_LINK }]
+)
 
-# Efficiency vs. Eta
-gemlayout(dqmitems, "07 Efficiency vs Tight GLB Muon Eta",
-    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge-11_odd",
+gemlayout(dqmitems, "03 - Efficiency vs Muon Eta",
+    [{ "path": "GEM/Efficiency/type1/Efficiency/eff_muon_eta_GE-11",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge+11_odd",
+     { "path": "GEM/Efficiency/type1/Efficiency/eff_muon_eta_GE+11",
        "description": _GEM_OFF_LINK }],
-    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge-11_even",
+    [{ "path": "GEM/Efficiency/type2/Efficiency/eff_muon_eta_GE-11",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Efficiency/eff_muon_eta_ge+11_even",
-       "description": _GEM_OFF_LINK }])
+     { "path": "GEM/Efficiency/type2/Efficiency/eff_muon_eta_GE+11",
+       "description": _GEM_OFF_LINK }]
+)
 
-
-gemlayout(dqmitems, "08 Efficiency vs STA Muon Eta",
-    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge-11_odd",
+gemlayout(dqmitems, "04 - Resolution Summary",
+    [{ "path": "GEM/Efficiency/type1/Resolution/residual_rphi_mean",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge+11_odd",
+     { "path": "GEM/Efficiency/type1/Resolution/residual_rphi_stddev",
+       "description": _GEM_OFF_LINK },
+     { "path": "GEM/Efficiency/type1/Resolution/residual_rphi_skewness",
        "description": _GEM_OFF_LINK }],
-    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge-11_even",
+    [{ "path": "GEM/Efficiency/type2/Resolution/residual_rphi_mean",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_muon_eta_ge+11_even",
-       "description": _GEM_OFF_LINK }])
-
-# Phi Residual Histogram Parammeters
-gemlayout(dqmitems, "09 Phi Residual - Tight GLB Muon",
-    [{ "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge-11_odd",
+     { "path": "GEM/Efficiency/type2/Resolution/residual_rphi_stddev",
        "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge+11_odd",
+     { "path": "GEM/Efficiency/type2/Resolution/residual_rphi_skewness",
        "description": _GEM_OFF_LINK }],
-    [ { "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge-11_even",
-        "description": _GEM_OFF_LINK },
-      { "path": "GEM/GEMEfficiency/TightGlobalMuon/Resolution/residual_phi_ge+11_even",
-        "description": _GEM_OFF_LINK }])
-
-gemlayout(dqmitems, "10 Phi Residual - STA Muon",
-    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge-11_odd",
-       "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge+11_odd",
-       "description": _GEM_OFF_LINK }],
-    [{ "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge-11_even",
-       "description": _GEM_OFF_LINK },
-     { "path": "GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge+11_even",
-       "description": _GEM_OFF_LINK }])
+)

--- a/dqmgui/style/GEMRenderPlugin.cc
+++ b/dqmgui/style/GEMRenderPlugin.cc
@@ -122,10 +122,8 @@ private:
     TH1F* obj = dynamic_cast<TH1F*>(o.object);
     assert(obj);
 
-    // NOTE
-    if (TPRegexp("^GEM/GEMEfficiency/\\w+Muon/Efficiency/muon_\\w+_(?:matched_)?ge(\\+|\\-)\\d1_(odd|even)$").MatchB(o.name))
+    if (TPRegexp("^GEM/Efficiency/type\\d/Efficiency/muon_\\w+_GE(\\+|\\-)\\d1(?:_matched)?$").MatchB(o.name))
     {
-      // e.g. GEM/GEMEfficiency/StandaloneMuon/Efficiency/muon_eta_ge-11_odd
       obj->SetOption("hist E");
       gStyle->SetOptStat("euo");
 
@@ -139,9 +137,8 @@ private:
       }
 
     }
-    else if (TPRegexp("^GEM/GEMEfficiency/\\w+Muon/Resolution/(residual|pull)_\\w+_ge(\\+|\\-)\\d1_(odd|even)_ieta\\d$").MatchB(o.name))
+    else if (TPRegexp("^GEM/Efficiency/type\\d/Resolution/(residual|pull)_\\w+_GE(\\+|\\-)\\d1_R\\d$").MatchB(o.name))
     {
-      // e.g. GEM/GEMEfficiency/StandaloneMuon/Resolution/pull_x_ge-11_even_ieta1
       obj->SetOption("hist E");
       gStyle->SetOptStat("emruos");
 
@@ -183,31 +180,29 @@ private:
       drawTimeHisto(dynamic_cast<TH2F*>(o.object));
     }
 
-    if (TPRegexp("GEM/GEMEfficiency/\\w+Muon/Efficiency/detector_(?:matched_)?ge(\\+|\\-)\\d1$").MatchB(o.name))
+    if (TPRegexp("^GEM/Efficiency/type\\d/Efficiency/detector_GE(\\+|\\-)\\d1(?:matched_)?$").MatchB(o.name))
     {
-      // e.g. GEM/GEMEfficiency/StandaloneMuon/Efficiency/detector_matched_ge-11
       obj->SetOption("colz");
       gStyle->SetOptStat("e");
     }
-    else if (TPRegexp("GEM/GEMEfficiency/\\w+Muon/Efficiency/eff_detector_ge(\\+|\\-)\\d1$").MatchB(o.name))
+    else if (TPRegexp("^GEM/Efficiency/type\\d/Efficiency/eff_detector_GE(\\+|\\-)\\d1$").MatchB(o.name))
     {
-      // e.g. GEM/GEMEfficiency/StandaloneMuon/Efficiency/eff_detector_ge-11
       obj->SetOption("colz");
       gStyle->SetOptStat(0);
 
+      obj->SetNdivisions(-obj->GetNbinsX(), "Y"); // use a negative number to turn off ndivisios optimization.
+      obj->SetNdivisions(-obj->GetNbinsY(), "X");
+
       obj->SetMinimum(0.80);
       obj->SetMaximum(1.00);
+
+      gStyle->SetGridWidth(3);
     }
-    else if (TPRegexp("GEM/GEMEfficiency/\\w+Muon/Resolution/residual_phi_ge(\\+|\\-)\\d1_(odd|even)$").MatchB(o.name))
+    else if (TPRegexp("^GEM/Efficiency/type\\d/Resolution/residual_rphi_(mean|stddev|skewness)$").MatchB(o.name))
     {
-      // e.g. GEM/GEMEfficiency/StandaloneMuon/Resolution/residual_phi_ge-11_even
       obj->SetOption("colz text");
       obj->SetStats(false);
       gStyle->SetOptStat(0);
-
-      obj->Scale(1000); // rad to mrad
-      obj->GetYaxis()->SetBinLabel(1, "#splitline{Mean}{[mrad]}");
-      obj->GetYaxis()->SetBinLabel(2, "#splitline{Std. Dev.}{[mrad]}");
 
       obj->SetNdivisions(-obj->GetNbinsX(), "Y"); // use a negative number to turn off ndivisios optimization.
       obj->SetNdivisions(-obj->GetNbinsY(), "X");
@@ -226,7 +221,7 @@ private:
     TProfile* obj = dynamic_cast<TProfile*>(o.object);
     assert(obj);
 
-    if (TPRegexp("^GEM/GEMEfficiency/\\w+Muon/Efficiency/eff_muon_\\w+_ge(\\+|\\-)\\d1_(odd|even)").MatchB(o.name))
+    if (TPRegexp("^GEM/Efficiency/type\\d/Efficiency/eff_muon_\\w+_GE(\\+|\\-)\\d1").MatchB(o.name))
     {
       obj->SetOption("E");
       obj->SetStats(false);

--- a/dqmgui/workspaces-offline.py
+++ b/dqmgui/workspaces-offline.py
@@ -215,16 +215,10 @@ server.workspace('DQMContent', 41, 'Muons', 'DT', '^DT/', '')
 server.workspace('DQMContent', 42, 'Muons', 'RPC', '^RPC/', '')
 
 server.workspace('DQMContent', 43, 'Muons', 'GEM', '^GEM/', '',
-                 "GEM/Layouts/01 DIGI Occupancy",
-                 "GEM/Layouts/02 RecHit Occupancy",
-                 "GEM/Layouts/03 Efficiency - Tight GLB Muon",
-                 "GEM/Layouts/04 Efficiency - STA Muon",
-                 "GEM/Layouts/05 Efficiency vs Tight GLB Muon PT",
-                 "GEM/Layouts/06 Efficiency vs STA Muon PT",
-                 "GEM/Layouts/07 Efficiency vs Tight GLB Muon Eta",
-                 "GEM/Layouts/08 Efficiency vs STA Muon Eta",
-                 "GEM/Layouts/09 Phi Residual - Tight GLB Muon",
-                 "GEM/Layouts/10 Phi Residual - STA Muon",
+                 "GEM/Layouts/01 - Efficiency per Eta Partition",
+                 "GEM/Layouts/02 - Efficiency vs Muon PT",
+                 "GEM/Layouts/03 - Efficiency vs Muon Eta",
+                 "GEM/Layouts/04 - Resolution Summary",
                 )
 
 # CTPPS workspaces:


### PR DESCRIPTION
This PR updates GEM offline DQM according to the related update of CMSSW. This PR is aimed at the next MWGR (April 14-16, 2021).

There are two major changes. 
* The first is to make DQM GUI work in both pp and cosmics scenario.
* The second is to reduce the number of histograms for reducing memory usage, reflecting the feedback from PPD.

I tested this PR with the local GUI server using both MC and the MWGR2 data:
* http://cms.sscc.uos.ac.kr:50200/dqm/offline/

Also, the changes were presented in GEM DPG meeting:
* https://indico.cern.ch/event/1010727/contributions/4241619/attachments/2199578/3719850/200226-OfflineDQMUpdate.pdf

Both PRs to CMSSW are merged:
* https://github.com/cms-sw/cmssw/pull/33031 (PR to master)
* https://github.com/cms-sw/cmssw/pull/33032 (backport PR to CMSSW_11_2_X for MWGR#3 (April 14-16, 2021))

@jshlee, @szaleski