### PR TITLE
fix SiStrip render plugin for 2D maps

### DIFF
--- a/dqmgui/style/SiStripRenderPlugin.cc
+++ b/dqmgui/style/SiStripRenderPlugin.cc
@@ -130,6 +130,22 @@ private:
       ya->SetTitleSize(0.05);
       ya->SetLabelSize(0.04);
 
+      if( o.name.find( "TkHMap" )  != std::string::npos)
+      {
+        obj->SetStats( kFALSE );
+        gStyle->SetPalette(1,0);
+        obj->SetOption("colz");
+        return;
+      }
+
+      if( o.name.find( "Summary_ClusterPosition2D" )  != std::string::npos)
+      {
+        obj->SetStats( kFALSE );
+        gStyle->SetPalette(1,0);
+        obj->SetOption("colz");
+        return;
+      }
+
       if( o.name.find( "PedsEvolution" ) != std::string::npos)
       {
         gStyle->SetOptStat( 1111 );


### PR DESCRIPTION
Fixed the appearance of several heatmaps in the  `SiStrip / MechanicalView /` folder, which have been migrated from ` TProfile2D` to `TH2F` .
Tested in a private instance of the GUI:

   * Before the changes:
![image](https://user-images.githubusercontent.com/5082376/115373437-2caf0500-a1cc-11eb-9536-71797619baa5.png)
   * After the changes:
![image](https://user-images.githubusercontent.com/5082376/115373509-3f293e80-a1cc-11eb-84c9-b4737c027717.png)

cc:
@sroychow @arossi83    