### PR TITLE
enable colz and phase-1 pixel map dressing for Phase1PixelV

### DIFF
--- a/dqmgui/style/SiPixelMapsRenderPlugin.cc
+++ b/dqmgui/style/SiPixelMapsRenderPlugin.cc
@@ -31,7 +31,7 @@ class SiPixelMapsRenderPlugin : public DQMRenderPlugin
 public:
   virtual bool applies( const VisDQMObject & o, const VisDQMImgInfo & )
     {
-      if ((o.name.find( "PixelPhase1/Phase1_MechanicalView" ) != std::string::npos || o.name.find( "PixelPhase1/Tracks" ) != std::string::npos || o.name.find( "PixelPhase1/FED" ) != std::string::npos || o.name.find( "PixelPhase1Timing/" ) != std::string::npos  || o.name.find("PixelPhase1/SiPixelQualityPCL") != std::string::npos)
+      if ((o.name.find( "PixelPhase1/Phase1_MechanicalView" ) != std::string::npos || o.name.find( "PixelPhase1/Tracks" ) != std::string::npos || o.name.find( "PixelPhase1/FED" ) != std::string::npos || o.name.find( "PixelPhase1Timing/" ) != std::string::npos  || o.name.find("PixelPhase1/SiPixelQualityPCL") != std::string::npos || o.name.find( "PixelPhase1V/") != std::string::npos )
         && o.object && (o.name.find( "Coord" ) != std::string::npos || o.name.find( "per_SignedModule_per_SignedLadder" ) != std::string::npos || o.name.find( "per_PXDisk_per_SignedBlade" ) != std::string::npos )) {
         return true;
       } else {

--- a/dqmgui/style/SiPixelRenderPlugin.cc
+++ b/dqmgui/style/SiPixelRenderPlugin.cc
@@ -31,6 +31,8 @@ public:
         return true;
       if( o.name.find( "PixelPhase1/" ) == 0 )
         return true;
+      if( o.name.find( "PixelPhase1V/" ) == 0 )
+        return true;
       if( o.name.find( "PixelPhase1Timing/" ) != std::string::npos )
         return true;
       if( o.name.find( "TrackTimingPixelPhase1/Phase1_MechanicalView" ) != std::string::npos )


### PR DESCRIPTION
Title says it all, enables the coloring of 2D maps in the Phase-1 Pixel Validation folder.
Tested in a local GUI:
   * before this PR:

![image](https://user-images.githubusercontent.com/5082376/115447393-c00e2780-a218-11eb-8abd-41f603c0f79a.png)

   * after this PR:
   
![image](https://user-images.githubusercontent.com/5082376/115447486-da480580-a218-11eb-90e4-02ab45bb78f1.png)

cc:
@sroychow @arossi83    