### PR TITLE
DQM^2 offsite access

### DIFF
--- a/frontend/app_dqm_nossl.conf
+++ b/frontend/app_dqm_nossl.conf
@@ -6,6 +6,7 @@ RewriteRule ^(/dqm/online-new(/.*)?)$          https://%{SERVER_NAME}${escape:$1
 RewriteRule ^(/dqm/online-playback-new(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/online-test-new(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/hcal-online(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/dqm-square(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 
 # Redirect rules for offline DQM, back to the https interface.
 

--- a/frontend/app_dqm_ssl.conf
+++ b/frontend/app_dqm_ssl.conf
@@ -1,5 +1,5 @@
 RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie;limited-proxy;cert;host]
-RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 
 RewriteRule ^/auth/complete(/dqm/(relval-test-new)(/.*)?$)$ http://%{ENV:BACKEND}:8888${escape:$3} [QSA,P,L,NE]

--- a/frontend/app_dqm_ssl.conf
+++ b/frontend/app_dqm_ssl.conf
@@ -1,5 +1,5 @@
 RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie;limited-proxy;cert;host]
-RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 
 RewriteRule ^/auth/complete(/dqm/(relval-test-new)(/.*)?$)$ http://%{ENV:BACKEND}:8888${escape:$3} [QSA,P,L,NE]
@@ -7,3 +7,5 @@ RewriteRule ^/auth/complete(/dqm/(offline-new|offline-test-new|relval-new)(/.*)?
 
 RewriteRule ^/auth/complete(/dqm/(relval|relval-test)(/.*)?)$ http://%{ENV:BACKEND}:8081${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/(offline|offline-test)(/.*)?)$ http://%{ENV:BACKEND}:8080${escape:$1} [QSA,P,L,NE]
+
+RewriteRule ^/auth/complete(/dqm/(dqm-square)(/.*)?)$ http://%{ENV:BACKEND}:FIXME${escape:$1} [QSA,P,L,NE]

--- a/frontend/app_dqm_ssl.conf
+++ b/frontend/app_dqm_ssl.conf
@@ -1,5 +1,5 @@
 RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie;limited-proxy;cert;host]
-RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 
 RewriteRule ^/auth/complete(/dqm/(relval-test-new)(/.*)?$)$ http://%{ENV:BACKEND}:8888${escape:$3} [QSA,P,L,NE]
@@ -7,5 +7,3 @@ RewriteRule ^/auth/complete(/dqm/(offline-new|offline-test-new|relval-new)(/.*)?
 
 RewriteRule ^/auth/complete(/dqm/(relval|relval-test)(/.*)?)$ http://%{ENV:BACKEND}:8081${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/(offline|offline-test)(/.*)?)$ http://%{ENV:BACKEND}:8080${escape:$1} [QSA,P,L,NE]
-
-RewriteRule ^/auth/complete(/dqm/(dqm-square)(/.*)?)$ http://%{ENV:BACKEND}:FIXME${escape:$1} [QSA,P,L,NE]

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -2,7 +2,7 @@
 ^/auth/complete/reqmgr2(?:/|$) reqmgr2.dmwm.svc.cluster.local
 ^/auth/complete/phedex(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch

--- a/frontend/backends-k8s-prod.txt
+++ b/frontend/backends-k8s-prod.txt
@@ -1,6 +1,6 @@
 ^/auth/complete/phedex(?:/|$) vocms0136.cern.ch|vocms0161.cern.ch|vocms0163.cern.ch|vocms0165.cern.ch|vocms0766.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0136.cern.ch|vocms0161.cern.ch|vocms0163.cern.ch|vocms0165.cern.ch|vocms0766.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch

--- a/frontend/backends-prod.txt
+++ b/frontend/backends-prod.txt
@@ -1,4 +1,4 @@
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch

--- a/frontend/htdocs/index.html
+++ b/frontend/htdocs/index.html
@@ -41,6 +41,7 @@
             <a href="/dqm/relval-new/">RelVal-new</a>,
             <a href="/dqm/relval-test-new/">Relval-test-new</a>,
             <a href="/dqm/dev/">Development</a>
+            <a href="/dqm/dqm-square/">DQM^2 Mirrow</a>
           </li>
           <li class="box">Site systems:
              <a href="https://hammercloud.cern.ch/hc/app/cms/">HammerCloud</a>,
@@ -55,5 +56,6 @@
     <div id="bottom"><div class="boxFooter">&nbsp;</div></div>
     </div>
   </body>
-
 </html>
+
+


### PR DESCRIPTION
Add DQM^2 site and redirection rules to the list.
WIP:

- the machine to run the server is  `srv-c2f11-29-02`, same as for online|online-playback|online-test|online-new|online-playback-new|online-test-new sites => because of this, from my understanding, need to specify a different specific port to listen at [0] => need to figure out available ports and firewall settings

[0] https://github.com/pmandrik/deployment/blob/0d5da1dd565bdf714bcfeb0985e94ec0e3ef0149/frontend/app_dqm_ssl.conf#L11