### PR TITLE
Add devtools variant to wmagentpy3 deploy script, for unittests

### DIFF
--- a/wmagentpy3/deploy
+++ b/wmagentpy3/deploy
@@ -1,4 +1,5 @@
 # vim: set ft=sh sw=2 ts=8 et :
+deploy_wmagentpy3_variants="default devtools"
 
 deploy_wmagentpy3_prep()
 {
@@ -7,6 +8,13 @@ deploy_wmagentpy3_prep()
 
 deploy_wmagentpy3_sw()
 {
+  case $variant in devtools )
+    deploy_pkg comp cms+wmcorepy3-devtools
+    deploy_pkg comp external+py3-psutil
+    pkgs="$pkgs wmcorepy3-devtools py3-psutil"
+    ;;
+  esac
+
   deploy_pkg comp cms+wmagentpy3
 
   mkdir -p $root/$cfgversion/install/wmagentpy3
@@ -26,4 +34,12 @@ deploy_wmagentpy3_sw()
 
   local rucio_config=$root/$cfgversion/config/wmagentpy3/rucio.cfg
   cp -f $rucio_config $root/$cfgversion/config/rucio/etc/
+}
+
+deploy_wmagentpy3_post()
+{
+  case $variant in devtools )
+    disable;
+    return ;;
+  esac
 }


### PR DESCRIPTION
This PR provides a different `variant` to the `wmagentpy3` deploy script, such that we can also deploy the required `wmcorepy3-devtools` when deploying the WMCore python3 unit tests environment. 

It does not affect standard `wmagentpy3` deployment, however, when deploying the unit tests setup, one needs to install it like:
```
$PWD/deployment/Deploy -R wmagentpy3-dev@$VERSION -r comp=comp -t $VERSION -A $DMWM_ARCH -s "prep sw post" $INSTALL_DIR wmagentpy3/devtools
```

For the record, in our python2 unit tests, this is how we deploy those RPMs:
```
$PWD/deployment/Deploy -R wmagent-dev@$1 -r comp=comp -t $1 -A $DMWM_ARCH -s 'prep sw post' $INSTALL_DIR admin/devtools wmagent
```

so we needed an alternative to this `admin/devtools` package, which does not depend on the obsolete `pystack` package:
https://github.com/dmwm/deployment/blob/master/admin/deploy#L15