### PR TITLE
Stop implicitly deploying pystack

### DIFF
--- a/admin/deploy
+++ b/admin/deploy
@@ -12,7 +12,7 @@ deploy_admin_prep()
 
 deploy_admin_sw()
 {
-  local p pkgs="rotatelogs pystack py2-psutil"
+  local p pkgs="rotatelogs py2-psutil"
   case $variant in devtools )
     deploy_pkg comp cms+wmcore-devtools
     pkgs="$pkgs wmcore-devtools"

--- a/asyncstageout/manage
+++ b/asyncstageout/manage
@@ -140,7 +140,6 @@ print_settings(){
 # Environment
 #
 
-. $ROOT_DIR/apps/pystack/etc/profile.d/init.sh
 . $ROOT_DIR/apps/couchdb/etc/profile.d/init.sh
 . $ROOT_DIR/apps/asyncstageout/etc/profile.d/init.sh
 

--- a/backend/deploy
+++ b/backend/deploy
@@ -6,9 +6,7 @@ deploy_backend_prep()
 
 deploy_backend_sw()
 {
-  deploy_pkg comp cms+pystack
-  rm -f $root/$cfgversion/bin/{pystack,gdb}
-  ln -s ../apps.$glabel/pystack/bin/{pystack,gdb} $root/$cfgversion/bin/
+  echo "No longer deploying pystack"
 }
 
 deploy_backend_post()

--- a/wmagent/deployment-test.py
+++ b/wmagent/deployment-test.py
@@ -194,7 +194,6 @@ class DeploymentTest:
             os.path.join(self.installDir, "current", "apps", "couchdb"),
             os.path.join(self.installDir, "current", "apps", "mysql"),
             os.path.join(self.installDir, "current", "apps", "wmagent"),
-            os.path.join(self.installDir, "current", "apps", "pystack"),
             os.path.join(self.installDir, "current", "config", "wmagent"),
             os.path.join(self.installDir, "current", "config", "reqmgr"),
             os.path.join(self.installDir, "current", "config", "workqueue"),


### PR DESCRIPTION
No longer deploys the `pystack` package, which is an implicit dependency of the `admin` package, and it's the whole `backend` package.

NOT ready to be merged yet, see discussion: https://hypernews.cern.ch/HyperNews/CMS/get/webInterfaces/1785.html