### PR TITLE
Remove RPC quality state overview plot from the shifter layout

### DIFF
--- a/dqmgui/layouts/shift_rpc_T0_layout.py
+++ b/dqmgui/layouts/shift_rpc_T0_layout.py
@@ -5,7 +5,6 @@ fed = "FED Fatal Errors. Entries MUST be ZERO at all times. If not, report the p
 rpcevents = "Number of processed events."
 eff = "RPC Efficiency distribution. Make sure average values is greater than 80."
 rpclink = "   >>> <a href=https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftRPC>Description</a>"
-quality = "Overview of system quality. Expressed in percentage of chambers."
 occupancy = "Occupancy per sector"
 hv = "High Voltage status per lumi section. If ALL bins are red mark the run as BAD."
 
@@ -23,19 +22,15 @@ shiftrpclayout(dqmitems, "03-RPC_Events",
                [{ 'path': "RPC/AllHits/RPCEvents", 'description': rpcevents + rpclink }])
 
 
-shiftrpclayout(dqmitems, "04-Quality_State_Overview",
-               [{ 'path': "RPC/AllHits/SummaryHistograms/RPC_System_Quality_Overview", 'description': quality + rpclink }])
-
-
-shiftrpclayout(dqmitems, "05-RPC_Occupancy",
+shiftrpclayout(dqmitems, "04-RPC_Occupancy",
                [{ 'path': "RPC/AllHits/SummaryHistograms/Occupancy_for_Barrel", 'description': occupancy + rpclink  }],
                [{ 'path': "RPC/AllHits/SummaryHistograms/Occupancy_for_Endcap", 'description': occupancy + rpclink  }])
 
 
-shiftrpclayout(dqmitems, "06-Statistics",
+shiftrpclayout(dqmitems, "05-Statistics",
                [{ 'path': "RPC/RPCEfficiency/Statistics", 'description': eff + rpclink }])
 
-shiftrpclayout(dqmitems, "07-Efficiency_Distribution",
+shiftrpclayout(dqmitems, "06-Efficiency_Distribution",
                [{ 'path': "RPC/RPCEfficiency/EffBarrelRoll", 'description': eff + rpclink  }],
                [{ 'path': "RPC/RPCEfficiency/EffEndcapPlusRoll", 'description': eff + rpclink  },
                 { 'path': "RPC/RPCEfficiency/EffEndcapMinusRoll", 'description':  eff + rpclink }])

--- a/dqmgui/layouts/shift_rpc_layout.py
+++ b/dqmgui/layouts/shift_rpc_layout.py
@@ -5,7 +5,6 @@ summary = "summary map for rpc, this is NOT an efficiency measurement"
 rpclink = "   >>> <a href=https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftRPC>Description</a>"
 fed = "FED Fatal Errors";
 rpcevents = "Events processed by the RPC DQM"
-quality = "Overview of system quality. Expressed in percentage of chambers."
 occupancy = "Occupancy per sector"
 
 ################### Links to Histograms #################################
@@ -20,9 +19,6 @@ shiftrpclayout(dqmitems, "01-Fatal_FED_Errors",
 shiftrpclayout(dqmitems, "02-RPC_Events",
                [{ 'path': "RPC/AllHits/RPCEvents", 'description': rpcevents + rpclink }])
 
-shiftrpclayout(dqmitems, "03-Quality_State_Overview",
-               [{ 'path': "RPC/AllHits/SummaryHistograms/RPC_System_Quality_Overview", 'description': quality + rpclink }])
-
-shiftrpclayout(dqmitems, "04-RPC_Occupancy",
+shiftrpclayout(dqmitems, "03-RPC_Occupancy",
                [{ 'path': "RPC/AllHits/SummaryHistograms/Occupancy_for_Barrel", 'description': occupancy + rpclink  }],
                [{ 'path': "RPC/AllHits/SummaryHistograms/Occupancy_for_Endcap", 'description': occupancy + rpclink }])


### PR DESCRIPTION
The "RPC quality state" variable is not well-defined for the shifts and has been raised lots of questions from shifters.
We decide not to include this plot in the shifter layout to avoid confusions.

These plots are to be removed also in the CMSSW in the near future, and be replaced with new variables in the future.

@andresib @mileva