### PR TITLE
MSTransferor: created Rucio weight config parameter

### DIFF
--- a/reqmgr2ms/config-transferor.py
+++ b/reqmgr2ms/config-transferor.py
@@ -78,6 +78,7 @@ data.services = ['transferor']
 data.quotaUsage = 0.9
 data.minimumThreshold = 1 * (1000 ** 4)  # 1 TB (terabyte)
 data.rulesLifetime = RULE_LIFETIME
+data.rucioRuleWeight = "ddm_quota"
 data.rucioAccount = "wmcore_transferor"
 data.rucioAuthUrl = RUCIO_AUTH_URL
 data.rucioUrl = RUCIO_URL


### PR DESCRIPTION
This new weight parameter will be set for all the input data placement rules created by MSTransferor.

Equivalent gitlab changes in:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/101
and
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/102