### PR TITLE
Fix rewrite rules for MSUnmerged, supporting rses query string

### DIFF
--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -38,9 +38,9 @@
 ^/auth/complete/ms-monitor(?:/|$) ms-monitor.dmwm.svc.cluster.local
 ^/auth/complete/ms-output(?:/|$) ms-output.dmwm.svc.cluster.local
 ^/auth/complete/ms-rulecleaner(?:/|$) ms-rulecleaner.dmwm.svc.cluster.local
-^/auth/complete/ms-unmerged/(?:data/status|info?rses=t1)(?:/|$) ms-unmerged-t1.dmwm.svc.cluster.local
-^/auth/complete/ms-unmerged/(?:data/status|info?rses=t2-t3-us)(?:/|$) ms-unmerged-t2-t3-us.dmwm.svc.cluster.local
-^/auth/complete/ms-unmerged/(?:data/status|info?rses=t2-t3)(?:/|$) ms-unmerged-t2-t3.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged/(?:.*rses=t1)(?:/|$) ms-unmerged-t1.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged/(?:.*rses=t2-t3-us)(?:/|$) ms-unmerged-t2-t3-us.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged/(?:.*rses=t2-t3)(?:/|$) ms-unmerged-t2-t3.dmwm.svc.cluster.local
 ^/auth/complete/t0wmadatasvc(?:/|$) t0wmadatasvc.tzero.svc.cluster.local
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch

--- a/frontend/backends-k8s-prod.txt
+++ b/frontend/backends-k8s-prod.txt
@@ -32,9 +32,9 @@
 ^/auth/complete/ms-monitor(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/ms-output(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/ms-rulecleaner(?:/|$) cmsweb-srv.cern.ch
-^/auth/complete/ms-unmerged/(?:data/status|info?rses=t1)(?:/|$) cmsweb-srv.cern.ch
-^/auth/complete/ms-unmerged/(?:data/status|info?rses=t2-t3-us)(?:/|$) cmsweb-srv.cern.ch
-^/auth/complete/ms-unmerged/(?:data/status|info?rses=t2-t3)(?:/|$) cmsweb-srv.cern.ch
+^/auth/complete/ms-unmerged/(?:.*rses=t1)(?:/|$) cmsweb-srv.cern.ch
+^/auth/complete/ms-unmerged/(?:.*rses=t2-t3-us)(?:/|$) cmsweb-srv.cern.ch
+^/auth/complete/ms-unmerged/(?:.*rses=t2-t3)(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch
 ^/auth/complete/scheddmon/0106/ vocms0106.cern.ch


### PR DESCRIPTION
Complement to: https://github.com/dmwm/deployment/pull/1074

Queries like (tested with my own VM url):
https://cmsweb-testbed.cern.ch/ms-transferor/data/info?detail=true&rses=t2-t3-us
https://cmsweb-testbed.cern.ch/ms-transferor/data/status?detail=true&rses=t2-t3-us

and the same for `rses=t1` and `rses=t2-t3` seem to be redirecting the http call to the correct backend now.