### PR TITLE
makes certificates optional for mkauthmap

### DIFF
--- a/frontend/mkauthmap
+++ b/frontend/mkauthmap
@@ -65,9 +65,11 @@ def request(uri, opts):
     path = apimap[query] + path
     query = "json&preset=" + query
     url = urlunparse((scheme, netloc, path, '', query, frag))
-    cert = (opts.cert, opts.key)
+    cert = None
+    if opts.cert and opts.key:
+        cert = (opts.cert, opts.key)
     try:
-        result = requests.get(url, cert=cert, verify=opts.ca_cert)
+        result = requests.get(url, cert=cert, verify=opts.ca_cert or True)
         result.raise_for_status()
     except requests.exceptions.HTTPError as errh:
         print ("Http Error:", errh)
@@ -200,18 +202,6 @@ if not opts.conf:
 
 if not opts.out:
     print >> sys.stderr, "Output file name is required"
-    exit(1)
-
-if not opts.cert:
-    print >> sys.stderr, "Cert file name is required"
-    exit(1)
-
-if not opts.key:
-    print >> sys.stderr, "Cert key file name is required"
-    exit(1)
-
-if not opts.ca_cert:
-    print >> sys.stderr, "CA bundle file name is required"
     exit(1)
     
 ##Calling core functions

--- a/frontend/mkauthmap
+++ b/frontend/mkauthmap
@@ -52,7 +52,7 @@ def getFecthDetails(fname):
         return url
 
 
-def request(uri):
+def request(uri, opts):
     content = ''
     url = "https:" + uri
     apimap = {
@@ -65,9 +65,9 @@ def request(uri):
     path = apimap[query] + path
     query = "json&preset=" + query
     url = urlunparse((scheme, netloc, path, '', query, frag))
-    cert = ('/etc/robots/robotcert.pem', '/etc/robots/robotkey.pem')
+    cert = (opts.cert, opts.key)
     try:
-        result = requests.get(url, cert=cert, verify='/etc/ssl/certs/CERN-bundle.pem')
+        result = requests.get(url, cert=cert, verify=opts.ca_cert)
         result.raise_for_status()
     except requests.exceptions.HTTPError as errh:
         print ("Http Error:", errh)
@@ -189,6 +189,9 @@ opt = OptionParser(__doc__)
 opt.add_option("-c", "--conf", dest="conf", metavar="FILE", help="configuration file")
 opt.add_option("-o", "--out", dest="out", metavar="FILE", help="output file")
 opt.add_option("-v", "--verbose", action="store_true", help="increase output verbosity")
+opt.add_option("-e", "--cert", dest="cert", help="path to cert file")
+opt.add_option("-k", "--key", dest="key", help="path to cert key")
+opt.add_option("-b", "--ca-cert", dest="ca_cert", help="path to ca cert bundle")
 opts, args = opt.parse_args()
 # Checking command line options
 if not opts.conf:
@@ -199,11 +202,23 @@ if not opts.out:
     print >> sys.stderr, "Output file name is required"
     exit(1)
 
+if not opts.cert:
+    print >> sys.stderr, "Cert file name is required"
+    exit(1)
+
+if not opts.key:
+    print >> sys.stderr, "Cert key file name is required"
+    exit(1)
+
+if not opts.ca_cert:
+    print >> sys.stderr, "CA bundle file name is required"
+    exit(1)
+    
 ##Calling core functions
 uri = getFecthDetails(opts.conf)
-roles = request(uri)
+roles = request(uri, opts)
 # sites = request (uri.replace('roles','site-names'))
-sites = request(uri.replace('roles', 'site-names&rcsite_state=ANY'))
+sites = request(uri.replace('roles', 'site-names&rcsite_state=ANY'), opts)
 sitemap = buildSiteMap(sites)
 updateFile(opts, roles, sitemap)
 # content = request(uri)

--- a/phedex/mkauthmap
+++ b/phedex/mkauthmap
@@ -42,7 +42,7 @@ def getFecthDetails(fname):
         url = ml[5:]
         return url
 
-def request(uri):
+def request(uri, opts):
     content = ''
     url = "https:" + uri
     apimap = {
@@ -56,9 +56,9 @@ def request(uri):
     path = apimap[query] + path
     query = "json&preset=" + query
     url = urlunparse((scheme, netloc, path, '', query, frag))
-    cert = ('/etc/robots/robotcert.pem', '/etc/robots/robotkey.pem')
+    cert = (opts.cert, opts.key)
     try:
-        result = requests.get(url, cert=cert, verify='/etc/ssl/certs/CERN-bundle.pem')
+        result = requests.get(url, cert=cert, verify=opts.ca_cert)
         result.raise_for_status()
     except requests.exceptions.HTTPError as errh:
         print ("Http Error:", errh)
@@ -109,6 +109,10 @@ opt = OptionParser(__doc__)
 opt.add_option("-c", "--conf", dest="conf", metavar="FILE", help="configuration file")
 opt.add_option("-o", "--out", dest="out", metavar="FILE", help="output file")
 opt.add_option("-v", "--verbose", action="store_true", help="increase output verbosity")
+opt.add_option("-e", "--cert", dest="cert", help="path to cert file")
+opt.add_option("-k", "--key", dest="key", help="path to cert key")
+opt.add_option("-b", "--ca-cert", dest="ca_cert", help="path to ca cert bundle")
+
 opts, args = opt.parse_args()
 # Checking command line options
 if not opts.conf:
@@ -119,6 +123,17 @@ if not opts.out:
     print >> sys.stderr, "Output file name is required"
     exit(1)
 
+if not opts.cert:
+    print >> sys.stderr, "Cert file name is required"
+    exit(1)
+
+if not opts.key:
+    print >> sys.stderr, "Cert key file name is required"
+    exit(1)
+
+if not opts.ca_cert:
+    print >> sys.stderr, "CA bundle file name is required"
+    exit(1)
 
 ##Calling core functions
 #Identifiying api to fetch
@@ -130,19 +145,19 @@ uri = getFecthDetails(opts.conf)
 
 if api == "group-responsibilities.json":
     uri = uri + "group-responsibilities"
-    ncontent = request(uri)
+    ncontent = request(uri, opts)
 
 if api == "people.json":
     uri = uri + "people"
-    ncontent = request(uri)
+    ncontent = request(uri, opts)
 
 if api == "site-names.json":
     uri = uri + "site-names&rcsite_state=ANY"
-    ncontent = request(uri)
+    ncontent = request(uri, opts)
 
 if api == "site-responsibilities.json":
     uri = uri + "site-responsibilities"
-    ncontent = request(uri)
+    ncontent = request(uri, opts)
 
 updateFile(opts, ncontent)
 exit(0)

--- a/phedex/mkauthmap
+++ b/phedex/mkauthmap
@@ -56,9 +56,11 @@ def request(uri, opts):
     path = apimap[query] + path
     query = "json&preset=" + query
     url = urlunparse((scheme, netloc, path, '', query, frag))
-    cert = (opts.cert, opts.key)
+    cert = None
+    if opts.cert and opts.key:
+        cert = (opts.cert, opts.key)
     try:
-        result = requests.get(url, cert=cert, verify=opts.ca_cert)
+        result = requests.get(url, cert=cert, verify=opts.ca_cert or True)
         result.raise_for_status()
     except requests.exceptions.HTTPError as errh:
         print ("Http Error:", errh)
@@ -121,18 +123,6 @@ if not opts.conf:
 
 if not opts.out:
     print >> sys.stderr, "Output file name is required"
-    exit(1)
-
-if not opts.cert:
-    print >> sys.stderr, "Cert file name is required"
-    exit(1)
-
-if not opts.key:
-    print >> sys.stderr, "Cert key file name is required"
-    exit(1)
-
-if not opts.ca_cert:
-    print >> sys.stderr, "CA bundle file name is required"
     exit(1)
 
 ##Calling core functions


### PR DESCRIPTION
I thought I pushed that yesterday but apparently I didn't,

Cron should now be:

```
*/4 * * * * . /data/srv/current/apps/frontend/etc/profile.d/init.sh && PYTHONPATH=/data/srv/current/auth/frontend:$PYTHONPATH /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem
```