### PR TITLE
Default frontend rules for MSUnmerged

### DIFF
--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -38,10 +38,10 @@
 ^/auth/complete/ms-monitor(?:/|$) ms-monitor.dmwm.svc.cluster.local
 ^/auth/complete/ms-output(?:/|$) ms-output.dmwm.svc.cluster.local
 ^/auth/complete/ms-rulecleaner(?:/|$) ms-rulecleaner.dmwm.svc.cluster.local
-^/auth/complete/ms-unmerged/(?:.*rses=t1)(?:/|$) ms-unmerged-t1.dmwm.svc.cluster.local
-^/auth/complete/ms-unmerged/(?:.*rses=t2-t3-us)(?:/|$) ms-unmerged-t2-t3-us.dmwm.svc.cluster.local
-^/auth/complete/ms-unmerged/(?:.*rses=t2-t3)(?:/|$) ms-unmerged-t2-t3.dmwm.svc.cluster.local
-^/auth/complete/ms-unmerged(?:/|$) ms-unmerged-t1.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged/(?:.*rse_type=t1)(?:/|$) ms-unmer-t1.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged/(?:.*rse_type=t2t3us)(?:/|$) ms-unmer-t2t3us.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged/(?:.*rse_type=t2t3)(?:/|$) ms-unmer-t2t3.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged(?:/|$) ms-unmer-t1.dmwm.svc.cluster.local
 ^/auth/complete/t0wmadatasvc(?:/|$) t0wmadatasvc.tzero.svc.cluster.local
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -41,6 +41,7 @@
 ^/auth/complete/ms-unmerged/(?:.*rses=t1)(?:/|$) ms-unmerged-t1.dmwm.svc.cluster.local
 ^/auth/complete/ms-unmerged/(?:.*rses=t2-t3-us)(?:/|$) ms-unmerged-t2-t3-us.dmwm.svc.cluster.local
 ^/auth/complete/ms-unmerged/(?:.*rses=t2-t3)(?:/|$) ms-unmerged-t2-t3.dmwm.svc.cluster.local
+^/auth/complete/ms-unmerged(?:/|$) ms-unmerged-t1.dmwm.svc.cluster.local
 ^/auth/complete/t0wmadatasvc(?:/|$) t0wmadatasvc.tzero.svc.cluster.local
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch

--- a/frontend/backends-k8s-prod.txt
+++ b/frontend/backends-k8s-prod.txt
@@ -32,9 +32,9 @@
 ^/auth/complete/ms-monitor(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/ms-output(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/ms-rulecleaner(?:/|$) cmsweb-srv.cern.ch
-^/auth/complete/ms-unmerged/(?:.*rses=t1)(?:/|$) cmsweb-srv.cern.ch
-^/auth/complete/ms-unmerged/(?:.*rses=t2-t3-us)(?:/|$) cmsweb-srv.cern.ch
-^/auth/complete/ms-unmerged/(?:.*rses=t2-t3)(?:/|$) cmsweb-srv.cern.ch
+^/auth/complete/ms-unmerged/(?:.*rse_type=t1)(?:/|$) cmsweb-srv.cern.ch
+^/auth/complete/ms-unmerged/(?:.*rse_type=t2t3us)(?:/|$) cmsweb-srv.cern.ch
+^/auth/complete/ms-unmerged/(?:.*rse_type=t2t3)(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/ms-unmerged(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch

--- a/frontend/backends-k8s-prod.txt
+++ b/frontend/backends-k8s-prod.txt
@@ -35,6 +35,7 @@
 ^/auth/complete/ms-unmerged/(?:.*rses=t1)(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/ms-unmerged/(?:.*rses=t2-t3-us)(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/ms-unmerged/(?:.*rses=t2-t3)(?:/|$) cmsweb-srv.cern.ch
+^/auth/complete/ms-unmerged(?:/|$) cmsweb-srv.cern.ch
 ^/auth/complete/scheddmon/068/ vocms068.cern.ch
 ^/auth/complete/scheddmon/069/ vocms069.cern.ch
 ^/auth/complete/scheddmon/0106/ vocms0106.cern.ch


### PR DESCRIPTION
Standard MSUnmerged queries - which do not contain the `rses` query string - are failing with a "Bad Request" at the moment, url like:
https://cmsweb-testbed.cern.ch/ms-unmerged/data/status

So, this PR creates a default ms-unmerged map pointing to the `t1` MSUnmerged service/pod.

@todor-ivanov @muhammadimranfarooqi can you please review it?