### PR TITLE
Import an ECAL Trend plot to Layouts folder

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -1000,6 +1000,9 @@ ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/08 Timing mean',
 ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/09 Timing rms',
 	   [{'path': 'Ecal/Trends/TimingClient EB timing rms', 'description': 'Trend of timing rms. Plots simple average of all channel timing rms at each lumisection.'}],
 	   [{'path': 'Ecal/Trends/TimingClient EE timing rms', 'description': 'Trend of timing rms. Plots simple average of all channel timing rms at each lumisection.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/10 TTF4 Flag',
+	    [{'path': 'Ecal/Trends/TrigPrimClient EB number of TTs with TTF4 set', 'description':'Trend of the total number of TTs in this partition with TTF4 flag set.'}],
+	    [{'path': 'Ecal/Trends/TrigPrimClient EE number of TTs with TTF4 set', 'description':'Trend of the total number of TTs in this partition with TTF4 flag set.'}])
 
 #____________________ Layouts / 12 By SuperModule ____________________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE


### PR DESCRIPTION
### PR description:
At the request of the ECAL trigger team two existing plots in `Ecal/Trends` are being imported to `Ecal/Layouts/Trend`. 
This makes the plots easily accessible to the Ecal PFG and trigger shifters.
This layout change is only for the ECAL internal layouts and not for the DQM shifter layouts.

#### PR validation:
Online DQM root files for ECAL from a global run were used and uploaded to a private DQM GUI.