### PR TITLE
new rules for dbs2go-migrate redirects

### DIFF
--- a/frontend/app_dbs_nossl.conf
+++ b/frontend/app_dbs_nossl.conf
@@ -1,3 +1,4 @@
 RewriteRule ^(/dbsproxy(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dbs2go(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dbs2go-migrate(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dbs(/.*)?)$ https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]

--- a/frontend/app_dbs_ssl.conf
+++ b/frontend/app_dbs_ssl.conf
@@ -2,6 +2,8 @@ RewriteRule ^(/dbsproxy(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cer
 RewriteRule ^/auth/complete(/dbsproxy(/.*)?)$ http://%{ENV:BACKEND}:8222${escape:$1} [QSA,P,L,NE]
 RewriteRule ^(/dbs2go(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
 RewriteRule ^/auth/complete(/dbs2go(/.*)?)$ http://%{ENV:BACKEND}:8258${escape:$1} [QSA,P,L,NE]
+RewriteRule ^(/dbs2go-migrate(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
+RewriteRule ^/auth/complete(/dbs2go-migrate(/.*)?)$ http://%{ENV:BACKEND}:8259${escape:$1} [QSA,P,L,NE]
 RewriteRule ^(/dbs(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
 RewriteRule ^/auth/complete(/dbs(/.*)/global/DBSReader(/.*)?)$ http://%{ENV:BACKEND}:8252${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dbs(/.*)/global/DBSWriter(/.*)?)$ http://%{ENV:BACKEND}:8253${escape:$1} [QSA,P,L,NE]

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -25,6 +25,7 @@
 ^/auth/complete/crabserver(?:/|$) crabserver.crab.svc.cluster.local
 ^/auth/complete/dbsproxy(?:/|$) dbsproxy.dbs.svc.cluster.local
 ^/auth/complete/dbs2go(?:/|$) dbs2go.dbs.svc.cluster.local
+^/auth/complete/dbs2go-migrate(?:/|$) dbs2go-migrate.dbs.svc.cluster.local
 ^/auth/complete/dbs/(?:int/global/DBSMigrate|prod/global/DBSMigrate|dev/global/DBSMigrate)(?:/|$) dbs-migrate.dbs.svc.cluster.local
 ^/auth/complete/dbs/(?:int/global/DBSReader|prod/global/DBSReader|dev/global/DBSReader)(?:/|$) dbs-global-r.dbs.svc.cluster.local
 ^/auth/complete/dbs/(?:int/global/DBSWriter|prod/global/DBSWriter|dev/global/DBSWriter)(?:/|$) dbs-global-w.dbs.svc.cluster.local


### PR DESCRIPTION
@muhammadimranfarooqi please merge this PR and deploy to cmsweb testbed k8s cluster. I need new rules to start validation testing of dbs2go migration service. Once validation is over we'll most likely remove them and use default DBS ones.