### PR TITLE
Initial manage/config changes for CouchDB 3.1.2

### DIFF
--- a/couchdb/default.ini
+++ b/couchdb/default.ini
@@ -1,0 +1,650 @@
+; Upgrading CouchDB will overwrite this file.
+[vendor]
+name = The Apache Software Foundation
+
+[couchdb]
+uuid = 
+database_dir = ./data
+view_index_dir = ./data
+; util_driver_dir =
+; plugin_dir =
+os_process_timeout = 5000 ; 5 seconds. for view servers.
+max_dbs_open = 500
+; Method used to compress everything that is appended to database and view index files, except
+; for attachments (see the attachments section). Available methods are:
+;
+; none         - no compression
+; snappy       - use google snappy, a very fast compressor/decompressor
+; deflate_N    - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
+;                lowest compression ratio) to 9 (slowest, highest compression ratio)
+file_compression = snappy
+; Higher values may give better read performance due to less read operations
+; and/or more OS page cache hits, but they can also increase overall response
+; time for writes when there are many attachment write requests in parallel.
+attachment_stream_buffer_size = 4096
+; Default security object for databases if not explicitly set
+; everyone - same as couchdb 1.0, everyone can read/write
+; admin_only - only admins can read/write
+; admin_local - sharded dbs on :5984 are read/write for everyone,
+;               local dbs on :5986 are read/write for admins only
+default_security = admin_only
+; btree_chunk_size = 1279
+; maintenance_mode = false
+; stem_interactive_updates = true
+; uri_file =
+; The speed of processing the _changes feed with doc_ids filter can be
+; influenced directly with this setting - increase for faster processing at the
+; expense of more memory usage.
+changes_doc_ids_optimization_threshold = 100
+; Maximum document ID length. Can be set to an integer or 'infinity'.
+;max_document_id_length = infinity
+;
+; Limit maximum document size. Requests to create / update documents with a body
+; size larger than this will fail with a 413 http error. This limit applies to
+; requests which update a single document as well as individual documents from
+; a _bulk_docs request. Since there is no canonical size of json encoded data,
+; due to variabiliy in what is escaped or how floats are encoded, this limit is
+; applied conservatively. For example 1.0e+16 could be encoded as 1e16, so 4 used
+; for size calculation instead of 7.
+max_document_size = 8000000 ; bytes
+;
+; Maximum attachment size.
+; max_attachment_size = infinity
+;
+; Do not update the least recently used DB cache on reads, only writes
+;update_lru_on_read = false
+;
+; The default storage engine to use when creating databases
+; is set as a key into the [couchdb_engines] section.
+default_engine = couch
+;
+; Enable this to only "soft-delete" databases when DELETE /{db} requests are
+; made. This will place a .recovery directory in your data directory and
+; move deleted databases/shards there instead. You can then manually delete
+; these files later, as desired.
+;enable_database_recovery = false
+;
+; Set the maximum size allowed for a partition. This helps users avoid
+; inadvertently abusing partitions resulting in hot shards. The default
+; is 10GiB. A value of 0 or less will disable partition size checks.
+;max_partition_size = 10737418240
+;
+; When true, system databases _users and _replicator are created immediately
+; on startup if not present.
+;single_node = false
+
+; Allow edits on the _security object in the user db. By default, it's disabled.
+users_db_security_editable = false
+
+[purge]
+; Allowed maximum number of documents in one purge request
+;max_document_id_number = 100
+;
+; Allowed maximum number of accumulated revisions in one purge request
+;max_revisions_number = 1000
+;
+; Allowed durations when index is not updated for local purge checkpoint
+; document. Default is 24 hours.
+;index_lag_warn_seconds = 86400
+
+[couchdb_engines]
+; The keys in this section are the filename extension that
+; the specified engine module will use. This is important so
+; that couch_server is able to find an existing database without
+; having to ask every configured engine.
+couch = couch_bt_engine
+
+[process_priority]
+; Selectively disable altering process priorities for modules that request it.
+; * NOTE: couch_server priority has been shown to lead to CouchDB hangs and
+;     failures on Erlang releases 21.0 - 21.3.8.12 and 22.0 -> 22.2.4. Do not
+;     enable when running with those versions.
+;couch_server = false
+
+[cluster]
+q=2
+n=3
+; placement = metro-dc-a:2,metro-dc-b:1
+
+; Supply a comma-delimited list of node names that this node should
+; contact in order to join a cluster. If a seedlist is configured the ``_up``
+; endpoint will return a 404 until the node has successfully contacted at
+; least one of the members of the seedlist and replicated an up-to-date copy
+; of the ``_nodes``, ``_dbs``, and ``_users`` system databases.
+; seedlist = couchdb@node1.example.com,couchdb@node2.example.com
+
+[chttpd]
+; These settings affect the main, clustered port (5984 by default).
+port = 5984
+bind_address = 127.0.0.1
+backlog = 512
+socket_options = [{sndbuf, 262144}, {nodelay, true}]
+server_options = [{recbuf, undefined}]
+require_valid_user = false
+; require_valid_user_except_for_up = false
+; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
+; If Server header is left out, Mochiweb will add its own one in.
+prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;
+; Limit maximum number of databases when tying to get detailed information using
+; _dbs_info in a request
+max_db_number_for_dbs_info_req = 100
+
+; set to true to delay the start of a response until the end has been calculated
+;buffer_response = false
+
+; authentication handlers
+; authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+; uncomment the next line to enable proxy authentication
+; authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+; uncomment the next line to enable JWT authentication
+; authentication_handlers = {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+
+; prevent non-admins from accessing /_all_dbs
+; admin_only_all_dbs = true
+
+;[jwt_auth]
+; List of claims to validate
+; required_claims =
+;
+; [jwt_keys]
+; Configure at least one key here if using the JWT auth handler.
+; If your JWT tokens do not include a "kid" attribute, use "_default"
+; as the config key, otherwise use the kid as the config key.
+; Examples
+; hmac:_default = aGVsbG8=
+; hmac:foo = aGVsbG8=
+; The config values can represent symmetric and asymmetrics keys.
+; For symmetrics keys, the value is base64 encoded;
+; hmac:_default = aGVsbG8= # base64-encoded form of "hello"
+; For asymmetric keys, the value is the PEM encoding of the public
+; key with newlines replaced with the escape sequence \n.
+; rsa:foo = -----BEGIN PUBLIC KEY-----\nMIIBIjAN...IDAQAB\n-----END PUBLIC KEY-----\n
+; ec:bar = -----BEGIN PUBLIC KEY-----\nMHYwEAYHK...AzztRs\n-----END PUBLIC KEY-----\n
+
+[couch_peruser]
+; If enabled, couch_peruser ensures that a private per-user database
+; exists for each document in _users. These databases are writable only
+; by the corresponding user. Databases are in the following form:
+; userdb-{hex encoded username}
+enable = false
+; If set to true and a user is deleted, the respective database gets
+; deleted as well.
+delete_dbs = false
+; Set a default q value for peruser-created databases that is different from
+; cluster / q
+;q = 1
+; prefix for user databases. If you change this after user dbs have been
+; created, the existing databases won't get deleted if the associated user
+; gets deleted because of the then prefix mismatch.
+database_prefix = userdb-
+
+[httpd]
+port = 5986
+bind_address = 127.0.0.1
+authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+secure_rewrites = true
+allow_jsonp = false
+; Options for the MochiWeb HTTP server.
+;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
+; For more socket options, consult Erlang's module 'inet' man page.
+;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
+socket_options = [{sndbuf, 262144}]
+enable_cors = false
+enable_xframe_options = false
+; CouchDB can optionally enforce a maximum uri length;
+; max_uri_length = 8000
+; changes_timeout = 60000
+; config_whitelist = 
+; max_uri_length = 
+; rewrite_limit = 100
+; x_forwarded_host = X-Forwarded-Host
+; x_forwarded_proto = X-Forwarded-Proto
+; x_forwarded_ssl = X-Forwarded-Ssl
+; Maximum allowed http request size. Applies to both clustered and local port.
+max_http_request_size = 4294967296 ; 4GB
+
+; [httpd_design_handlers]
+; _view = 
+
+; [ioq]
+; concurrency = 10
+; ratio = 0.01
+
+[ssl]
+port = 6984
+
+; [chttpd_auth]
+; authentication_db = _users
+
+; [chttpd_auth_cache]
+; max_lifetime = 600000
+; max_objects = 
+; max_size = 104857600
+
+; [mem3]
+; nodes_db = _nodes
+; shard_cache_size = 25000
+; shards_db = _dbs
+; sync_concurrency = 10
+
+; [fabric]
+; all_docs_concurrency = 10
+; changes_duration = 
+; shard_timeout_factor = 2
+; uuid_prefix_len = 7
+; request_timeout = 60000
+; all_docs_timeout = 10000
+; attachments_timeout = 60000
+; view_timeout = 3600000
+; partition_view_timeout = 3600000
+
+; [rexi]
+; buffer_count = 2000
+; server_per_node = true
+; stream_limit = 5
+;
+; Use a single message to kill a group of remote workers This is
+; mostly is an upgrade clause to allow operating in a mixed cluster of
+; 2.x and 3.x nodes. After upgrading switch to true to save some
+; network bandwidth
+;use_kill_all = false
+
+; [global_changes]
+; max_event_delay = 25
+; max_write_delay = 500
+; update_db = true
+
+; [view_updater]
+; min_writer_items = 100
+; min_writer_size = 16777216
+
+[couch_httpd_auth]
+; WARNING! This only affects the node-local port (5986 by default).
+; You probably want the settings under [chttpd].
+authentication_db = _users
+authentication_redirect = /_utils/session.html
+require_valid_user = false
+timeout = 600 ; number of seconds before automatic logout
+auth_cache_size = 50 ; size is number of cache entries
+allow_persistent_cookies = true ; set to false to disallow persistent cookies
+iterations = 10 ; iterations for password hashing
+; min_iterations = 1
+; max_iterations = 1000000000
+; password_scheme = pbkdf2
+; proxy_use_secret = false
+; comma-separated list of public fields, 404 if empty
+; public_fields =
+; secret = 
+; users_db_public = false
+; cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+; same_site =
+
+; CSP (Content Security Policy) Support
+[csp]
+;utils_enable = true
+;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
+;attachments_enable = false
+;attachments_header_value = sandbox
+;showlist_enable = false
+;showlist_header_value = sandbox
+
+[cors]
+credentials = false
+; List of origins separated by a comma, * means accept all
+; Origins must include the scheme: http://example.com
+; You can't set origins: * and credentials = true at the same time.
+;origins = *
+; List of accepted headers separated by a comma
+; headers =
+; List of accepted methods
+; methods =
+
+; Configuration for a vhost
+;[cors:http://example.com]
+; credentials = false
+; List of origins separated by a comma
+; Origins must include the scheme: http://example.com
+; You can't set origins: * and credentials = true at the same time.
+;origins =
+; List of accepted headers separated by a comma
+; headers =
+; List of accepted methods
+; methods =
+
+; Configuration for the design document cache
+;[ddoc_cache]
+; The maximum size of the cache in bytes
+;max_size = 104857600 ; 100MiB
+; The period each cache entry should wait before
+; automatically refreshing in milliseconds
+;refresh_timeout = 67000
+
+[x_frame_options]
+; Settings same-origin will return X-Frame-Options: SAMEORIGIN.
+; If same origin is set, it will ignore the hosts setting
+; same_origin = true
+; Settings hosts will return X-Frame-Options: ALLOW-FROM https://example.com/
+; List of hosts separated by a comma. * means accept all
+; hosts =
+
+[native_query_servers]
+; erlang query server
+; enable_erlang_query_server = false
+
+; Changing reduce_limit to false will disable reduce_limit.
+; If you think you're hitting reduce_limit with a "good" reduce function,
+; please let us know on the mailing list so we can fine tune the heuristic.
+[query_server_config]
+; commit_freq = 5
+reduce_limit = true
+os_process_limit = 100
+; os_process_idle_limit = 300
+; os_process_soft_limit = 100
+; Timeout for how long a response from a busy view group server can take.
+; "infinity" is also a valid configuration value.
+;group_info_timeout = 5000
+;query_limit = 268435456
+;partition_query_limit = 268435456
+
+[mango]
+; Set to true to disable the "index all fields" text index, which can lead
+; to out of memory issues when users have documents with nested array fields.
+;index_all_disabled = false
+; Default limit value for mango _find queries.
+;default_limit = 25
+; Ratio between documents scanned and results matched that will
+; generate a warning in the _find response. Setting this to 0 disables
+; the warning.
+;index_scan_warning_threshold = 10
+
+[indexers]
+couch_mrview = true
+
+[feature_flags]
+; This enables any database to be created as a partitioned databases (except system db's). 
+; Setting this to false will stop the creation of paritioned databases.
+; paritioned||allowed* = true will scope the creation of partitioned databases
+; to databases with 'allowed' prefix.
+partitioned||* = true
+
+[uuids]
+; Known algorithms:
+;   random - 128 bits of random awesome
+;     All awesome, all the time.
+;   sequential - monotonically increasing ids with random increments
+;     First 26 hex characters are random. Last 6 increment in
+;     random amounts until an overflow occurs. On overflow, the
+;     random prefix is regenerated and the process starts over.
+;   utc_random - Time since Jan 1, 1970 UTC with microseconds
+;     First 14 characters are the time in hex. Last 18 are random.
+;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
+;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
+algorithm = sequential
+; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
+; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
+utc_id_suffix =
+# Maximum number of UUIDs retrievable from /_uuids in a single request
+max_count = 1000
+
+[attachments]
+compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+compressible_types = text/*, application/javascript, application/json, application/xml
+
+[replicator]
+; Random jitter applied on replication job startup (milliseconds)
+startup_jitter = 5000
+; Number of actively running replications
+max_jobs = 500
+;Scheduling interval in milliseconds. During each reschedule cycle
+interval = 60000
+; Maximum number of replications to start and stop during rescheduling.
+max_churn = 20
+; More worker processes can give higher network throughput but can also
+; imply more disk and network IO.
+worker_processes = 4
+; With lower batch sizes checkpoints are done more frequently. Lower batch sizes
+; also reduce the total amount of used RAM memory.
+worker_batch_size = 500
+; Maximum number of HTTP connections per replication.
+http_connections = 20
+; HTTP connection timeout per replication.
+; Even for very fast/reliable networks it might need to be increased if a remote
+; database is too busy.
+connection_timeout = 30000
+; Request timeout
+;request_timeout = infinity
+; If a request fails, the replicator will retry it up to N times.
+retries_per_request = 5
+; Use checkpoints
+;use_checkpoints = true
+; Checkpoint interval
+;checkpoint_interval = 30000
+; Some socket options that might boost performance in some scenarios:
+;       {nodelay, boolean()}
+;       {sndbuf, integer()}
+;       {recbuf, integer()}
+;       {priority, integer()}
+; See the `inet` Erlang module's man page for the full list of options.
+socket_options = [{keepalive, true}, {nodelay, false}]
+; Path to a file containing the user's certificate.
+;cert_file = /full/path/to/server_cert.pem
+; Path to file containing user's private PEM encoded key.
+;key_file = /full/path/to/server_key.pem
+; String containing the user's password. Only used if the private keyfile is password protected.
+;password = somepassword
+; Set to true to validate peer certificates.
+verify_ssl_certificates = false
+; File containing a list of peer trusted certificates (in the PEM format).
+;ssl_trusted_certificates_file = /etc/ssl/certs/ca-certificates.crt
+; Maximum peer certificate depth (must be set even if certificate validation is off).
+ssl_certificate_max_depth = 3
+; Maximum document ID length for replication.
+;max_document_id_length = infinity
+; How much time to wait before retrying after a missing doc exception. This
+; exception happens if the document was seen in the changes feed, but internal
+; replication hasn't caught up yet, and fetching document's revisions
+; fails. This a common scenario when source is updated while continous
+; replication is running. The retry period would depend on how quickly internal
+; replication is expected to catch up. In general this is an optimisation to
+; avoid crashing the whole replication job, which would consume more resources
+; and add log noise.
+;missing_doc_retry_msec = 2000
+; Wait this many seconds after startup before attaching changes listeners
+; cluster_start_period = 5
+; Re-check cluster state at least every cluster_quiet_period seconds
+; cluster_quiet_period = 60
+
+; List of replicator client authentication plugins to try. Plugins will be
+; tried in order. The first to initialize successfully will be used for that
+; particular endpoint (source or target). Normally couch_replicator_auth_noop
+; would be used at the end of the list as a "catch-all". It doesn't do anything
+; and effectively implements the previous behavior of using basic auth.
+; There are currently two plugins available:
+;   couch_replicator_auth_session - use _session cookie authentication
+;   couch_replicator_auth_noop - use basic authentication (previous default)
+; Currently, the new _session cookie authentication is tried first, before
+; falling back to the old basic authenticaion default:
+;auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
+; To restore the old behaviour, use the following value:
+;auth_plugins = couch_replicator_auth_noop
+
+; Force couch_replicator_auth_session plugin to refresh the session
+; periodically if max-age is not present in the cookie. This is mostly to
+; handle the case where anonymous writes are allowed to the database and a VDU
+; function is used to forbid writes based on the authenticated user name. In
+; that case this value should be adjusted based on the expected minimum session
+; expiry timeout on replication endpoints. If session expiry results in a 401
+; or 403 response this setting is not needed.
+;session_refresh_interval_sec = 550
+
+[log]
+; Possible log levels:
+;  debug
+;  info
+;  notice
+;  warning, warn
+;  error, err
+;  critical, crit
+;  alert
+;  emergency, emerg
+;  none
+;
+level = info
+;
+; Set the maximum log message length in bytes that will be
+; passed through the writer
+;
+; max_message_size = 16000
+;
+;
+; There are four different log writers that can be configured
+; to write log messages. The default writes to stderr of the
+; Erlang VM which is useful for debugging/development as well
+; as a lot of container deployments.
+;
+; There's also a file writer that works with logrotate, a
+; rsyslog writer for deployments that need to have logs sent
+; over the network, and a journald writer that's more suitable
+; when using systemd journald.
+;
+writer = stderr
+; Journald Writer notes:
+;
+; The journald writer doesn't have any options. It still writes
+; the logs to stderr, but without the timestamp prepended, since
+; the journal will add it automatically, and with the log level
+; formated as per
+; https://www.freedesktop.org/software/systemd/man/sd-daemon.html
+;
+;
+; File Writer Options:
+;
+; The file writer will check every 30s to see if it needs
+; to reopen its file. This is useful for people that configure
+; logrotate to move log files periodically.
+;
+; file = ./couch.log ; Path name to write logs to
+;
+; Write operations will happen either every write_buffer bytes
+; or write_delay milliseconds. These are passed directly to the
+; Erlang file module with the write_delay option documented here:
+;
+;     http://erlang.org/doc/man/file.html
+;
+; write_buffer = 0
+; write_delay = 0
+;
+;
+; Syslog Writer Options:
+;
+; The syslog writer options all correspond to their obvious
+; counter parts in rsyslog nomenclature.
+;
+; syslog_host =
+; syslog_port = 514
+; syslog_appid = couchdb
+; syslog_facility = local2
+
+[stats]
+; Stats collection interval in seconds. Default 10 seconds.
+;interval = 10
+
+[smoosh]
+;
+; More documentation on these is in the Automatic Compaction
+; section of the documentation.
+;
+;db_channels = upgrade_dbs,ratio_dbs,slack_dbs
+;view_channels = upgrade_views,ratio_views,slack_views
+;
+;[smoosh.ratio_dbs]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.ratio_views]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.slack_dbs]
+;priority = slack
+;min_priority = 16777216
+;
+;[smoosh.slack_views]
+;priority = slack
+;min_priority = 16777216
+
+[ioq]
+; The maximum number of concurrent in-flight IO requests that
+concurrency = 10
+
+; The fraction of the time that a background IO request will be selected
+; over an interactive IO request when both queues are non-empty
+ratio = 0.01
+
+[ioq.bypass]
+; System administrators can choose to submit specific classes of IO directly
+; to the underlying file descriptor or OS process, bypassing the queues
+; altogether. Installing a bypass can yield higher throughput and lower
+; latency, but relinquishes some control over prioritization. The following
+; classes are recognized with the following defaults:
+
+; Messages on their way to an external process (e.g., couchjs) are bypassed
+os_process = true
+
+; Disk IO fulfilling interactive read requests is bypassed
+read = true
+
+; Disk IO required to update a database is bypassed
+write = true
+
+; Disk IO required to update views and other secondary indexes is bypassed
+view_update = true
+
+; Disk IO issued by the background replication processes that fix any
+; inconsistencies between shard copies is queued
+shard_sync = false
+
+; Disk IO issued by compaction jobs is queued
+compaction = false
+
+[dreyfus]
+; The name and location of the Clouseau Java service required to
+; enable Search functionality.
+; name = clouseau@127.0.0.1
+
+; CouchDB will try to re-connect to Clouseau using a bounded
+; exponential backoff with the following number of iterations.
+; retry_limit = 5
+
+; The default number of results returned from a global search query.
+; limit = 25
+
+; The default number of results returned from a search on a partition
+; of a database.
+; limit_partitions = 2000
+ 
+; The maximum number of results that can be returned from a global
+; search query (or any search query on a database without user-defined
+; partitions). Attempts to set ?limit=N higher than this value will
+; be rejected.
+; max_limit = 200
+
+; The maximum number of results that can be returned when searching
+; a partition of a database. Attempts to set ?limit=N higher than this
+; value will be rejected. If this config setting is not defined,
+; CouchDB will use the value of `max_limit` instead. If neither is
+; defined, the default is 2000 as stated here.
+; max_limit_partitions = 2000
+
+[reshard]
+;max_jobs = 48
+;max_history = 20
+;max_retries = 1
+;retry_interval_sec = 10
+;delete_source = true
+;update_shard_map_timeout_sec = 60
+;source_close_timeout_sec = 600
+;require_node_param = false
+;require_range_param = false

--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -19,24 +19,20 @@ deploy_couchdb_sw()
 
   case $variant in
     default )
-      deploy_pkg -l couchdb -a couchdb/hmackey.ini comp external+couchdb16
+      deploy_pkg -l couchdb -a couchdb/hmackey.ini comp external+couchdb31
       $authlink || setgroup ug+rx,o-rwx _config $project_auth/hmackey.ini
       ;;
     * )
       deploy_pkg -a couchdb/hmackey.ini comp external+couchdb
-      perl -p -i -e "s|bind_address = 0.0.0.0|bind_address = 127.0.0.1|g" $root/$cfgversion/config/$project/local.ini
-      (echo
-       echo "[ssl]"
-       echo "cert_file = $project_state/proxy/proxy.cert"
-       echo "key_file = $project_state/proxy/proxy.cert"
-       echo "cacert_file = $project_state/proxy/proxy.cert"
-       echo
-       echo "[replicator]"
-       echo "max_replication_retry_count = infinity"
-      ) >> $root/$cfgversion/config/$project/local.ini
       ;;
   esac
+
   perl -p -i -e "s|{ROOT}|$root|g" $root/$cfgversion/config/$project/local.ini
+
+  # BAD code for the hmackey that does not work when read from a separate file
+  local hmacKey=`tail -n1 $project_auth/hmackey.ini`
+  sed -i '/^validate_hmac=.*/a $hmacKey' $root/$cfgversion/config/$project/local.ini
+
 }
 
 deploy_couchdb_post()
@@ -79,6 +75,14 @@ deploy_couchdb_post()
 
 deploy_couchdb_auth()
 {
+  cp $privauthdir/$project/couch_creds $project_auth/couch_creds
+  setgroup ug+rx,o-rwx _config $project_auth/couch_creds || true
+  local COUCH_USER=`cat $project_auth/couch_creds | grep COUCH_USER | sed s/COUCH_USER=//`
+  local COUCH_PASS=`cat $project_auth/couch_creds | grep COUCH_PASS | sed s/COUCH_PASS=//`
+  sed -i "s+;user = pass+$COUCH_USER = $COUCH_PASS+" $root/$cfgversion/config/$project/local.ini
+  # Update the monitoring script as well
+  sed -i "s+@@@USER:@@@PASS+$COUCH_USER:$COUCH_PASS+" $root/$cfgversion/config/$project/monitoring.ini
+
   perl -e \
     'undef $/; print "[couch_cms_auth]\n";
      print "hmac_secret = ", unpack("h*", <STDIN>), "\n"' < \

--- a/couchdb/local.ini
+++ b/couchdb/local.ini
@@ -1,12 +1,19 @@
-[httpd]
-bind_address = 0.0.0.0
+; CouchDB configuration settings
 
-authentication_handlers = {couch_cms_auth, cms_backend_authentication_handler},{couch_cms_auth, cms_host_authentication_hander}
+[chttpd]
+port = 5984
+bind_address = 127.0.0.1
+authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}
+; this allows any user to view the databases
+admin_only_all_dbs = false
 
-[couch_cms_auth]
-allowed_hosts = {127.0.0.1, _admin, _admin}
-allow_backend_passthrough = true
-validate_hmac = true
+; These two sections are no longer needed for central CouchDB
+;[httpd]
+;authentication_handlers = {couch_cms_auth, cms_backend_authentication_handler},{couch_cms_auth, cms_host_authentication_hander}
+;[couch_cms_auth]
+;allowed_hosts = {127.0.0.1, _admin, _admin}
+;allow_backend_passthrough = true
+;validate_hmac = true
 
 [couchdb]
 database_dir = {ROOT}/state/couchdb/database
@@ -14,6 +21,11 @@ view_index_dir = {ROOT}/state/couchdb/database
 uri_file = {ROOT}/state/couchdb/couch.uri
 ; increase the timeout from 5 seconds to 4 minutes
 os_process_timeout=240000
+; single node is only for test purposes, otherwise it will work just like CouchDB 1.x
+; for now, define it in the default config such that _users, _replicator and _global_changes databases are automatically created
+single_node=true
+; any user can perform read and writes to the databases
+default_security = everyone
 
 [compactions]
 _default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]
@@ -29,3 +41,6 @@ file = {ROOT}/logs/couchdb/couch.log
 
 [native_query_servers]
 erlang = {couch_native_process, start_link, []}
+
+[admins]
+;user = pass

--- a/couchdb/manage
+++ b/couchdb/manage
@@ -37,14 +37,22 @@ CFGDIR=$(cd $(dirname $0) && pwd)
 LOGDIR=$TOP/logs/$ME
 STATEDIR=$TOP/state/$ME
 KEYFILE=$ROOT/auth/$ME/hmackey.ini
+COUCH_CREDS=$ROOT/auth/$ME/couch_creds
+EXCEPTIONS="wmstats"
+
 COLOR_OK="\\033[0;32m"
 COLOR_WARN="\\033[0;31m"
 COLOR_NORMAL="\\033[0;39m"
 PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/kerberos/bin
-export STAGE_HOST=${STAGE_HOST:-castorcms}
-export STAGE_SVCCLASS=archive
 
-EXCEPTIONS="wmstats"
+# Does the credential file exist and is it readable?
+if [ ! -r $COUCH_CREDS ]; then
+   echo "Variable COUCH_CREDS needs to be defined"
+   exit 1
+fi
+COUCH_USER=`cat $COUCH_CREDS | grep COUCH_USER | sed s/COUCH_USER=//`
+COUCH_PASS=`cat $COUCH_CREDS | grep COUCH_PASS | sed s/COUCH_PASS=//`
+COUCH_CREDS_URL="http://$COUCH_USER:$COUCH_PASS@localhost:5984"
 
 . $ROOT/apps/$ME/etc/profile.d/init.sh
 
@@ -195,7 +203,8 @@ files_needed_from_yui=('build/animation/animation-min.js'
 # Start service conditionally on crond restart.
 sysboot()
 {
-  if couchdb -p $STATEDIR/couchdb.pid -s; then :; else
+  num_procs=$(get_num_couch_process)
+  if [ -z "$num_procs" ]; then
     start
   fi
 }
@@ -204,10 +213,11 @@ sysboot()
 start()
 {
   cd $STATEDIR
-  couchdb -A $CFGDIR/ -a $KEYFILE -b \
-    -o /dev/null \
-    -e $LOGDIR/$(date +%Y%m%d-%H%M%S).stderr \
-    -p $STATEDIR/couchdb.pid </dev/null >/dev/null 2>&1
+  echo -n "Which couchdb: "
+  which couchdb
+  echo "  With configuration directory: $CFGDIR"
+  echo "  With logdir: $LOGDIR"
+  nohup couchdb -couch_ini $CFGDIR >> ${LOGDIR}/couch.log 2>&1 &
 
   push_apps
   replications push
@@ -216,18 +226,28 @@ start()
 # Stop the service.
 stop()
 {
-  couchdb -d -p $STATEDIR/couchdb.pid
+  echo "Stopping CouchDB service..."
+  # FIXME: grepping for couchdb31 is fragile!!!
+  for couch_pid in $(ps aux | grep couchdb31 | grep -v grep | awk '{print $2}'); do
+    echo "  killing CouchDB process... ${pid}"
+    kill -9 $couch_pid || true
+  done
+}
+
+# check the number of beam/couchdb processes
+get_num_couch_process()
+{
+  local num_proc=`ps aux | grep beam | grep -v grep`
+  echo $num_proc
 }
 
 # Check if the server is running.
 status()
 {
-  couchdb -p $STATEDIR/couchdb.pid -s
-
-  curl -s localhost:5984 | grep -q '"version":"1.[0-9.]*"' ||
+  curl -s localhost:5984/_up | grep -q '"status":"ok"' ||
     { echo "CouchDB is not correctly responding to requests"; return; }
 
-  local TASKS=$(curl -s localhost:5984/_active_tasks)
+  local TASKS=$(curl -s $COUCH_CREDS_URL/_active_tasks)
   [ "$TASKS" = '[]' ] && TASKS="No active tasks (e.g. compactions)"
   echo $TASKS
 
@@ -242,7 +262,7 @@ clean_views()
   [ -n "$database" ] ||
     { echo "You must specify the database you wish to clean the views "; exit 1; }
 
-  curl -s -H "Content-Type: application/json" -X POST http://localhost:5984/$database/_view_cleanup | \
+  curl -s -H "Content-Type: application/json" -X POST $COUCH_CREDS_URL/$database/_view_cleanup | \
        grep -q '{"ok":true}' ||
     { echo "An error occured while cleaning the views. Please look in the CouchDB logs."; exit 3; }
 }
@@ -259,8 +279,7 @@ push_apps()
 
   n=0 started=false
   while [ $n -le 100 ]; do
-    couchdb -p $STATEDIR/couchdb.pid -s &> /dev/null &&
-      curl -s localhost:5984 | grep -q '"version":"1.[0-9.]*"' &&
+    curl -s localhost:5984/_up | grep -q '"status":"ok"' &&
       started=true && break
     echo "waiting for couchdb..."
     sleep 1
@@ -269,44 +288,35 @@ push_apps()
 
   if $started; then
     # acdc server
-    couchapp push -p $couchapps_path/ACDC -c http://localhost:5984/acdcserver
-    couchapp push -p $couchapps_path/GroupUser -c http://localhost:5984/acdcserver
+    for ddoc in "ACDC" "GroupUser"; do
+      couchapp push -p $couchapps_path/$ddoc -c $COUCH_CREDS_URL/acdcserver
+    done
 
     # reqmgr2
-    couchapp push -p $couchapps_path/ReqMgrAux -c http://localhost:5984/reqmgr_auxiliary
-    couchapp push -p $couchapps_path/ReqMgr -c http://localhost:5984/reqmgr_workload_cache
-    couchapp push -p $couchapps_path/ConfigCache -c http://localhost:5984/reqmgr_config_cache
+    couchapp push -p $couchapps_path/ReqMgrAux -c $COUCH_CREDS_URL/reqmgr_auxiliary
+    couchapp push -p $couchapps_path/ReqMgr -c $COUCH_CREDS_URL/reqmgr_workload_cache
+    couchapp push -p $couchapps_path/ConfigCache -c $COUCH_CREDS_URL/reqmgr_config_cache
 
     # reqmon
-    couchapp push -p $couchapps_path/WorkloadSummary -c http://localhost:5984/workloadsummary
-    couchapp push -p $couchapps_path/LogDB -c http://localhost:5984/wmstats_logdb
-    couchapp push -p $couchapps_path/WMStats -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl1 -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl2 -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl3 -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl4 -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl5 -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl6 -c http://localhost:5984/wmstats
-    couchapp push -p $couchapps_path/WMStatsErl7 -c http://localhost:5984/wmstats
+    couchapp push -p $couchapps_path/WorkloadSummary -c $COUCH_CREDS_URL/workloadsummary
+    couchapp push -p $couchapps_path/LogDB -c $COUCH_CREDS_URL/wmstats_logdb
+    for ddoc in "WMStats" "WMStatsErl" "WMStatsErl1" "WMStatsErl2" "WMStatsErl3" \
+      "WMStatsErl4" "WMStatsErl5" "WMStatsErl6" "WMStatsErl7"; do
+      couchapp push -p $couchapps_path/$ddoc -c $COUCH_CREDS_URL/wmstats
+    done
 
     # t0_reqmon
-    couchapp push -p $couchapps_path/T0Request -c http://localhost:5984/t0_request
-    couchapp push -p $couchapps_path/WorkloadSummary -c http://localhost:5984/t0_workloadsummary
-    couchapp push -p $couchapps_path/LogDB -c http://localhost:5984/t0_logdb
-    couchapp push -p $couchapps_path/WMStats -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl1 -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl2 -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl3 -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl4 -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl5 -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl6 -c http://localhost:5984/tier0_wmstats
-    couchapp push -p $couchapps_path/WMStatsErl7 -c http://localhost:5984/tier0_wmstats
+    couchapp push -p $couchapps_path/T0Request -c $COUCH_CREDS_URL/t0_request
+    couchapp push -p $couchapps_path/WorkloadSummary -c $COUCH_CREDS_URL/t0_workloadsummary
+    couchapp push -p $couchapps_path/LogDB -c $COUCH_CREDS_URL/t0_logdb
+    for ddoc in "WMStats" "WMStatsErl" "WMStatsErl1" "WMStatsErl2" "WMStatsErl3" \
+      "WMStatsErl4" "WMStatsErl5" "WMStatsErl6" "WMStatsErl7"; do
+      couchapp push -p $couchapps_path/$ddoc -c $COUCH_CREDS_URL/tier0_wmstats
+    done
 
     # workqueue
-    couchapp push -p $couchapps_path/WorkQueue -c http://localhost:5984/workqueue
-    couchapp push -p $couchapps_path/WorkQueue -c http://localhost:5984/workqueue_inbox
+    couchapp push -p $couchapps_path/WorkQueue -c $COUCH_CREDS_URL/workqueue
+    couchapp push -p $couchapps_path/WorkQueue -c $COUCH_CREDS_URL/workqueue_inbox
 
     # clean views
     local databases="acdcserver reqmgr_auxiliary reqmgr_workload_cache reqmgr_config_cache workloadsummary
@@ -401,7 +411,7 @@ update_couchapps()
 replications()
 {
   [ "$1" = "push" ] && local status=false || local status=true
-  local all_reps=$(curl -s localhost:5984/_replicator/_all_docs?include_docs=true \
+  local all_reps=$(curl -s $COUCH_CREDS_URL/_replicator/_all_docs?include_docs=true \
                    | grep '^{"id":"[^_]' | awk -F\" '{print $4,$14,$28,$32,$38,$42}')
   local req_reps=$(cat $STATEDIR/replication/* 2>/dev/null || echo "")
 
@@ -413,7 +423,7 @@ replications()
         echo "Replication 'id=$ID source=$SRC target=$DST filter=$FILTER' unknown."
         if ! $status; then
           echo -n "Removing it... "
-          curl -s -X DELETE localhost:5984/_replicator/$ID?rev=$REV
+          curl -s -X DELETE $COUCH_CREDS_URL/_replicator/$ID?rev=$REV
         fi
       fi
     done
@@ -427,7 +437,7 @@ replications()
         echo "Replication 'id=$ID source=$SRC target=$DST filter=$FILTER' not pushed."
         if ! $status; then
           echo -n "Pushing it... "
-          curl -s -X PUT localhost:5984/_replicator/$ID \
+          curl -s -X PUT $COUCH_CREDS_URL/_replicator/$ID \
                -d "{\"source\":\"$SRC\", \"target\":\"$DST\", \"continuous\":true, \"filter\":\"$FILTER\"}"
         fi
       fi
@@ -463,10 +473,10 @@ compact()
 compact_database()
 {
   local database=$1
-  curl -s localhost:5984/$database | grep -q '"compact_running":true' &&
+  curl -s $COUCH_CREDS_URL/$database | grep -q '"compact_running":true' &&
     { echo "$database is already compacting"; exit 5; }
 
-  curl -s -H "Content-Type: application/json" -X POST http://localhost:5984/$database/_compact | \
+  curl -s -H "Content-Type: application/json" -X POST $COUCH_CREDS_URL/$database/_compact | \
         grep -q '{"ok":true}' ||
     { echo "An error occured triggering compaction. Please look in the CouchDB logs."; exit 7; }
 }
@@ -492,14 +502,14 @@ compact_views()
       if [[ $EXCEPTIONS == *$db* && "$database" = all_but_exceptions ]]; then
         continue
       fi
-      curl -s "localhost:5984/$db/_all_docs?startkey=%22_design%22&endkey=%22_design/zzzzzzzz%22" |
+      curl -s "$COUCH_CREDS_URL/$db/_all_docs?startkey=%22_design%22&endkey=%22_design/zzzzzzzz%22" |
         awk -F\" '/"id":"_design/ {print $4}' |
         while read dbview; do
           compact_view $db ${dbview#*/}
 	done
     done
   elif [ "$designdoc" = all ]; then
-    curl -s "localhost:5984/$database/_all_docs?startkey=%22_design%22&endkey=%22_design/zzzzzzzz%22" |
+    curl -s "$COUCH_CREDS_URL/$database/_all_docs?startkey=%22_design%22&endkey=%22_design/zzzzzzzz%22" |
       awk -F\" '/"id":"_design/ {print $4}' |
       while read dbview; do
         compact_view $database ${dbview#*/}
@@ -515,10 +525,10 @@ compact_view()
   local database=$1
   local designdoc=$2
 
-  curl -s localhost:5984/$database/_design/$designdoc/_info | grep -q '"compact_running":true' &&
+  curl -s $COUCH_CREDS_URL/$database/_design/$designdoc/_info | grep -q '"compact_running":true' &&
     { echo "$database/$designdoc is already compacting"; exit 5; }
 
-  curl -s -H "Content-Type: application/json" -X POST http://localhost:5984/$database/_compact/$designdoc | \
+  curl -s -H "Content-Type: application/json" -X POST $COUCH_CREDS_URL/$database/_compact/$designdoc | \
         grep -q '{"ok":true}' ||
     { echo "An error occured triggering view compaction. Please look in the CouchDB logs."; exit 7; }
 }

--- a/couchdb/monitoring.ini
+++ b/couchdb/monitoring.ini
@@ -7,7 +7,7 @@ LOG_ERROR_REGEX='CRASH REPORT'
 PS_REGEX="/bin/beam.smp .*/config/couchdb//local.ini.* -heart"
 
 # The ping test fetches the provided URL and look for the following perl regex
-PING_URL="http://localhost:5984/workqueue/_design/WorkQueue/_rewrite/"
+PING_URL="http://@@@USER:@@@PASS@localhost:5984/workqueue/_design/WorkQueue/_rewrite/"
 PING_REGEX='WorkQueue Monitor'
 
 PROCESS_OWNER="_couchdb"

--- a/reqmgr2ms/manage
+++ b/reqmgr2ms/manage
@@ -53,6 +53,8 @@ else
   CFGFILERCLEAN=$CFGDIR/config-ruleCleaner.py
   CFGFILEUNMERGED=$CFGDIR/config-unmerged.py
 fi
+CFGFILEOUT=$CFGDIR # force ms-output to be disabled
+CFGFILEUNMERGED=$CFGDIR # force ms-unmerged to be disabled
 
 LOG_TRANS=ms-transferor
 LOG_MON=ms-monitor

--- a/tier0/default.ini
+++ b/tier0/default.ini
@@ -1,0 +1,650 @@
+; Upgrading CouchDB will overwrite this file.
+[vendor]
+name = The Apache Software Foundation
+
+[couchdb]
+uuid = 
+database_dir = ./data
+view_index_dir = ./data
+; util_driver_dir =
+; plugin_dir =
+os_process_timeout = 5000 ; 5 seconds. for view servers.
+max_dbs_open = 500
+; Method used to compress everything that is appended to database and view index files, except
+; for attachments (see the attachments section). Available methods are:
+;
+; none         - no compression
+; snappy       - use google snappy, a very fast compressor/decompressor
+; deflate_N    - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
+;                lowest compression ratio) to 9 (slowest, highest compression ratio)
+file_compression = snappy
+; Higher values may give better read performance due to less read operations
+; and/or more OS page cache hits, but they can also increase overall response
+; time for writes when there are many attachment write requests in parallel.
+attachment_stream_buffer_size = 4096
+; Default security object for databases if not explicitly set
+; everyone - same as couchdb 1.0, everyone can read/write
+; admin_only - only admins can read/write
+; admin_local - sharded dbs on :5984 are read/write for everyone,
+;               local dbs on :5986 are read/write for admins only
+default_security = admin_only
+; btree_chunk_size = 1279
+; maintenance_mode = false
+; stem_interactive_updates = true
+; uri_file =
+; The speed of processing the _changes feed with doc_ids filter can be
+; influenced directly with this setting - increase for faster processing at the
+; expense of more memory usage.
+changes_doc_ids_optimization_threshold = 100
+; Maximum document ID length. Can be set to an integer or 'infinity'.
+;max_document_id_length = infinity
+;
+; Limit maximum document size. Requests to create / update documents with a body
+; size larger than this will fail with a 413 http error. This limit applies to
+; requests which update a single document as well as individual documents from
+; a _bulk_docs request. Since there is no canonical size of json encoded data,
+; due to variabiliy in what is escaped or how floats are encoded, this limit is
+; applied conservatively. For example 1.0e+16 could be encoded as 1e16, so 4 used
+; for size calculation instead of 7.
+max_document_size = 8000000 ; bytes
+;
+; Maximum attachment size.
+; max_attachment_size = infinity
+;
+; Do not update the least recently used DB cache on reads, only writes
+;update_lru_on_read = false
+;
+; The default storage engine to use when creating databases
+; is set as a key into the [couchdb_engines] section.
+default_engine = couch
+;
+; Enable this to only "soft-delete" databases when DELETE /{db} requests are
+; made. This will place a .recovery directory in your data directory and
+; move deleted databases/shards there instead. You can then manually delete
+; these files later, as desired.
+;enable_database_recovery = false
+;
+; Set the maximum size allowed for a partition. This helps users avoid
+; inadvertently abusing partitions resulting in hot shards. The default
+; is 10GiB. A value of 0 or less will disable partition size checks.
+;max_partition_size = 10737418240
+;
+; When true, system databases _users and _replicator are created immediately
+; on startup if not present.
+;single_node = false
+
+; Allow edits on the _security object in the user db. By default, it's disabled.
+users_db_security_editable = false
+
+[purge]
+; Allowed maximum number of documents in one purge request
+;max_document_id_number = 100
+;
+; Allowed maximum number of accumulated revisions in one purge request
+;max_revisions_number = 1000
+;
+; Allowed durations when index is not updated for local purge checkpoint
+; document. Default is 24 hours.
+;index_lag_warn_seconds = 86400
+
+[couchdb_engines]
+; The keys in this section are the filename extension that
+; the specified engine module will use. This is important so
+; that couch_server is able to find an existing database without
+; having to ask every configured engine.
+couch = couch_bt_engine
+
+[process_priority]
+; Selectively disable altering process priorities for modules that request it.
+; * NOTE: couch_server priority has been shown to lead to CouchDB hangs and
+;     failures on Erlang releases 21.0 - 21.3.8.12 and 22.0 -> 22.2.4. Do not
+;     enable when running with those versions.
+;couch_server = false
+
+[cluster]
+q=2
+n=3
+; placement = metro-dc-a:2,metro-dc-b:1
+
+; Supply a comma-delimited list of node names that this node should
+; contact in order to join a cluster. If a seedlist is configured the ``_up``
+; endpoint will return a 404 until the node has successfully contacted at
+; least one of the members of the seedlist and replicated an up-to-date copy
+; of the ``_nodes``, ``_dbs``, and ``_users`` system databases.
+; seedlist = couchdb@node1.example.com,couchdb@node2.example.com
+
+[chttpd]
+; These settings affect the main, clustered port (5984 by default).
+port = 5984
+bind_address = 127.0.0.1
+backlog = 512
+socket_options = [{sndbuf, 262144}, {nodelay, true}]
+server_options = [{recbuf, undefined}]
+require_valid_user = false
+; require_valid_user_except_for_up = false
+; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
+; If Server header is left out, Mochiweb will add its own one in.
+prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;
+; Limit maximum number of databases when tying to get detailed information using
+; _dbs_info in a request
+max_db_number_for_dbs_info_req = 100
+
+; set to true to delay the start of a response until the end has been calculated
+;buffer_response = false
+
+; authentication handlers
+; authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+; uncomment the next line to enable proxy authentication
+; authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+; uncomment the next line to enable JWT authentication
+; authentication_handlers = {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+
+; prevent non-admins from accessing /_all_dbs
+; admin_only_all_dbs = true
+
+;[jwt_auth]
+; List of claims to validate
+; required_claims =
+;
+; [jwt_keys]
+; Configure at least one key here if using the JWT auth handler.
+; If your JWT tokens do not include a "kid" attribute, use "_default"
+; as the config key, otherwise use the kid as the config key.
+; Examples
+; hmac:_default = aGVsbG8=
+; hmac:foo = aGVsbG8=
+; The config values can represent symmetric and asymmetrics keys.
+; For symmetrics keys, the value is base64 encoded;
+; hmac:_default = aGVsbG8= # base64-encoded form of "hello"
+; For asymmetric keys, the value is the PEM encoding of the public
+; key with newlines replaced with the escape sequence \n.
+; rsa:foo = -----BEGIN PUBLIC KEY-----\nMIIBIjAN...IDAQAB\n-----END PUBLIC KEY-----\n
+; ec:bar = -----BEGIN PUBLIC KEY-----\nMHYwEAYHK...AzztRs\n-----END PUBLIC KEY-----\n
+
+[couch_peruser]
+; If enabled, couch_peruser ensures that a private per-user database
+; exists for each document in _users. These databases are writable only
+; by the corresponding user. Databases are in the following form:
+; userdb-{hex encoded username}
+enable = false
+; If set to true and a user is deleted, the respective database gets
+; deleted as well.
+delete_dbs = false
+; Set a default q value for peruser-created databases that is different from
+; cluster / q
+;q = 1
+; prefix for user databases. If you change this after user dbs have been
+; created, the existing databases won't get deleted if the associated user
+; gets deleted because of the then prefix mismatch.
+database_prefix = userdb-
+
+[httpd]
+port = 5986
+bind_address = 127.0.0.1
+authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+secure_rewrites = true
+allow_jsonp = false
+; Options for the MochiWeb HTTP server.
+;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
+; For more socket options, consult Erlang's module 'inet' man page.
+;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
+socket_options = [{sndbuf, 262144}]
+enable_cors = false
+enable_xframe_options = false
+; CouchDB can optionally enforce a maximum uri length;
+; max_uri_length = 8000
+; changes_timeout = 60000
+; config_whitelist = 
+; max_uri_length = 
+; rewrite_limit = 100
+; x_forwarded_host = X-Forwarded-Host
+; x_forwarded_proto = X-Forwarded-Proto
+; x_forwarded_ssl = X-Forwarded-Ssl
+; Maximum allowed http request size. Applies to both clustered and local port.
+max_http_request_size = 4294967296 ; 4GB
+
+; [httpd_design_handlers]
+; _view = 
+
+; [ioq]
+; concurrency = 10
+; ratio = 0.01
+
+[ssl]
+port = 6984
+
+; [chttpd_auth]
+; authentication_db = _users
+
+; [chttpd_auth_cache]
+; max_lifetime = 600000
+; max_objects = 
+; max_size = 104857600
+
+; [mem3]
+; nodes_db = _nodes
+; shard_cache_size = 25000
+; shards_db = _dbs
+; sync_concurrency = 10
+
+; [fabric]
+; all_docs_concurrency = 10
+; changes_duration = 
+; shard_timeout_factor = 2
+; uuid_prefix_len = 7
+; request_timeout = 60000
+; all_docs_timeout = 10000
+; attachments_timeout = 60000
+; view_timeout = 3600000
+; partition_view_timeout = 3600000
+
+; [rexi]
+; buffer_count = 2000
+; server_per_node = true
+; stream_limit = 5
+;
+; Use a single message to kill a group of remote workers This is
+; mostly is an upgrade clause to allow operating in a mixed cluster of
+; 2.x and 3.x nodes. After upgrading switch to true to save some
+; network bandwidth
+;use_kill_all = false
+
+; [global_changes]
+; max_event_delay = 25
+; max_write_delay = 500
+; update_db = true
+
+; [view_updater]
+; min_writer_items = 100
+; min_writer_size = 16777216
+
+[couch_httpd_auth]
+; WARNING! This only affects the node-local port (5986 by default).
+; You probably want the settings under [chttpd].
+authentication_db = _users
+authentication_redirect = /_utils/session.html
+require_valid_user = false
+timeout = 600 ; number of seconds before automatic logout
+auth_cache_size = 50 ; size is number of cache entries
+allow_persistent_cookies = true ; set to false to disallow persistent cookies
+iterations = 10 ; iterations for password hashing
+; min_iterations = 1
+; max_iterations = 1000000000
+; password_scheme = pbkdf2
+; proxy_use_secret = false
+; comma-separated list of public fields, 404 if empty
+; public_fields =
+; secret = 
+; users_db_public = false
+; cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+; same_site =
+
+; CSP (Content Security Policy) Support
+[csp]
+;utils_enable = true
+;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
+;attachments_enable = false
+;attachments_header_value = sandbox
+;showlist_enable = false
+;showlist_header_value = sandbox
+
+[cors]
+credentials = false
+; List of origins separated by a comma, * means accept all
+; Origins must include the scheme: http://example.com
+; You can't set origins: * and credentials = true at the same time.
+;origins = *
+; List of accepted headers separated by a comma
+; headers =
+; List of accepted methods
+; methods =
+
+; Configuration for a vhost
+;[cors:http://example.com]
+; credentials = false
+; List of origins separated by a comma
+; Origins must include the scheme: http://example.com
+; You can't set origins: * and credentials = true at the same time.
+;origins =
+; List of accepted headers separated by a comma
+; headers =
+; List of accepted methods
+; methods =
+
+; Configuration for the design document cache
+;[ddoc_cache]
+; The maximum size of the cache in bytes
+;max_size = 104857600 ; 100MiB
+; The period each cache entry should wait before
+; automatically refreshing in milliseconds
+;refresh_timeout = 67000
+
+[x_frame_options]
+; Settings same-origin will return X-Frame-Options: SAMEORIGIN.
+; If same origin is set, it will ignore the hosts setting
+; same_origin = true
+; Settings hosts will return X-Frame-Options: ALLOW-FROM https://example.com/
+; List of hosts separated by a comma. * means accept all
+; hosts =
+
+[native_query_servers]
+; erlang query server
+; enable_erlang_query_server = false
+
+; Changing reduce_limit to false will disable reduce_limit.
+; If you think you're hitting reduce_limit with a "good" reduce function,
+; please let us know on the mailing list so we can fine tune the heuristic.
+[query_server_config]
+; commit_freq = 5
+reduce_limit = true
+os_process_limit = 100
+; os_process_idle_limit = 300
+; os_process_soft_limit = 100
+; Timeout for how long a response from a busy view group server can take.
+; "infinity" is also a valid configuration value.
+;group_info_timeout = 5000
+;query_limit = 268435456
+;partition_query_limit = 268435456
+
+[mango]
+; Set to true to disable the "index all fields" text index, which can lead
+; to out of memory issues when users have documents with nested array fields.
+;index_all_disabled = false
+; Default limit value for mango _find queries.
+;default_limit = 25
+; Ratio between documents scanned and results matched that will
+; generate a warning in the _find response. Setting this to 0 disables
+; the warning.
+;index_scan_warning_threshold = 10
+
+[indexers]
+couch_mrview = true
+
+[feature_flags]
+; This enables any database to be created as a partitioned databases (except system db's). 
+; Setting this to false will stop the creation of paritioned databases.
+; paritioned||allowed* = true will scope the creation of partitioned databases
+; to databases with 'allowed' prefix.
+partitioned||* = true
+
+[uuids]
+; Known algorithms:
+;   random - 128 bits of random awesome
+;     All awesome, all the time.
+;   sequential - monotonically increasing ids with random increments
+;     First 26 hex characters are random. Last 6 increment in
+;     random amounts until an overflow occurs. On overflow, the
+;     random prefix is regenerated and the process starts over.
+;   utc_random - Time since Jan 1, 1970 UTC with microseconds
+;     First 14 characters are the time in hex. Last 18 are random.
+;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
+;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
+algorithm = sequential
+; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
+; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
+utc_id_suffix =
+# Maximum number of UUIDs retrievable from /_uuids in a single request
+max_count = 1000
+
+[attachments]
+compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+compressible_types = text/*, application/javascript, application/json, application/xml
+
+[replicator]
+; Random jitter applied on replication job startup (milliseconds)
+startup_jitter = 5000
+; Number of actively running replications
+max_jobs = 500
+;Scheduling interval in milliseconds. During each reschedule cycle
+interval = 60000
+; Maximum number of replications to start and stop during rescheduling.
+max_churn = 20
+; More worker processes can give higher network throughput but can also
+; imply more disk and network IO.
+worker_processes = 4
+; With lower batch sizes checkpoints are done more frequently. Lower batch sizes
+; also reduce the total amount of used RAM memory.
+worker_batch_size = 500
+; Maximum number of HTTP connections per replication.
+http_connections = 20
+; HTTP connection timeout per replication.
+; Even for very fast/reliable networks it might need to be increased if a remote
+; database is too busy.
+connection_timeout = 30000
+; Request timeout
+;request_timeout = infinity
+; If a request fails, the replicator will retry it up to N times.
+retries_per_request = 5
+; Use checkpoints
+;use_checkpoints = true
+; Checkpoint interval
+;checkpoint_interval = 30000
+; Some socket options that might boost performance in some scenarios:
+;       {nodelay, boolean()}
+;       {sndbuf, integer()}
+;       {recbuf, integer()}
+;       {priority, integer()}
+; See the `inet` Erlang module's man page for the full list of options.
+socket_options = [{keepalive, true}, {nodelay, false}]
+; Path to a file containing the user's certificate.
+;cert_file = /full/path/to/server_cert.pem
+; Path to file containing user's private PEM encoded key.
+;key_file = /full/path/to/server_key.pem
+; String containing the user's password. Only used if the private keyfile is password protected.
+;password = somepassword
+; Set to true to validate peer certificates.
+verify_ssl_certificates = false
+; File containing a list of peer trusted certificates (in the PEM format).
+;ssl_trusted_certificates_file = /etc/ssl/certs/ca-certificates.crt
+; Maximum peer certificate depth (must be set even if certificate validation is off).
+ssl_certificate_max_depth = 3
+; Maximum document ID length for replication.
+;max_document_id_length = infinity
+; How much time to wait before retrying after a missing doc exception. This
+; exception happens if the document was seen in the changes feed, but internal
+; replication hasn't caught up yet, and fetching document's revisions
+; fails. This a common scenario when source is updated while continous
+; replication is running. The retry period would depend on how quickly internal
+; replication is expected to catch up. In general this is an optimisation to
+; avoid crashing the whole replication job, which would consume more resources
+; and add log noise.
+;missing_doc_retry_msec = 2000
+; Wait this many seconds after startup before attaching changes listeners
+; cluster_start_period = 5
+; Re-check cluster state at least every cluster_quiet_period seconds
+; cluster_quiet_period = 60
+
+; List of replicator client authentication plugins to try. Plugins will be
+; tried in order. The first to initialize successfully will be used for that
+; particular endpoint (source or target). Normally couch_replicator_auth_noop
+; would be used at the end of the list as a "catch-all". It doesn't do anything
+; and effectively implements the previous behavior of using basic auth.
+; There are currently two plugins available:
+;   couch_replicator_auth_session - use _session cookie authentication
+;   couch_replicator_auth_noop - use basic authentication (previous default)
+; Currently, the new _session cookie authentication is tried first, before
+; falling back to the old basic authenticaion default:
+;auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
+; To restore the old behaviour, use the following value:
+;auth_plugins = couch_replicator_auth_noop
+
+; Force couch_replicator_auth_session plugin to refresh the session
+; periodically if max-age is not present in the cookie. This is mostly to
+; handle the case where anonymous writes are allowed to the database and a VDU
+; function is used to forbid writes based on the authenticated user name. In
+; that case this value should be adjusted based on the expected minimum session
+; expiry timeout on replication endpoints. If session expiry results in a 401
+; or 403 response this setting is not needed.
+;session_refresh_interval_sec = 550
+
+[log]
+; Possible log levels:
+;  debug
+;  info
+;  notice
+;  warning, warn
+;  error, err
+;  critical, crit
+;  alert
+;  emergency, emerg
+;  none
+;
+level = info
+;
+; Set the maximum log message length in bytes that will be
+; passed through the writer
+;
+; max_message_size = 16000
+;
+;
+; There are four different log writers that can be configured
+; to write log messages. The default writes to stderr of the
+; Erlang VM which is useful for debugging/development as well
+; as a lot of container deployments.
+;
+; There's also a file writer that works with logrotate, a
+; rsyslog writer for deployments that need to have logs sent
+; over the network, and a journald writer that's more suitable
+; when using systemd journald.
+;
+writer = stderr
+; Journald Writer notes:
+;
+; The journald writer doesn't have any options. It still writes
+; the logs to stderr, but without the timestamp prepended, since
+; the journal will add it automatically, and with the log level
+; formated as per
+; https://www.freedesktop.org/software/systemd/man/sd-daemon.html
+;
+;
+; File Writer Options:
+;
+; The file writer will check every 30s to see if it needs
+; to reopen its file. This is useful for people that configure
+; logrotate to move log files periodically.
+;
+; file = ./couch.log ; Path name to write logs to
+;
+; Write operations will happen either every write_buffer bytes
+; or write_delay milliseconds. These are passed directly to the
+; Erlang file module with the write_delay option documented here:
+;
+;     http://erlang.org/doc/man/file.html
+;
+; write_buffer = 0
+; write_delay = 0
+;
+;
+; Syslog Writer Options:
+;
+; The syslog writer options all correspond to their obvious
+; counter parts in rsyslog nomenclature.
+;
+; syslog_host =
+; syslog_port = 514
+; syslog_appid = couchdb
+; syslog_facility = local2
+
+[stats]
+; Stats collection interval in seconds. Default 10 seconds.
+;interval = 10
+
+[smoosh]
+;
+; More documentation on these is in the Automatic Compaction
+; section of the documentation.
+;
+;db_channels = upgrade_dbs,ratio_dbs,slack_dbs
+;view_channels = upgrade_views,ratio_views,slack_views
+;
+;[smoosh.ratio_dbs]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.ratio_views]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.slack_dbs]
+;priority = slack
+;min_priority = 16777216
+;
+;[smoosh.slack_views]
+;priority = slack
+;min_priority = 16777216
+
+[ioq]
+; The maximum number of concurrent in-flight IO requests that
+concurrency = 10
+
+; The fraction of the time that a background IO request will be selected
+; over an interactive IO request when both queues are non-empty
+ratio = 0.01
+
+[ioq.bypass]
+; System administrators can choose to submit specific classes of IO directly
+; to the underlying file descriptor or OS process, bypassing the queues
+; altogether. Installing a bypass can yield higher throughput and lower
+; latency, but relinquishes some control over prioritization. The following
+; classes are recognized with the following defaults:
+
+; Messages on their way to an external process (e.g., couchjs) are bypassed
+os_process = true
+
+; Disk IO fulfilling interactive read requests is bypassed
+read = true
+
+; Disk IO required to update a database is bypassed
+write = true
+
+; Disk IO required to update views and other secondary indexes is bypassed
+view_update = true
+
+; Disk IO issued by the background replication processes that fix any
+; inconsistencies between shard copies is queued
+shard_sync = false
+
+; Disk IO issued by compaction jobs is queued
+compaction = false
+
+[dreyfus]
+; The name and location of the Clouseau Java service required to
+; enable Search functionality.
+; name = clouseau@127.0.0.1
+
+; CouchDB will try to re-connect to Clouseau using a bounded
+; exponential backoff with the following number of iterations.
+; retry_limit = 5
+
+; The default number of results returned from a global search query.
+; limit = 25
+
+; The default number of results returned from a search on a partition
+; of a database.
+; limit_partitions = 2000
+ 
+; The maximum number of results that can be returned from a global
+; search query (or any search query on a database without user-defined
+; partitions). Attempts to set ?limit=N higher than this value will
+; be rejected.
+; max_limit = 200
+
+; The maximum number of results that can be returned when searching
+; a partition of a database. Attempts to set ?limit=N higher than this
+; value will be rejected. If this config setting is not defined,
+; CouchDB will use the value of `max_limit` instead. If neither is
+; defined, the default is 2000 as stated here.
+; max_limit_partitions = 2000
+
+[reshard]
+;max_jobs = 48
+;max_history = 20
+;max_retries = 1
+;retry_interval_sec = 10
+;delete_source = true
+;update_shard_map_timeout_sec = 60
+;source_close_timeout_sec = 600
+;require_node_param = false
+;require_range_param = false

--- a/tier0/deploy
+++ b/tier0/deploy
@@ -11,15 +11,15 @@ deploy_tier0_sw()
 
   mkdir -p $root/$cfgversion/install/tier0
   mkdir -p $root/$cfgversion/install/couchdb
+  mkdir -p $root/$cfgversion/config/couchdb
 
   local couchdb_ini=$root/$cfgversion/config/tier0/local.ini
-  perl -p -i -e "s{deploy_project_root}{$root/current/install}g" $couchdb_ini
-
-  mkdir -p $root/$cfgversion/config/couchdb
-  cp -f $couchdb_ini $root/$cfgversion/config/couchdb
+  local couchdb_configs=$root/$cfgversion/config/tier0
+  sed -i "s+deploy_project_root+$root/$cfgversion/install+" $couchdb_configs/local.ini
+  cp -f $couchdb_configs/local.ini $root/$cfgversion/config/couchdb/
+  cp -f $couchdb_configs/default.ini $root/$cfgversion/config/couchdb/
 
   mkdir -p $root/$cfgversion/config/rucio/etc
   local rucio_config=$root/$cfgversion/config/tier0/rucio.cfg
   cp -f $rucio_config $root/$cfgversion/config/rucio/etc/
-
 }

--- a/tier0/local.ini
+++ b/tier0/local.ini
@@ -1,8 +1,10 @@
-; CouchDB Configuration Settings
+; WMAgent CouchDB configuration settings
 
-; Custom settings should be made in this file. They will override settings
-; in default.ini, but unlike changes made to default.ini, this file won't be
-; overwritten on server upgrade.
+[chttpd]
+port = 6994
+bind_address = 127.0.0.1
+; Maximum period in milliseconds to wait for a change before the response is sent
+changes_timeout = 300000
 
 [couchdb]
 ;max_document_size = 4294967296 ; bytes
@@ -10,53 +12,40 @@ database_dir = deploy_project_root/couchdb/database
 view_index_dir = deploy_project_root/couchdb/database
 uri_file = deploy_project_root/couchdb/logs/couch.uri
 os_process_timeout = 1000000
-
-
-
-[httpd]
-port = 5984
-bind_address = 0.0.0.0
+; single node is only for test purposes, otherwise it will work just like CouchDB 1.x
+; for now, define it in the default config such that _users, _replicator and _global_changes databases are automatically created
+single_node=true
 
 [log]
 level = info
 file = deploy_project_root/couchdb/logs/couch.log
 
-[couch_httpd_auth]
-;secret = replace this with a real secret
-
-
-[update_notification]
-;unique notifier name=/full/path/to/exe -with "cmd line arg"
-
-; To create an admin account uncomment the '[admins]' section below and add a
-; line in the format 'username = password'. When you next start CouchDB, it
-; will change the password to a hash (so that your passwords don't linger
-; around in plain-text files). You can add more admin accounts with more
-; 'username = password' lines. Don't forget to restart CouchDB after
-; changing this.
-[admins]
-;admin = mysecretpassword
-
 [ssl]
-;cert_file = deploy_project_root/couchdb/certs/cert.pem
-;key_file = deploy_project_root/couchdb/certs/key.pem
-;cacert_file = deploy_project_root/couchdb/certs/cert.pem
+enable = true
+cert_file = deploy_project_root/couchdb/certs/cert.pem
+key_file = deploy_project_root/couchdb/certs/key.pem
+cacert_file = deploy_project_root/couchdb/certs/cert.pem
 ssl_certificate_max_depth = 10
+verify_ssl_certificates = false
 
 [replicator]
-;cert_file = deploy_project_root/couchdb/certs/cert.pem
-;key_file = deploy_project_root/couchdb/certs/key.pem
-;cacert_file = deploy_project_root/couchdb/certs/cert.pem
+cert_file = deploy_project_root/couchdb/certs/cert.pem
+key_file = deploy_project_root/couchdb/certs/key.pem
+cacert_file = deploy_project_root/couchdb/certs/cert.pem
 ssl_certificate_max_depth = 10
+verify_ssl_certificates = false
 ; checkpoint setup: 10 minutes interval
 use_checkpoints = true
-checkpoint_interval = 600000
+checkpoint_interval = 120000
 ; performance setup (still to be evaluated in the production nodes)
 worker_processes = 4
 http_connections = 10
 worker_batch_size = 2000
-max_replication_retry_count = infinity
 socket_options = [{keepalive, true}, {nodelay, true}]
+; don't give up if replication fails; set timeout to 200secs
+max_replication_retry_count = infinity
+; wait for 300 seconds before timing out (actual timeout is 1/3 of it, since it's used in other parts of the code)
+connection_timeout = 900000
 
 [compactions]
 _default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]
@@ -66,3 +55,7 @@ _default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:0
 check_interval = 3600
 ; ~200 MB
 min_file_size = 209715200
+
+[admins]
+;produser = prodpasswd
+unittestagent = passwd

--- a/tier0/manage
+++ b/tier0/manage
@@ -248,20 +248,22 @@ db_prompt(){
 #
 init_couch_pre(){
     echo "Initialising CouchDB on $COUCH_HOST:$COUCH_PORT..."
+    echo "  With installation directory: $INSTALL_COUCH"
+    echo "  With configuration directory: $CONFIG_COUCH"
     mkdir -p $INSTALL_COUCH/logs
     mkdir -p $INSTALL_COUCH/database
     perl -p -i -e "s{deploy_project_root/couchdb}{$INSTALL_COUCH}" $CONFIG_COUCH/local.ini
     # couch ini file requires IP based hostname
-    perl -p -i -e "s{bind_address = 0.0.0.0}{bind_address = $COUCH_HOST}g" $CONFIG_COUCH/local.ini
-    perl -p -i -e "s{port = 5984}{port = $COUCH_PORT}g" $CONFIG_COUCH/local.ini
-    perl -p -i -e "s{;admin = mysecretpassword}{$COUCH_USER = $COUCH_PASS}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{bind_address = 127.0.0.1}{bind_address = $COUCH_HOST}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{port = 6994}{port = $COUCH_PORT}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{unittestagent = passwd}{$COUCH_USER = $COUCH_PASS}g" $CONFIG_COUCH/local.ini
     if [ "x$COUCH_CERT_FILE" != "x" ] && [ "x$COUCH_KEY_FILE" != "x" ]; then
-	mkdir -p $INSTALL_COUCH/certs
-	perl -p -i -e "s{;cert_file =.*}{cert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
-	perl -p -i -e "s{;key_file =.*}{key_file = $INSTALL_COUCH/certs/key.pem}g" $CONFIG_COUCH/local.ini
-	perl -p -i -e "s{;cacert_file =.*}{cacert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
-	ln -s $COUCH_CERT_FILE $INSTALL_COUCH/certs/cert.pem
-	ln -s $COUCH_KEY_FILE $INSTALL_COUCH/certs/key.pem
+        mkdir -p $INSTALL_COUCH/certs
+        perl -p -i -e "s{;cert_file =.*}{cert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
+        perl -p -i -e "s{;key_file =.*}{key_file = $INSTALL_COUCH/certs/key.pem}g" $CONFIG_COUCH/local.ini
+        perl -p -i -e "s{;cacert_file =.*}{cacert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
+        ln -s $COUCH_CERT_FILE $INSTALL_COUCH/certs/cert.pem
+        ln -s $COUCH_KEY_FILE $INSTALL_COUCH/certs/key.pem
     fi
 }
 
@@ -270,19 +272,8 @@ init_couch_post(){
 }
 
 status_of_couch(){
+    load_secrets_file
     echo "+ Couch Status:"
-    if [ ! -e $INSTALL_COUCH/logs/couchdb.pid ]; then
-        echo "++ Couch process file not found"
-        return
-    fi
-    local COUCH_PID=`cat $INSTALL_COUCH/logs/couchdb.pid`
-    kill -0 $COUCH_PID;
-    local COUCH_STATUS=$?
-    if [ $COUCH_STATUS -eq 0 ]; then
-        echo "++ Couch running with process: $COUCH_PID";
-    else
-        echo "++ Couch process not running"
-    fi
     echo "++" `curl -s $COUCH_HOST:$COUCH_PORT`
 }
 
@@ -296,10 +287,11 @@ start_couch(){
 	echo "CouchDB has not been initialised... running pre initialisation";
 	init_couch_pre;
     fi
-    couchdb -b -a $CONFIG_COUCH/local.ini \
-            -p $INSTALL_COUCH/logs/couchdb.pid \
-            -e $INSTALL_COUCH/logs/stderr.log \
-            -o $INSTALL_COUCH/logs/stdout.log
+    echo -n "Which couchdb: "
+    which couchdb
+    echo "  With installation directory: $INSTALL_COUCH"
+    echo "  With configuration directory: $CONFIG_COUCH"
+    nohup couchdb -couch_ini $CONFIG_COUCH >> $INSTALL_COUCH/logs/couch.log 2>&1 &
     if [ $COUCH_INIT_DONE -eq 0 ]; then
 	echo "CouchDB has not been initialised... running post initialisation"
 	init_couch_post;
@@ -310,8 +302,11 @@ start_couch(){
 # shutdown couch
 #
 stop_couch(){
-    echo "stopping couch...";
-    couchdb  -d  -p $INSTALL_COUCH/logs/couchdb.pid;
+    echo "Stopping CouchDB service..."
+    for couch_pid in $(ps aux | grep couch | grep -v grep | awk '{print $2}'); do
+        echo "  killing CouchDB process... ${pid}"
+        kill -9 $couch_pid
+    done
 }
 
 clean_couch(){

--- a/wmagentpy3/default.ini
+++ b/wmagentpy3/default.ini
@@ -1,0 +1,650 @@
+; Upgrading CouchDB will overwrite this file.
+[vendor]
+name = The Apache Software Foundation
+
+[couchdb]
+uuid = 
+database_dir = ./data
+view_index_dir = ./data
+; util_driver_dir =
+; plugin_dir =
+os_process_timeout = 5000 ; 5 seconds. for view servers.
+max_dbs_open = 500
+; Method used to compress everything that is appended to database and view index files, except
+; for attachments (see the attachments section). Available methods are:
+;
+; none         - no compression
+; snappy       - use google snappy, a very fast compressor/decompressor
+; deflate_N    - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
+;                lowest compression ratio) to 9 (slowest, highest compression ratio)
+file_compression = snappy
+; Higher values may give better read performance due to less read operations
+; and/or more OS page cache hits, but they can also increase overall response
+; time for writes when there are many attachment write requests in parallel.
+attachment_stream_buffer_size = 4096
+; Default security object for databases if not explicitly set
+; everyone - same as couchdb 1.0, everyone can read/write
+; admin_only - only admins can read/write
+; admin_local - sharded dbs on :5984 are read/write for everyone,
+;               local dbs on :5986 are read/write for admins only
+default_security = admin_only
+; btree_chunk_size = 1279
+; maintenance_mode = false
+; stem_interactive_updates = true
+; uri_file =
+; The speed of processing the _changes feed with doc_ids filter can be
+; influenced directly with this setting - increase for faster processing at the
+; expense of more memory usage.
+changes_doc_ids_optimization_threshold = 100
+; Maximum document ID length. Can be set to an integer or 'infinity'.
+;max_document_id_length = infinity
+;
+; Limit maximum document size. Requests to create / update documents with a body
+; size larger than this will fail with a 413 http error. This limit applies to
+; requests which update a single document as well as individual documents from
+; a _bulk_docs request. Since there is no canonical size of json encoded data,
+; due to variabiliy in what is escaped or how floats are encoded, this limit is
+; applied conservatively. For example 1.0e+16 could be encoded as 1e16, so 4 used
+; for size calculation instead of 7.
+max_document_size = 8000000 ; bytes
+;
+; Maximum attachment size.
+; max_attachment_size = infinity
+;
+; Do not update the least recently used DB cache on reads, only writes
+;update_lru_on_read = false
+;
+; The default storage engine to use when creating databases
+; is set as a key into the [couchdb_engines] section.
+default_engine = couch
+;
+; Enable this to only "soft-delete" databases when DELETE /{db} requests are
+; made. This will place a .recovery directory in your data directory and
+; move deleted databases/shards there instead. You can then manually delete
+; these files later, as desired.
+;enable_database_recovery = false
+;
+; Set the maximum size allowed for a partition. This helps users avoid
+; inadvertently abusing partitions resulting in hot shards. The default
+; is 10GiB. A value of 0 or less will disable partition size checks.
+;max_partition_size = 10737418240
+;
+; When true, system databases _users and _replicator are created immediately
+; on startup if not present.
+;single_node = false
+
+; Allow edits on the _security object in the user db. By default, it's disabled.
+users_db_security_editable = false
+
+[purge]
+; Allowed maximum number of documents in one purge request
+;max_document_id_number = 100
+;
+; Allowed maximum number of accumulated revisions in one purge request
+;max_revisions_number = 1000
+;
+; Allowed durations when index is not updated for local purge checkpoint
+; document. Default is 24 hours.
+;index_lag_warn_seconds = 86400
+
+[couchdb_engines]
+; The keys in this section are the filename extension that
+; the specified engine module will use. This is important so
+; that couch_server is able to find an existing database without
+; having to ask every configured engine.
+couch = couch_bt_engine
+
+[process_priority]
+; Selectively disable altering process priorities for modules that request it.
+; * NOTE: couch_server priority has been shown to lead to CouchDB hangs and
+;     failures on Erlang releases 21.0 - 21.3.8.12 and 22.0 -> 22.2.4. Do not
+;     enable when running with those versions.
+;couch_server = false
+
+[cluster]
+q=2
+n=3
+; placement = metro-dc-a:2,metro-dc-b:1
+
+; Supply a comma-delimited list of node names that this node should
+; contact in order to join a cluster. If a seedlist is configured the ``_up``
+; endpoint will return a 404 until the node has successfully contacted at
+; least one of the members of the seedlist and replicated an up-to-date copy
+; of the ``_nodes``, ``_dbs``, and ``_users`` system databases.
+; seedlist = couchdb@node1.example.com,couchdb@node2.example.com
+
+[chttpd]
+; These settings affect the main, clustered port (5984 by default).
+port = 5984
+bind_address = 127.0.0.1
+backlog = 512
+socket_options = [{sndbuf, 262144}, {nodelay, true}]
+server_options = [{recbuf, undefined}]
+require_valid_user = false
+; require_valid_user_except_for_up = false
+; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
+; If Server header is left out, Mochiweb will add its own one in.
+prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;
+; Limit maximum number of databases when tying to get detailed information using
+; _dbs_info in a request
+max_db_number_for_dbs_info_req = 100
+
+; set to true to delay the start of a response until the end has been calculated
+;buffer_response = false
+
+; authentication handlers
+; authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+; uncomment the next line to enable proxy authentication
+; authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+; uncomment the next line to enable JWT authentication
+; authentication_handlers = {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+
+; prevent non-admins from accessing /_all_dbs
+; admin_only_all_dbs = true
+
+;[jwt_auth]
+; List of claims to validate
+; required_claims =
+;
+; [jwt_keys]
+; Configure at least one key here if using the JWT auth handler.
+; If your JWT tokens do not include a "kid" attribute, use "_default"
+; as the config key, otherwise use the kid as the config key.
+; Examples
+; hmac:_default = aGVsbG8=
+; hmac:foo = aGVsbG8=
+; The config values can represent symmetric and asymmetrics keys.
+; For symmetrics keys, the value is base64 encoded;
+; hmac:_default = aGVsbG8= # base64-encoded form of "hello"
+; For asymmetric keys, the value is the PEM encoding of the public
+; key with newlines replaced with the escape sequence \n.
+; rsa:foo = -----BEGIN PUBLIC KEY-----\nMIIBIjAN...IDAQAB\n-----END PUBLIC KEY-----\n
+; ec:bar = -----BEGIN PUBLIC KEY-----\nMHYwEAYHK...AzztRs\n-----END PUBLIC KEY-----\n
+
+[couch_peruser]
+; If enabled, couch_peruser ensures that a private per-user database
+; exists for each document in _users. These databases are writable only
+; by the corresponding user. Databases are in the following form:
+; userdb-{hex encoded username}
+enable = false
+; If set to true and a user is deleted, the respective database gets
+; deleted as well.
+delete_dbs = false
+; Set a default q value for peruser-created databases that is different from
+; cluster / q
+;q = 1
+; prefix for user databases. If you change this after user dbs have been
+; created, the existing databases won't get deleted if the associated user
+; gets deleted because of the then prefix mismatch.
+database_prefix = userdb-
+
+[httpd]
+port = 5986
+bind_address = 127.0.0.1
+authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+secure_rewrites = true
+allow_jsonp = false
+; Options for the MochiWeb HTTP server.
+;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
+; For more socket options, consult Erlang's module 'inet' man page.
+;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
+socket_options = [{sndbuf, 262144}]
+enable_cors = false
+enable_xframe_options = false
+; CouchDB can optionally enforce a maximum uri length;
+; max_uri_length = 8000
+; changes_timeout = 60000
+; config_whitelist = 
+; max_uri_length = 
+; rewrite_limit = 100
+; x_forwarded_host = X-Forwarded-Host
+; x_forwarded_proto = X-Forwarded-Proto
+; x_forwarded_ssl = X-Forwarded-Ssl
+; Maximum allowed http request size. Applies to both clustered and local port.
+max_http_request_size = 4294967296 ; 4GB
+
+; [httpd_design_handlers]
+; _view = 
+
+; [ioq]
+; concurrency = 10
+; ratio = 0.01
+
+[ssl]
+port = 6984
+
+; [chttpd_auth]
+; authentication_db = _users
+
+; [chttpd_auth_cache]
+; max_lifetime = 600000
+; max_objects = 
+; max_size = 104857600
+
+; [mem3]
+; nodes_db = _nodes
+; shard_cache_size = 25000
+; shards_db = _dbs
+; sync_concurrency = 10
+
+; [fabric]
+; all_docs_concurrency = 10
+; changes_duration = 
+; shard_timeout_factor = 2
+; uuid_prefix_len = 7
+; request_timeout = 60000
+; all_docs_timeout = 10000
+; attachments_timeout = 60000
+; view_timeout = 3600000
+; partition_view_timeout = 3600000
+
+; [rexi]
+; buffer_count = 2000
+; server_per_node = true
+; stream_limit = 5
+;
+; Use a single message to kill a group of remote workers This is
+; mostly is an upgrade clause to allow operating in a mixed cluster of
+; 2.x and 3.x nodes. After upgrading switch to true to save some
+; network bandwidth
+;use_kill_all = false
+
+; [global_changes]
+; max_event_delay = 25
+; max_write_delay = 500
+; update_db = true
+
+; [view_updater]
+; min_writer_items = 100
+; min_writer_size = 16777216
+
+[couch_httpd_auth]
+; WARNING! This only affects the node-local port (5986 by default).
+; You probably want the settings under [chttpd].
+authentication_db = _users
+authentication_redirect = /_utils/session.html
+require_valid_user = false
+timeout = 600 ; number of seconds before automatic logout
+auth_cache_size = 50 ; size is number of cache entries
+allow_persistent_cookies = true ; set to false to disallow persistent cookies
+iterations = 10 ; iterations for password hashing
+; min_iterations = 1
+; max_iterations = 1000000000
+; password_scheme = pbkdf2
+; proxy_use_secret = false
+; comma-separated list of public fields, 404 if empty
+; public_fields =
+; secret = 
+; users_db_public = false
+; cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+; same_site =
+
+; CSP (Content Security Policy) Support
+[csp]
+;utils_enable = true
+;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
+;attachments_enable = false
+;attachments_header_value = sandbox
+;showlist_enable = false
+;showlist_header_value = sandbox
+
+[cors]
+credentials = false
+; List of origins separated by a comma, * means accept all
+; Origins must include the scheme: http://example.com
+; You can't set origins: * and credentials = true at the same time.
+;origins = *
+; List of accepted headers separated by a comma
+; headers =
+; List of accepted methods
+; methods =
+
+; Configuration for a vhost
+;[cors:http://example.com]
+; credentials = false
+; List of origins separated by a comma
+; Origins must include the scheme: http://example.com
+; You can't set origins: * and credentials = true at the same time.
+;origins =
+; List of accepted headers separated by a comma
+; headers =
+; List of accepted methods
+; methods =
+
+; Configuration for the design document cache
+;[ddoc_cache]
+; The maximum size of the cache in bytes
+;max_size = 104857600 ; 100MiB
+; The period each cache entry should wait before
+; automatically refreshing in milliseconds
+;refresh_timeout = 67000
+
+[x_frame_options]
+; Settings same-origin will return X-Frame-Options: SAMEORIGIN.
+; If same origin is set, it will ignore the hosts setting
+; same_origin = true
+; Settings hosts will return X-Frame-Options: ALLOW-FROM https://example.com/
+; List of hosts separated by a comma. * means accept all
+; hosts =
+
+[native_query_servers]
+; erlang query server
+; enable_erlang_query_server = false
+
+; Changing reduce_limit to false will disable reduce_limit.
+; If you think you're hitting reduce_limit with a "good" reduce function,
+; please let us know on the mailing list so we can fine tune the heuristic.
+[query_server_config]
+; commit_freq = 5
+reduce_limit = true
+os_process_limit = 100
+; os_process_idle_limit = 300
+; os_process_soft_limit = 100
+; Timeout for how long a response from a busy view group server can take.
+; "infinity" is also a valid configuration value.
+;group_info_timeout = 5000
+;query_limit = 268435456
+;partition_query_limit = 268435456
+
+[mango]
+; Set to true to disable the "index all fields" text index, which can lead
+; to out of memory issues when users have documents with nested array fields.
+;index_all_disabled = false
+; Default limit value for mango _find queries.
+;default_limit = 25
+; Ratio between documents scanned and results matched that will
+; generate a warning in the _find response. Setting this to 0 disables
+; the warning.
+;index_scan_warning_threshold = 10
+
+[indexers]
+couch_mrview = true
+
+[feature_flags]
+; This enables any database to be created as a partitioned databases (except system db's). 
+; Setting this to false will stop the creation of paritioned databases.
+; paritioned||allowed* = true will scope the creation of partitioned databases
+; to databases with 'allowed' prefix.
+partitioned||* = true
+
+[uuids]
+; Known algorithms:
+;   random - 128 bits of random awesome
+;     All awesome, all the time.
+;   sequential - monotonically increasing ids with random increments
+;     First 26 hex characters are random. Last 6 increment in
+;     random amounts until an overflow occurs. On overflow, the
+;     random prefix is regenerated and the process starts over.
+;   utc_random - Time since Jan 1, 1970 UTC with microseconds
+;     First 14 characters are the time in hex. Last 18 are random.
+;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
+;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
+algorithm = sequential
+; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
+; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
+utc_id_suffix =
+# Maximum number of UUIDs retrievable from /_uuids in a single request
+max_count = 1000
+
+[attachments]
+compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+compressible_types = text/*, application/javascript, application/json, application/xml
+
+[replicator]
+; Random jitter applied on replication job startup (milliseconds)
+startup_jitter = 5000
+; Number of actively running replications
+max_jobs = 500
+;Scheduling interval in milliseconds. During each reschedule cycle
+interval = 60000
+; Maximum number of replications to start and stop during rescheduling.
+max_churn = 20
+; More worker processes can give higher network throughput but can also
+; imply more disk and network IO.
+worker_processes = 4
+; With lower batch sizes checkpoints are done more frequently. Lower batch sizes
+; also reduce the total amount of used RAM memory.
+worker_batch_size = 500
+; Maximum number of HTTP connections per replication.
+http_connections = 20
+; HTTP connection timeout per replication.
+; Even for very fast/reliable networks it might need to be increased if a remote
+; database is too busy.
+connection_timeout = 30000
+; Request timeout
+;request_timeout = infinity
+; If a request fails, the replicator will retry it up to N times.
+retries_per_request = 5
+; Use checkpoints
+;use_checkpoints = true
+; Checkpoint interval
+;checkpoint_interval = 30000
+; Some socket options that might boost performance in some scenarios:
+;       {nodelay, boolean()}
+;       {sndbuf, integer()}
+;       {recbuf, integer()}
+;       {priority, integer()}
+; See the `inet` Erlang module's man page for the full list of options.
+socket_options = [{keepalive, true}, {nodelay, false}]
+; Path to a file containing the user's certificate.
+;cert_file = /full/path/to/server_cert.pem
+; Path to file containing user's private PEM encoded key.
+;key_file = /full/path/to/server_key.pem
+; String containing the user's password. Only used if the private keyfile is password protected.
+;password = somepassword
+; Set to true to validate peer certificates.
+verify_ssl_certificates = false
+; File containing a list of peer trusted certificates (in the PEM format).
+;ssl_trusted_certificates_file = /etc/ssl/certs/ca-certificates.crt
+; Maximum peer certificate depth (must be set even if certificate validation is off).
+ssl_certificate_max_depth = 3
+; Maximum document ID length for replication.
+;max_document_id_length = infinity
+; How much time to wait before retrying after a missing doc exception. This
+; exception happens if the document was seen in the changes feed, but internal
+; replication hasn't caught up yet, and fetching document's revisions
+; fails. This a common scenario when source is updated while continous
+; replication is running. The retry period would depend on how quickly internal
+; replication is expected to catch up. In general this is an optimisation to
+; avoid crashing the whole replication job, which would consume more resources
+; and add log noise.
+;missing_doc_retry_msec = 2000
+; Wait this many seconds after startup before attaching changes listeners
+; cluster_start_period = 5
+; Re-check cluster state at least every cluster_quiet_period seconds
+; cluster_quiet_period = 60
+
+; List of replicator client authentication plugins to try. Plugins will be
+; tried in order. The first to initialize successfully will be used for that
+; particular endpoint (source or target). Normally couch_replicator_auth_noop
+; would be used at the end of the list as a "catch-all". It doesn't do anything
+; and effectively implements the previous behavior of using basic auth.
+; There are currently two plugins available:
+;   couch_replicator_auth_session - use _session cookie authentication
+;   couch_replicator_auth_noop - use basic authentication (previous default)
+; Currently, the new _session cookie authentication is tried first, before
+; falling back to the old basic authenticaion default:
+;auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
+; To restore the old behaviour, use the following value:
+;auth_plugins = couch_replicator_auth_noop
+
+; Force couch_replicator_auth_session plugin to refresh the session
+; periodically if max-age is not present in the cookie. This is mostly to
+; handle the case where anonymous writes are allowed to the database and a VDU
+; function is used to forbid writes based on the authenticated user name. In
+; that case this value should be adjusted based on the expected minimum session
+; expiry timeout on replication endpoints. If session expiry results in a 401
+; or 403 response this setting is not needed.
+;session_refresh_interval_sec = 550
+
+[log]
+; Possible log levels:
+;  debug
+;  info
+;  notice
+;  warning, warn
+;  error, err
+;  critical, crit
+;  alert
+;  emergency, emerg
+;  none
+;
+level = info
+;
+; Set the maximum log message length in bytes that will be
+; passed through the writer
+;
+; max_message_size = 16000
+;
+;
+; There are four different log writers that can be configured
+; to write log messages. The default writes to stderr of the
+; Erlang VM which is useful for debugging/development as well
+; as a lot of container deployments.
+;
+; There's also a file writer that works with logrotate, a
+; rsyslog writer for deployments that need to have logs sent
+; over the network, and a journald writer that's more suitable
+; when using systemd journald.
+;
+writer = stderr
+; Journald Writer notes:
+;
+; The journald writer doesn't have any options. It still writes
+; the logs to stderr, but without the timestamp prepended, since
+; the journal will add it automatically, and with the log level
+; formated as per
+; https://www.freedesktop.org/software/systemd/man/sd-daemon.html
+;
+;
+; File Writer Options:
+;
+; The file writer will check every 30s to see if it needs
+; to reopen its file. This is useful for people that configure
+; logrotate to move log files periodically.
+;
+; file = ./couch.log ; Path name to write logs to
+;
+; Write operations will happen either every write_buffer bytes
+; or write_delay milliseconds. These are passed directly to the
+; Erlang file module with the write_delay option documented here:
+;
+;     http://erlang.org/doc/man/file.html
+;
+; write_buffer = 0
+; write_delay = 0
+;
+;
+; Syslog Writer Options:
+;
+; The syslog writer options all correspond to their obvious
+; counter parts in rsyslog nomenclature.
+;
+; syslog_host =
+; syslog_port = 514
+; syslog_appid = couchdb
+; syslog_facility = local2
+
+[stats]
+; Stats collection interval in seconds. Default 10 seconds.
+;interval = 10
+
+[smoosh]
+;
+; More documentation on these is in the Automatic Compaction
+; section of the documentation.
+;
+;db_channels = upgrade_dbs,ratio_dbs,slack_dbs
+;view_channels = upgrade_views,ratio_views,slack_views
+;
+;[smoosh.ratio_dbs]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.ratio_views]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.slack_dbs]
+;priority = slack
+;min_priority = 16777216
+;
+;[smoosh.slack_views]
+;priority = slack
+;min_priority = 16777216
+
+[ioq]
+; The maximum number of concurrent in-flight IO requests that
+concurrency = 10
+
+; The fraction of the time that a background IO request will be selected
+; over an interactive IO request when both queues are non-empty
+ratio = 0.01
+
+[ioq.bypass]
+; System administrators can choose to submit specific classes of IO directly
+; to the underlying file descriptor or OS process, bypassing the queues
+; altogether. Installing a bypass can yield higher throughput and lower
+; latency, but relinquishes some control over prioritization. The following
+; classes are recognized with the following defaults:
+
+; Messages on their way to an external process (e.g., couchjs) are bypassed
+os_process = true
+
+; Disk IO fulfilling interactive read requests is bypassed
+read = true
+
+; Disk IO required to update a database is bypassed
+write = true
+
+; Disk IO required to update views and other secondary indexes is bypassed
+view_update = true
+
+; Disk IO issued by the background replication processes that fix any
+; inconsistencies between shard copies is queued
+shard_sync = false
+
+; Disk IO issued by compaction jobs is queued
+compaction = false
+
+[dreyfus]
+; The name and location of the Clouseau Java service required to
+; enable Search functionality.
+; name = clouseau@127.0.0.1
+
+; CouchDB will try to re-connect to Clouseau using a bounded
+; exponential backoff with the following number of iterations.
+; retry_limit = 5
+
+; The default number of results returned from a global search query.
+; limit = 25
+
+; The default number of results returned from a search on a partition
+; of a database.
+; limit_partitions = 2000
+ 
+; The maximum number of results that can be returned from a global
+; search query (or any search query on a database without user-defined
+; partitions). Attempts to set ?limit=N higher than this value will
+; be rejected.
+; max_limit = 200
+
+; The maximum number of results that can be returned when searching
+; a partition of a database. Attempts to set ?limit=N higher than this
+; value will be rejected. If this config setting is not defined,
+; CouchDB will use the value of `max_limit` instead. If neither is
+; defined, the default is 2000 as stated here.
+; max_limit_partitions = 2000
+
+[reshard]
+;max_jobs = 48
+;max_history = 20
+;max_retries = 1
+;retry_interval_sec = 10
+;delete_source = true
+;update_shard_map_timeout_sec = 60
+;source_close_timeout_sec = 600
+;require_node_param = false
+;require_range_param = false

--- a/wmagentpy3/deploy
+++ b/wmagentpy3/deploy
@@ -26,8 +26,10 @@ deploy_wmagentpy3_sw()
   mkdir -p $root/$cfgversion/config/rucio/etc
 
   local couchdb_ini=$root/$cfgversion/config/wmagentpy3/local.ini
-  perl -p -i -e "s{deploy_project_root}{$root/$cfgversion/install}g" $couchdb_ini
-  cp -f $couchdb_ini $root/$cfgversion/config/couchdb/
+  local couchdb_configs=$root/$cfgversion/config/wmagentpy3
+  sed -i "s+deploy_project_root+$root/$cfgversion/install+" $couchdb_configs/local.ini
+  cp -f $couchdb_configs/local.ini $root/$cfgversion/config/couchdb/
+  cp -f $couchdb_configs/default.ini $root/$cfgversion/config/couchdb/
 
   local mysql_config=$root/$cfgversion/config/wmagentpy3/my.cnf
   cp -f $mysql_config $root/$cfgversion/config/mysql/

--- a/wmagentpy3/local.ini
+++ b/wmagentpy3/local.ini
@@ -1,8 +1,10 @@
-; CouchDB Configuration Settings
+; WMAgent CouchDB configuration settings
 
-; Custom settings should be made in this file. They will override settings
-; in default.ini, but unlike changes made to default.ini, this file won't be
-; overwritten on server upgrade.
+[chttpd]
+port = 6994
+bind_address = 127.0.0.1
+; Maximum period in milliseconds to wait for a change before the response is sent
+changes_timeout = 300000
 
 [couchdb]
 ;max_document_size = 4294967296 ; bytes
@@ -10,53 +12,40 @@ database_dir = deploy_project_root/couchdb/database
 view_index_dir = deploy_project_root/couchdb/database
 uri_file = deploy_project_root/couchdb/logs/couch.uri
 os_process_timeout = 1000000
-
-
-
-[httpd]
-port = 5984
-bind_address = 0.0.0.0
+; single node is only for test purposes, otherwise it will work just like CouchDB 1.x
+; for now, define it in the default config such that _users, _replicator and _global_changes databases are automatically created
+single_node=true
 
 [log]
 level = info
 file = deploy_project_root/couchdb/logs/couch.log
 
-[couch_httpd_auth]
-;secret = replace this with a real secret
-
-
-[update_notification]
-;unique notifier name=/full/path/to/exe -with "cmd line arg"
-
-; To create an admin account uncomment the '[admins]' section below and add a
-; line in the format 'username = password'. When you next start CouchDB, it
-; will change the password to a hash (so that your passwords don't linger
-; around in plain-text files). You can add more admin accounts with more
-; 'username = password' lines. Don't forget to restart CouchDB after
-; changing this.
-[admins]
-;admin = mysecretpassword
-
 [ssl]
-;cert_file = deploy_project_root/couchdb/certs/cert.pem
-;key_file = deploy_project_root/couchdb/certs/key.pem
-;cacert_file = deploy_project_root/couchdb/certs/cert.pem
+enable = true
+cert_file = deploy_project_root/couchdb/certs/cert.pem
+key_file = deploy_project_root/couchdb/certs/key.pem
+cacert_file = deploy_project_root/couchdb/certs/cert.pem
 ssl_certificate_max_depth = 10
+verify_ssl_certificates = false
 
 [replicator]
-;cert_file = deploy_project_root/couchdb/certs/cert.pem
-;key_file = deploy_project_root/couchdb/certs/key.pem
-;cacert_file = deploy_project_root/couchdb/certs/cert.pem
+cert_file = deploy_project_root/couchdb/certs/cert.pem
+key_file = deploy_project_root/couchdb/certs/key.pem
+cacert_file = deploy_project_root/couchdb/certs/cert.pem
 ssl_certificate_max_depth = 10
+verify_ssl_certificates = false
 ; checkpoint setup: 10 minutes interval
 use_checkpoints = true
-checkpoint_interval = 600000
+checkpoint_interval = 120000
 ; performance setup (still to be evaluated in the production nodes)
 worker_processes = 4
 http_connections = 10
 worker_batch_size = 2000
-max_replication_retry_count = infinity
 socket_options = [{keepalive, true}, {nodelay, true}]
+; don't give up if replication fails; set timeout to 200secs
+max_replication_retry_count = infinity
+; wait for 300 seconds before timing out (actual timeout is 1/3 of it, since it's used in other parts of the code)
+connection_timeout = 900000
 
 [compactions]
 _default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]
@@ -66,3 +55,7 @@ _default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:0
 check_interval = 3600
 ; ~200 MB
 min_file_size = 209715200
+
+[admins]
+;produser = prodpasswd
+unittestagent = passwd

--- a/wmagentpy3/manage
+++ b/wmagentpy3/manage
@@ -444,20 +444,22 @@ db_prompt(){
 #
 init_couch_pre(){
     echo "Initialising CouchDB on $COUCH_HOST:$COUCH_PORT..."
+    echo "  With installation directory: $INSTALL_COUCH"
+    echo "  With configuration directory: $CONFIG_COUCH"
     mkdir -p $INSTALL_COUCH/logs
     mkdir -p $INSTALL_COUCH/database
     perl -p -i -e "s{deploy_project_root/couchdb}{$INSTALL_COUCH}" $CONFIG_COUCH/local.ini
     # couch ini file requires IP based hostname
-    perl -p -i -e "s{bind_address = 0.0.0.0}{bind_address = $COUCH_HOST}g" $CONFIG_COUCH/local.ini
-    perl -p -i -e "s{port = 5984}{port = $COUCH_PORT}g" $CONFIG_COUCH/local.ini
-    perl -p -i -e "s{;admin = mysecretpassword}{$COUCH_USER = $COUCH_PASS}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{bind_address = 127.0.0.1}{bind_address = $COUCH_HOST}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{port = 6994}{port = $COUCH_PORT}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{unittestagent = passwd}{$COUCH_USER = $COUCH_PASS}g" $CONFIG_COUCH/local.ini
     if [ "x$COUCH_CERT_FILE" != "x" ] && [ "x$COUCH_KEY_FILE" != "x" ]; then
-	mkdir -p $INSTALL_COUCH/certs
-	perl -p -i -e "s{;cert_file =.*}{cert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
-	perl -p -i -e "s{;key_file =.*}{key_file = $INSTALL_COUCH/certs/key.pem}g" $CONFIG_COUCH/local.ini
-	perl -p -i -e "s{;cacert_file =.*}{cacert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
-	ln -s $COUCH_CERT_FILE $INSTALL_COUCH/certs/cert.pem
-	ln -s $COUCH_KEY_FILE $INSTALL_COUCH/certs/key.pem
+        mkdir -p $INSTALL_COUCH/certs
+        perl -p -i -e "s{;cert_file =.*}{cert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
+        perl -p -i -e "s{;key_file =.*}{key_file = $INSTALL_COUCH/certs/key.pem}g" $CONFIG_COUCH/local.ini
+        perl -p -i -e "s{;cacert_file =.*}{cacert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
+        ln -s $COUCH_CERT_FILE $INSTALL_COUCH/certs/cert.pem
+        ln -s $COUCH_KEY_FILE $INSTALL_COUCH/certs/key.pem
     fi
 }
 
@@ -466,19 +468,8 @@ init_couch_post(){
 }
 
 status_of_couch(){
+    load_secrets_file;
     echo "+ Couch Status:"
-    if [ ! -e $INSTALL_COUCH/logs/couchdb.pid ]; then
-        echo "++ Couch process file not found"
-        return
-    fi
-    local COUCH_PID=`cat $INSTALL_COUCH/logs/couchdb.pid`
-    kill -0 $COUCH_PID;
-    local COUCH_STATUS=$?
-    if [ $COUCH_STATUS -eq 0 ]; then
-        echo "++ Couch running with process: $COUCH_PID";
-    else
-        echo "++ Couch process not running"
-    fi
     echo "++" `curl -s $COUCH_HOST:$COUCH_PORT`
 }
 
@@ -492,10 +483,11 @@ start_couch(){
 	echo "CouchDB has not been initialised... running pre initialisation";
 	init_couch_pre;
     fi
-    couchdb -b -a $CONFIG_COUCH/local.ini \
-            -p $INSTALL_COUCH/logs/couchdb.pid \
-            -e $INSTALL_COUCH/logs/stderr.log \
-            -o /dev/null
+    echo -n "Which couchdb: "
+    which couchdb
+    echo "  With installation directory: $INSTALL_COUCH"
+    echo "  With configuration directory: $CONFIG_COUCH"
+    nohup couchdb -couch_ini $CONFIG_COUCH >> $INSTALL_COUCH/logs/couch.log 2>&1 &
     if [ $COUCH_INIT_DONE -eq 0 ]; then
 	echo "CouchDB has not been initialised... running post initialisation"
 	init_couch_post;
@@ -506,8 +498,11 @@ start_couch(){
 # shutdown couch
 #
 stop_couch(){
-    echo "stopping couch...";
-    couchdb  -d  -p $INSTALL_COUCH/logs/couchdb.pid;
+    echo "Stopping CouchDB service..."
+    for couch_pid in $(ps aux | grep couch | grep -v grep | awk '{print $2}'); do
+        echo "  killing CouchDB process... ${pid}"
+        kill -9 $couch_pid
+    done
 }
 
 clean_couch(){


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10829

Let me try to document all the changes and why they have been made:
* `couchdb/default.ini`, `wmagentpy3/default.ini` and `tier0/default.ini` configuration file is required to start up CouchDB. This is a blind copy of what is provided by CouchDB itself.
* `local.ini` configuration file contains our specific CouchDB configuration, overriding whatever is in the `default.ini`
  * `chttpd/authentication_handlers` define the Proxy Authentication mechanism
  * `couchdb/single_node` defined to true to get the admin users automatically created during deployment, in addition to some system-like databases
* `manage` script required a few changes, like:
  * database/management calls need to be made with user/pass, even if it's all localhost!
  * `couchdb -p`, `couchdb -a`, `couchdb -o`, `couchdb -e` and `couchdb -b` no longer exist, removed!
  * `couchdb -A` has been replaced by `couchdb -couch_ini`
  * adapted the `start` and `stop` code
  * CouchDB `status` now uses the `_up` unathenticated endpoint
  * pushing couchapps follow exactly the same logic, only difference is that it uses for loop now
* `couchdb/monitoring.ini` needs to use user/pass (set up during couchdb deployment)
*  `wmagentpy3/deploy` position CouchDB config files under the `couchdb` configuration directory
* `wmagentpy3/local.ini` defines 2 accounts, the admin one and unittest users. The unittest user will be disabled when CouchDB gets deployed in production. These accounts are automatically created during start up.
* `wmagentpy3/manage` is a mess and it makes our CI jenkins hard to deal with. 
* for central CouchDB deployment and `manage` script operations, read credentials from `couch_creds` file.
* define `max_replication_retry_count` to infinity for WMAgent/Tier0 backend
* define replication `connection_timeout` to 300 secs (I've seen timeouts in testbed replications!)

In addition to that, it also includes:
* changes to `reqmgr2ms/manage` such that MSOutput and MSUnmerged do not get started in our VMs (MongoDB setup is broken).

TODO: Imran, we need to define a file for the Couch credentials under /data/auth/couchdb. We can discuss this over Mattermost.