### PR TITLE
Default CouchDB deployment to couchdb16 package

### DIFF
--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -19,7 +19,7 @@ deploy_couchdb_sw()
 
   case $variant in
     default )
-      deploy_pkg -l couchdb -a couchdb/hmackey.ini comp external+couchdb15
+      deploy_pkg -l couchdb -a couchdb/hmackey.ini comp external+couchdb16
       $authlink || setgroup ug+rx,o-rwx _config $project_auth/hmackey.ini
       ;;
     * )


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10655

When we deploy the `couchdb` package in CMSWEB, the deploy script was actually deploying the `couchdb15` package, which brings in python2 dependencies such as `couchapp`.
This PR changes that to the `couchdb16` package, thus bringing in the python3 version of the `couchapp` library.