### PR TITLE
Run CouchDB compaction_daemon for T0 WMAgent

### DIFF
--- a/tier0/local.ini
+++ b/tier0/local.ini
@@ -57,3 +57,12 @@ http_connections = 10
 worker_batch_size = 2000
 max_replication_retry_count = infinity
 socket_options = [{keepalive, true}, {nodelay, true}]
+
+[compactions]
+_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]
+
+[compaction_daemon]
+; check for databases and views every hour
+check_interval = 3600
+; ~200 MB
+min_file_size = 209715200


### PR DESCRIPTION
This PR enables the CouchDB `compaction_daemon` for T0 WMAgent, and also provides some reasonable default thresholds for database and view compaction. This is aligned with the same setup we have for WMAgents and it's been working greatly.

@germanfgv German, could you please change the T0 CouchDB configuration, stop components + couch, start couch + components? At 20:00, it should trigger an automatic compaction of the tier0_request_local db.