### PR TITLE
Skip RAL_Disk and Caltech_Ceph in MSUnmerged

### DIFF
--- a/reqmgr2ms/config-unmerged.py
+++ b/reqmgr2ms/config-unmerged.py
@@ -89,7 +89,7 @@ data.rucioAuthUrl = RUCIO_AUTH_URL
 data.rucioUrl = RUCIO_URL
 data.enableRealMode = False
 data.rseExpr = RSEEXPR
-data.skipRSEs = ['T2_CH_CERN', 'T1_US_FNAL_Disk']
+data.skipRSEs = ['T1_UK_RAL_Disk', 'T2_US_Caltech_Ceph']
 data.dumpRse = False
 data.gfalLogLevel = 'warning'
 # possible values are:


### PR DESCRIPTION
It's meant to fix https://github.com/dmwm/WMCore/issues/10878 (but real fix is provided in https://gitlab.cern.ch/cmsweb-k8s/services_config/-/merge_requests/113)

This PR is only to keep these configuration changes all in sync.