### PR TITLE
Define RelVal Rucio account for WorkQueue and Microservices

### DIFF
--- a/reqmgr2ms/config-ruleCleaner.py
+++ b/reqmgr2ms/config-ruleCleaner.py
@@ -3,9 +3,10 @@ MicroService RuleCleaner configuration file.
 """
 
 import socket
-import time
 import sys
+import time
 from os import path
+
 from WMCore.Configuration import Configuration
 
 # globals
@@ -23,19 +24,17 @@ sys.path.append(path.join(ROOTDIR, 'auth/reqmgr2ms'))
 from ReqMgr2MSSecrets import USER_AMQ, PASS_AMQ, AMQ_TOPIC
 
 if BASE_URL == "https://cmsweb.cern.ch":
-    RUCIO_AUTH_URL="https://cms-rucio-auth.cern.ch"
-    RUCIO_URL="http://cms-rucio.cern.ch"
-    RUCIO_WMA_ACCT="wma_prod"
+    RUCIO_AUTH_URL = "https://cms-rucio-auth.cern.ch"
+    RUCIO_URL = "http://cms-rucio.cern.ch"
+    RUCIO_WMA_ACCT = "wma_prod"
     ARCH_DELAY_HOURS = 24 * 2
 else:
-    RUCIO_AUTH_URL="https://cms-rucio-auth-int.cern.ch"
-    RUCIO_URL="http://cms-rucio-int.cern.ch"
-    RUCIO_WMA_ACCT="wma_test"
+    RUCIO_AUTH_URL = "https://cms-rucio-auth-int.cern.ch"
+    RUCIO_URL = "http://cms-rucio-int.cern.ch"
+    RUCIO_WMA_ACCT = "wma_test"
     ARCH_DELAY_HOURS = 6
-
-RUCIO_ACCT = RUCIO_WMA_ACCT
 RUCIO_MSTR_ACCT = "wmcore_transferor"
-
+RUCIO_MSTR_RELVAL_ACCT = "wmcore_transferor_relval"
 
 config = Configuration()
 
@@ -44,11 +43,11 @@ srv = main.section_("server")
 srv.thread_pool = 30
 main.application = "ms-rulecleaner"
 main.port = 8244  # main application port it listens on
-main.index = 'ui' # Configuration requires index attribute
+main.index = 'ui'  # Configuration requires index attribute
 
 # Security configuration
 main.authz_defaults = {"role": None, "group": None, "site": None}
-#set default logging (prevent duplicate)
+# set default logging (prevent duplicate)
 main.log_screen = True
 
 sec = main.section_("tools").section_("cms_auth")
@@ -85,9 +84,10 @@ data.limitRequestsPerCycle = 500
 data.verbose = True
 data.interval = 60 * 60 * 8  # run it every 8 hours
 data.services = ['ruleCleaner']
-data.rucioAccount = RUCIO_ACCT
-data.rucioMstrAccount = RUCIO_MSTR_ACCT
+data.rucioAccount = RUCIO_WMA_ACCT
 data.rucioWmaAccount = RUCIO_WMA_ACCT
+data.rucioMstrAccount = RUCIO_MSTR_ACCT
+data.rucioMstrRelValAccount = RUCIO_MSTR_RELVAL_ACCT
 data.rucioAuthUrl = RUCIO_AUTH_URL
 data.rucioUrl = RUCIO_URL
 data.enableRealMode = True
@@ -103,7 +103,9 @@ heartbeatMonitor.object = "WMCore.MicroService.CherryPyThreads.HeartbeatMonitor.
 heartbeatMonitor.wmstats_url = "%s/%s" % (data.couch_host, data.couch_wmstats_db)
 heartbeatMonitor.wmstatsSvc_url = "%s/wmstatsserver" % BASE_URL
 heartbeatMonitor.heartbeatCheckDuration = 60 * 10  # every 10 min
-heartbeatMonitor.log_file = '%s/logs/reqmgr2ms/heartbeatMonitor_rulecleaner-%s-%s.log' % (__file__.rsplit('/', 4)[0], HOST.split('.', 1)[0], time.strftime("%Y%m%d"))
+heartbeatMonitor.log_file = '%s/logs/reqmgr2ms/heartbeatMonitor_rulecleaner-%s-%s.log' % (__file__.rsplit('/', 4)[0],
+                                                                                          HOST.split('.', 1)[0],
+                                                                                          time.strftime("%Y%m%d"))
 heartbeatMonitor.central_logdb_url = LOG_DB_URL
 heartbeatMonitor.log_reporter = LOG_REPORTER
 # AMQ MonIT settings
@@ -112,5 +114,5 @@ heartbeatMonitor.user_amq = USER_AMQ
 heartbeatMonitor.pass_amq = PASS_AMQ
 heartbeatMonitor.topic_amq = AMQ_TOPIC
 heartbeatMonitor.host_port_amq = AMQ_HOST_PORT
-#list all the thread need to be monitored
+# list all the thread need to be monitored
 heartbeatMonitor.thread_list = [a.object.split('.')[-1] for a in config.section_("extensions")]

--- a/reqmgr2ms/config-transferor.py
+++ b/reqmgr2ms/config-transferor.py
@@ -25,6 +25,9 @@ else:
     RULE_LIFETIME=24 * 60 * 60  # 24h
     RUCIO_AUTH_URL="https://cms-rucio-auth-int.cern.ch"
     RUCIO_URL="http://cms-rucio-int.cern.ch"
+RUCIO_PROD_ACCT = "wmcore_transferor"
+RUCIO_RELVAL_ACCT = "wmcore_transferor_relval"
+
 
 # load AMQ credentials
 sys.path.append(path.join(ROOTDIR, 'auth/reqmgr2ms'))
@@ -79,7 +82,8 @@ data.quotaUsage = 0.9
 data.minimumThreshold = 1 * (1000 ** 4)  # 1 TB (terabyte)
 data.rulesLifetime = RULE_LIFETIME
 data.rucioRuleWeight = "ddm_quota"
-data.rucioAccount = "wmcore_transferor"
+data.rucioAccount = RUCIO_PROD_ACCT
+data.rucioAccountRelVal = RUCIO_RELVAL_ACCT
 data.rucioAuthUrl = RUCIO_AUTH_URL
 data.rucioUrl = RUCIO_URL
 data.toAddr = ["alan.malta@cern.ch", "todor.trendafilov.ivanov@cern.ch", "kenyi.paolo.hurtado.anampa@cern.ch", "h.ozturk@cern.ch"]

--- a/workqueue/config.py
+++ b/workqueue/config.py
@@ -42,7 +42,6 @@ except ImportError:
     PASS_AMQ=None
     AMQ_TOPIC=None
 
-RUCIO_ACCT = "wmcore_transferor"
 # Production service has to point to production Rucio, anything else will use pre-production
 if BASE_URL == "https://cmsweb.cern.ch":
     RUCIO_AUTH_URL="https://cms-rucio-auth.cern.ch"
@@ -50,6 +49,8 @@ if BASE_URL == "https://cmsweb.cern.ch":
 else:
     RUCIO_AUTH_URL="https://cms-rucio-auth-int.cern.ch"
     RUCIO_URL="http://cms-rucio-int.cern.ch"
+RUCIO_ACCT = "wmcore_transferor"
+RUCIO_RELVAL_ACCT = "wmcore_transferor_relval"
 
 config = Configuration()
 
@@ -97,6 +98,7 @@ def setWorkQueueCommonConfig(config):
     config.queueParams['central_logdb_url'] = LOG_DB_URL
     config.queueParams['log_reporter'] = LOG_REPORTER
     config.queueParams['rucioAccount'] = RUCIO_ACCT
+    config.queueParams['rucioAccountRelVal'] = RUCIO_RELVAL_ACCT
     config.queueParams['rucioAuthUrl'] = RUCIO_AUTH_URL
     config.queueParams['rucioUrl'] = RUCIO_URL
 


### PR DESCRIPTION
We are going to adopt a new Rucio account for Release Validation input data placement, requiring the following changes provided in this PR:
* MSTransferor: definition of a new Rucio account for the RelVal input data business
* WorkQueue: definition of a new Rucio account for global and local data location
* MSRuleCleaner: definition of a new Rucio account for cleanup of no longer needed input data placement rules (for RelVals).