### PR TITLE
Add dqm-square-k8 redirection rules to cmsweb frontend

### DIFF
--- a/frontend/app_dqm_nossl.conf
+++ b/frontend/app_dqm_nossl.conf
@@ -7,6 +7,7 @@ RewriteRule ^(/dqm/online-playback-new(/.*)?)$ https://%{SERVER_NAME}${escape:$1
 RewriteRule ^(/dqm/online-test-new(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/hcal-online(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/dqm-square-origin(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 
 # Redirect rules for offline DQM, back to the https interface.
 

--- a/frontend/app_dqm_nossl.conf
+++ b/frontend/app_dqm_nossl.conf
@@ -8,6 +8,7 @@ RewriteRule ^(/dqm/online-test-new(/.*)?)$     https://%{SERVER_NAME}${escape:$1
 RewriteRule ^(/dqm/hcal-online(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square-origin(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/dqm-square-k8(/.*)?)$             https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 
 # Redirect rules for offline DQM, back to the https interface.
 

--- a/frontend/app_dqm_ssl.conf
+++ b/frontend/app_dqm_ssl.conf
@@ -1,5 +1,5 @@
 RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie;limited-proxy;cert;host]
-RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square|dqm-square-origin)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/autodqm(/.*)?)$ http://%{ENV:BACKEND}:8083${escape:$1} [QSA,P,L,NE]
 

--- a/frontend/app_dqm_ssl.conf
+++ b/frontend/app_dqm_ssl.conf
@@ -2,6 +2,8 @@ RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie
 RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square|dqm-square-origin)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/autodqm(/.*)?)$ http://%{ENV:BACKEND}:8083${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/dqm-square-k8(/.*)?)$ http://%{ENV:BACKEND}:8084${escape:$1} [QSA,P,L,NE]
+
 
 RewriteRule ^/auth/complete(/dqm/(relval-test-new)(/.*)?$)$ http://%{ENV:BACKEND}:8888${escape:$3} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/(offline-new|offline-test-new|relval-new)(/.*)?$)$ http://%{ENV:BACKEND}:8889${escape:$3} [QSA,P,L,NE]

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -8,7 +8,7 @@
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/(?:relval|relval-new)(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/autodqm(?:/|$) autodqm.dqm.svc.cluster.local
-^/auth/complete/dqm/dqm-square-k8(?:/|$) dqm-square.dqm.svc.cluster.local
+^/auth/complete/dqm/dqm-square-k8(?:/|$) dqm-square-k8.dqm.svc.cluster.local
 ^/auth/complete/(?:couchdb/wmdatamining|wmdatamining)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/reqmgr_workload_cache|reqmgr_workload_cache)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/reqmgr_config_cache|reqmgr_config_cache)(?:/|$) vocms0132.cern.ch :affinity

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -8,6 +8,7 @@
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch
 ^/auth/complete/dqm/(?:relval|relval-new)(?:/|$) vocms0739.cern.ch
 ^/auth/complete/dqm/autodqm(?:/|$) autodqm.dqm.svc.cluster.local
+^/auth/complete/dqm/dqm-square-k8(?:/|$) dqm-square.dqm.svc.cluster.local
 ^/auth/complete/(?:couchdb/wmdatamining|wmdatamining)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/reqmgr_workload_cache|reqmgr_workload_cache)(?:/|$) vocms0132.cern.ch :affinity
 ^/auth/complete/(?:couchdb/reqmgr_config_cache|reqmgr_config_cache)(?:/|$) vocms0132.cern.ch :affinity

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -2,7 +2,7 @@
 ^/auth/complete/reqmgr2(?:/|$) reqmgr2.dmwm.svc.cluster.local
 ^/auth/complete/phedex(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch

--- a/frontend/backends-k8s-prod.txt
+++ b/frontend/backends-k8s-prod.txt
@@ -1,6 +1,6 @@
 ^/auth/complete/phedex(?:/|$) vocms0136.cern.ch|vocms0161.cern.ch|vocms0163.cern.ch|vocms0165.cern.ch|vocms0766.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0136.cern.ch|vocms0161.cern.ch|vocms0163.cern.ch|vocms0165.cern.ch|vocms0766.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch


### PR DESCRIPTION
Add redirection rules to cmsweb frontend to make dqm-square-k8 server pod at cmsweb kubernet cluster visible in the internet.