### PR TITLE
Enable GEM DCS bits in DQM GUI plot

### DIFF
--- a/dqmgui/style/DQMInfoRenderPlugin.cc
+++ b/dqmgui/style/DQMInfoRenderPlugin.cc
@@ -562,8 +562,8 @@ const std::vector<std::string> DQMInfoRenderPlugin::summaryMapOrder_({
   "<thin_line>",
   "RPC",
   "<thin_line>",
-  "GEM-",
-  "GEM+",
+  "GEMp",
+  "GEMm",
   "<thin_line>",
   "CT-PPS", // Simply not implemented yet
             // Will need to be implemented with this label in the CMSSW

--- a/dqmgui/style/DQMInfoRenderPlugin.cc
+++ b/dqmgui/style/DQMInfoRenderPlugin.cc
@@ -562,8 +562,8 @@ const std::vector<std::string> DQMInfoRenderPlugin::summaryMapOrder_({
   "<thin_line>",
   "RPC",
   "<thin_line>",
-  "GEMp",
   "GEMm",
+  "GEMp",
   "<thin_line>",
   "CT-PPS", // Simply not implemented yet
             // Will need to be implemented with this label in the CMSSW


### PR DESCRIPTION
Labels in the vector used for filtering:
const std::vector<std::string> DQMInfoRenderPlugin::summaryMapOrder_
need to be in line with labels in the definition of hist:
https://github.com/cms-sw/cmssw/blob/db63563e447104cef63ed4661c230c4ad1049930/DQMServices/Components/plugins/DQMProvInfo.cc#L177-L178

FYI @quark2 