### PR TITLE
Define MongoDB target for VMs

### DIFF
--- a/reqmgr2ms/config-unmerged.py
+++ b/reqmgr2ms/config-unmerged.py
@@ -77,6 +77,9 @@ data.couch_wmstats_db = "wmstats"
 data.manager = 'WMCore.MicroService.MSManager.MSManager'
 data.reqmgr2Url = "%s/reqmgr2" % BASE_URL
 data.wmstatsUrl = "%s/wmstatsserver" % BASE_URL
+# VMs still rely on a local MongoDB instance
+data.mongoDBUrl = "mongodb://localhost"
+data.mongoDBPort = 8230
 data.limitRSEsPerInstance = 200
 data.limitFilesPerRSE = -1 # negative values mean NO Limit
 data.limitTiersPerInstance = ['T1', 'T2', 'T3']


### PR DESCRIPTION
Required for https://github.com/dmwm/WMCore/pull/10895 , otherwise the service no longer works when running in our VM (even though we want to stop using our VMs for any sort of central services tests).