### PR TITLE
Update wmagent manage script and my.cnf for mariadb upgrade

### DIFF
--- a/wmagent/manage
+++ b/wmagent/manage
@@ -343,7 +343,9 @@ init_mysql_db_post(){
         fi
     done
     echo "Socket file exists, proceeding with schema install..."
-    mysqladmin -u root password $MYSQL_PASS --socket=$MYSQL_SOCK
+
+    # set mariadb root password
+    mysql --socket=$MYSQL_SOCK --execute "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('$MYSQL_PASS');"
 
     inited_mysql;
 

--- a/wmagent/my.cnf
+++ b/wmagent/my.cnf
@@ -1,6 +1,7 @@
 [mysqld]
-# only STRICT_TRANS_TABLES mode is not default in MariaDB 10.1.x
+# this is the default setting in >= 10.2.4
 sql_mode="NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"
+# default: REPEATABLE-READ
 transaction-isolation=READ-COMMITTED
 
 max_heap_table_size=2048M
@@ -8,41 +9,61 @@ max_allowed_packet=128M
 max_connections = 200
 connect_timeout = 60
 
-binlog_format=row
+# default: MIXED
+binlog_format=ROW
+# default: 16MB
 tmp_table_size=2048M
+# default: 10
 long_query_time=5
 
+# default: 134217728
 key_buffer_size=4000M
 
-query_cache_type=1
-query_cache_limit=10M
-query_cache_size=128M
+# default: 0
+# disabling the query cache for now
+# unittests do not work with this enabled
+#query_cache_type=1
+#query_cache_limit=10M
+#query_cache_size=128M
 
 # threading
+# thread_cache_size defaults to 256, if > than max_connections, it is
+# set to max_connections
 thread_cache_size = 64
 thread_cache_size = 16
 thread_stack = 192K
 
 # innodb
-innodb_thread_concurrency=0
-innodb_concurrency_tickets=10000
-innodb_commit_concurrency=0
+# default: O_DIRECT
 innodb_flush_method=O_DIRECT
-innodb_file_io_threads = 4
-innodb_checksum_algorithm=NONE
+# default: 4
+innodb_read_io_threads = 4
+# default: 4
+innodb_write_io_threads = 4
+# default: full_crc23
+innodb_checksum_algorithm=full_crc32
+# default: 1
 innodb_doublewrite=0
+
 innodb_log_file_size=512M
 innodb_log_buffer_size=8M
 innodb_buffer_pool_size=2G
+# default: 30
 innodb_sync_spin_loops=60
+# default: 0
 innodb_force_recovery = 0
+# default: 50
 innodb_lock_wait_timeout = 100
 
 # Changes to support DYNAMIC / COMPRESSED row format
+# default: Barracuda
 innodb_file_format=Barracuda
+# default: ON
 innodb_file_per_table=ON
 # supports prefix index larger than 767 bytes (might be already implicit in the DYNAMIC mode?)
+# default: ON
 innodb_large_prefix=ON
+# default: ON
 innodb_strict_mode=ON
 #innodb_page_size=32k  # default is 16k
 

--- a/wmagentpy3/manage
+++ b/wmagentpy3/manage
@@ -282,8 +282,9 @@ init_mysql_db_post(){
         fi
     done
     echo "Socket file exists, proceeding with schema install..."
-    mysqladmin -u root password $MYSQL_PASS --socket=$MYSQL_SOCK
 
+    # set mariadb root password
+    mysql --socket=$MYSQL_SOCK --execute "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('$MYSQL_PASS');"
     inited_mysql;
 
     # create the user & grant privs (same db user for all three components)

--- a/wmagentpy3/my.cnf
+++ b/wmagentpy3/my.cnf
@@ -1,6 +1,7 @@
 [mysqld]
-# only STRICT_TRANS_TABLES mode is not default in MariaDB 10.1.x
+# this is the default setting in >= 10.2.4
 sql_mode="NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"
+# default: REPEATABLE-READ
 transaction-isolation=READ-COMMITTED
 
 max_heap_table_size=2048M
@@ -8,41 +9,61 @@ max_allowed_packet=128M
 max_connections = 200
 connect_timeout = 60
 
-binlog_format=row
+# default: MIXED
+binlog_format=ROW
+# default: 16MB
 tmp_table_size=2048M
+# default: 10
 long_query_time=5
 
+# default: 134217728
 key_buffer_size=4000M
 
-query_cache_type=1
-query_cache_limit=10M
-query_cache_size=128M
+# default: 0
+# disabling the query cache for now
+# unittests do not work with this enabled
+#query_cache_type=1
+#query_cache_limit=10M
+#query_cache_size=128M
 
 # threading
+# thread_cache_size defaults to 256, if > than max_connections, it is
+# set to max_connections
 thread_cache_size = 64
 thread_cache_size = 16
 thread_stack = 192K
 
 # innodb
-innodb_thread_concurrency=0
-innodb_concurrency_tickets=10000
-innodb_commit_concurrency=0
+# default: O_DIRECT
 innodb_flush_method=O_DIRECT
-innodb_file_io_threads = 4
-innodb_checksum_algorithm=NONE
+# default: 4
+innodb_read_io_threads = 4
+# default: 4
+innodb_write_io_threads = 4
+# default: full_crc23
+innodb_checksum_algorithm=full_crc32
+# default: 1
 innodb_doublewrite=0
+
 innodb_log_file_size=512M
 innodb_log_buffer_size=8M
 innodb_buffer_pool_size=2G
+# default: 30
 innodb_sync_spin_loops=60
+# default: 0
 innodb_force_recovery = 0
+# default: 50
 innodb_lock_wait_timeout = 100
 
 # Changes to support DYNAMIC / COMPRESSED row format
+# default: Barracuda
 innodb_file_format=Barracuda
+# default: ON
 innodb_file_per_table=ON
 # supports prefix index larger than 767 bytes (might be already implicit in the DYNAMIC mode?)
+# default: ON
 innodb_large_prefix=ON
+# default: ON
 innodb_strict_mode=ON
 #innodb_page_size=32k  # default is 16k
 


### PR DESCRIPTION
These changes required for the upgrade from mariadb 10.1.2 to 10.6.5. Many of the configuration parameters we used in 10.1.2 are the defaults in 10.6.5. I marked these in some comments. We can either choose to leave them in the config file or remove them.

The query cache is disabled as it caused the mariadb process to consistently lock up when running the unittests.

@amaltaro 

Fixes https://github.com/dmwm/WMCore/issues/10835
Requires https://github.com/cms-sw/cmsdist/pull/7205