### PR TITLE
Stop using passwords for mariadb users

### DIFF
--- a/wmagent/manage
+++ b/wmagent/manage
@@ -36,7 +36,6 @@ ORACLE_PASS=
 ORACLE_TNS=
 
 MYSQL_USER=
-MYSQL_PASS=
 if [ -z "$DBSOCK" ]; then
     MYSQL_SOCK=$INSTALL_MYSQL/logs/mysql.sock 
 else
@@ -138,7 +137,6 @@ load_secrets_file(){
     local MATCH_ORACLE_TNS=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_TNS | sed s/ORACLE_TNS=//`
     local MATCH_GRAFANA_TOKEN=`cat $WMAGENT_SECRETS_LOCATION | grep GRAFANA_TOKEN | sed s/GRAFANA_TOKEN=//`
     local MATCH_MYSQL_USER=`cat $WMAGENT_SECRETS_LOCATION | grep MYSQL_USER | sed s/MYSQL_USER=//`
-    local MATCH_MYSQL_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep MYSQL_PASS | sed s/MYSQL_PASS=//`
     local MATCH_COUCH_USER=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_USER | sed s/COUCH_USER=//`
     local MATCH_COUCH_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PASS | sed s/COUCH_PASS=//`
     local MATCH_COUCH_PORT=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PORT | sed s/COUCH_PORT=//`
@@ -173,11 +171,6 @@ load_secrets_file(){
     # database settings (mysql or oracle)
     if [ "x$MATCH_ORACLE_USER" == "x" ]; then
         MYSQL_USER=${MATCH_MYSQL_USER:-wmagentmysql};
-        MYSQL_PASS=$MATCH_MYSQL_PASS;
-        if [ "x$MYSQL_PASS" == "x" ]; then
-            echo "Secrets file does not contain MYSQL_PASS";
-            exit 1
-        fi
     else
         ORACLE_USER=$MATCH_ORACLE_USER;
         ORACLE_PASS=$MATCH_ORACLE_PASS;
@@ -266,7 +259,6 @@ print_settings(){
     echo "ORACLE_TNS=                $ORACLE_TNS                "
     echo "GRAFANA_TOKEN=             $GRAFANA_TOKEN             "
     echo "MYSQL_USER=                $MYSQL_USER                "
-    echo "MYSQL_PASS=                $MYSQL_PASS                "
     echo "COUCH_USER=                $COUCH_USER                "
     echo "COUCH_PASS=                $COUCH_PASS                "
     echo "COUCH_PORT=                $COUCH_PORT                "
@@ -344,26 +336,16 @@ init_mysql_db_post(){
     done
     echo "Socket file exists, proceeding with schema install..."
 
-    # set mariadb root password
-    mysql --socket=$MYSQL_SOCK --execute "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('$MYSQL_PASS');"
-
     inited_mysql;
-
-    # create the user & grant privs (same db user for all three components)
-    local SQLUSER="CREATE USER '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PASS}';"
-    local SQLGRANT="GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION;"
-
-    mysql -u root -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "$SQLUSER"
-    mysql -u root -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "$SQLGRANT"
 
     # create databases for agent, wq
     if [ $USING_AG -eq 1 ]; then
         echo "Installing WMAgent Database: ${MYSQL_DATABASE_AG}"
-        mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+        mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
     fi
     if [ $USING_WQ -eq 1 ]; then
         echo "Installing WorkQueue Database: ${MYSQL_DATABASE_WQ}"
-        mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_WQ}"
+        mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_WQ}"
     fi
 }
 
@@ -388,7 +370,7 @@ status_of_mysql(){
         echo "++ MYSQL process not running"
     fi
 
-    echo "++" `mysqladmin -u root --password=$MYSQL_PASS --socket=$MYSQL_SOCK status`
+    echo "++" `mysqladmin -u $MYSQL_USER --socket=$MYSQL_SOCK status`
 }
 
 #
@@ -435,7 +417,7 @@ start_mysql(){
         init_mysql_db_post;
     fi
     echo "Checking Server connection..."
-    mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
+    mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
     if [ $? -ne 0 ]; then
 	echo "ERROR: checking mysql database is running, failed to execute SHOW GLOBAL STATUS"
 	exit 1
@@ -454,7 +436,7 @@ stop_mysql(){
     fi
 
     echo "stopping mysql..."
-    mysqladmin -u root -p$MYSQL_PASS --socket=$MYSQL_SOCK shutdown &
+    mysqladmin -u $MYSQL_USER --socket=$MYSQL_SOCK shutdown &
     wait $!
     echo "Making sure the MySQL socket file is removed..."
     local TIMEOUT=0;
@@ -498,9 +480,9 @@ db_prompt(){
     if [ "x$MYSQL_USER" != "x" ]; then
 	case "$2" in
 	  "workqueue")
-	      mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --database=${MYSQL_DATABASE_WQ};;
+	      mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --database=${MYSQL_DATABASE_WQ};;
 	  "wmagent")
-	      mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --database=${MYSQL_DATABASE_AG};;
+	      mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --database=${MYSQL_DATABASE_AG};;
 	  *)
 	      echo "Unknown arg to db_prompt: $2"
 	      echo "Should be one of workqueue, wmagent"
@@ -637,7 +619,7 @@ init_wmagent(){
     init_rucio;
 
     if [ "x$MYSQL_USER" != "x" ]; then
-        local database_options="--mysql_url=mysql://$MYSQL_USER:$MYSQL_PASS@localhost/$MYSQL_DATABASE_AG \
+        local database_options="--mysql_url=mysql://$MYSQL_USER@localhost/$MYSQL_DATABASE_AG \
                           --mysql_socket=$MYSQL_SOCK "
     elif [ "x$ORACLE_USER" != "x" ]; then
         local database_options="--coredb_url=oracle://$ORACLE_USER:$ORACLE_PASS@$ORACLE_TNS "
@@ -680,7 +662,7 @@ init_workqueue(){
     if [ "x$MYSQL_USER" != "x" ]; then
 	wmagent-mod-config --input=$CONFIG_WQ/config-template.py \
                        --output=$CONFIG_WQ/config.py \
-                       --mysql_url=mysql://$MYSQL_USER:$MYSQL_PASS@localhost/$MYSQL_DATABASE_WQ \
+                       --mysql_url=mysql://$MYSQL_USER@localhost/$MYSQL_DATABASE_WQ \
                        --mysql_socket=$MYSQL_SOCK \
                        --working_dir=$INSTALL_WQ \
                        --couch_url=http://$COUCH_USER:$COUCH_PASS@$COUCH_HOST_NAME:$COUCH_PORT \
@@ -778,8 +760,8 @@ clean_agent(){
         rm -f $INSTALL_WQ/.init
 
 	if [ "x$MYSQL_USER" != "x" ]; then
-            mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "drop database ${MYSQL_DATABASE_WQ}"
-            mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_WQ}"
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "drop database ${MYSQL_DATABASE_WQ}"
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_WQ}"
 	fi
     fi
     if [ $USING_AG -eq 1 ]; then
@@ -789,8 +771,8 @@ clean_agent(){
         rm -f $INSTALL_AG/.init
 
 	if [ "x$MYSQL_USER" != "x" ]; then
-            mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "drop database ${MYSQL_DATABASE_AG}"
-            mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "drop database ${MYSQL_DATABASE_AG}"
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
 	fi
     fi
 }

--- a/wmagentpy3/manage
+++ b/wmagentpy3/manage
@@ -31,7 +31,6 @@ ORACLE_PASS=
 ORACLE_TNS=
 
 MYSQL_USER=
-MYSQL_PASS=
 if [ -z "$DBSOCK" ]; then
     MYSQL_SOCK=$INSTALL_MYSQL/logs/mysql.sock 
 else
@@ -113,7 +112,6 @@ load_secrets_file(){
     local MATCH_ORACLE_TNS=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_TNS | sed s/ORACLE_TNS=//`
     local MATCH_GRAFANA_TOKEN=`cat $WMAGENT_SECRETS_LOCATION | grep GRAFANA_TOKEN | sed s/GRAFANA_TOKEN=//`
     local MATCH_MYSQL_USER=`cat $WMAGENT_SECRETS_LOCATION | grep MYSQL_USER | sed s/MYSQL_USER=//`
-    local MATCH_MYSQL_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep MYSQL_PASS | sed s/MYSQL_PASS=//`
     local MATCH_COUCH_USER=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_USER | sed s/COUCH_USER=//`
     local MATCH_COUCH_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PASS | sed s/COUCH_PASS=//`
     local MATCH_COUCH_PORT=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PORT | sed s/COUCH_PORT=//`
@@ -139,11 +137,6 @@ load_secrets_file(){
     # database settings (mysql or oracle)
     if [ "x$MATCH_ORACLE_USER" == "x" ]; then
         MYSQL_USER=${MATCH_MYSQL_USER:-wmagentmysql};
-        MYSQL_PASS=$MATCH_MYSQL_PASS;
-        if [ "x$MYSQL_PASS" == "x" ]; then
-            echo "Secrets file does not contain MYSQL_PASS";
-            exit 1
-        fi
     else
         ORACLE_USER=$MATCH_ORACLE_USER;
         ORACLE_PASS=$MATCH_ORACLE_PASS;
@@ -214,7 +207,6 @@ print_settings(){
     echo "ORACLE_TNS=                $ORACLE_TNS                "
     echo "GRAFANA_TOKEN=             $GRAFANA_TOKEN             "
     echo "MYSQL_USER=                $MYSQL_USER                "
-    echo "MYSQL_PASS=                $MYSQL_PASS                "
     echo "COUCH_USER=                $COUCH_USER                "
     echo "COUCH_PASS=                $COUCH_PASS                "
     echo "COUCH_PORT=                $COUCH_PORT                "
@@ -283,21 +275,12 @@ init_mysql_db_post(){
     done
     echo "Socket file exists, proceeding with schema install..."
 
-    # set mariadb root password
-    mysql --socket=$MYSQL_SOCK --execute "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('$MYSQL_PASS');"
     inited_mysql;
-
-    # create the user & grant privs (same db user for all three components)
-    local SQLUSER="CREATE USER '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PASS}';"
-    local SQLGRANT="GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION;"
-
-    mysql -u root -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "$SQLUSER"
-    mysql -u root -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "$SQLGRANT"
 
     # create databases for agent
     if [ $USING_AG -eq 1 ]; then
         echo "Installing WMAgent Database: ${MYSQL_DATABASE_AG}"
-        mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+        mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
     fi
 }
 
@@ -322,7 +305,7 @@ status_of_mysql(){
         echo "++ MYSQL process not running"
     fi
 
-    echo "++" `mysqladmin -u root --password=$MYSQL_PASS --socket=$MYSQL_SOCK status`
+    echo "++" `mysqladmin -u $MYSQL_USER --socket=$MYSQL_SOCK status`
 }
 
 #
@@ -369,7 +352,7 @@ start_mysql(){
         init_mysql_db_post;
     fi
     echo "Checking Server connection..."
-    mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
+    mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
     if [ $? -ne 0 ]; then
 	echo "ERROR: checking mysql database is running, failed to execute SHOW GLOBAL STATUS"
 	exit 1
@@ -388,7 +371,7 @@ stop_mysql(){
     fi
 
     echo "stopping mysql..."
-    mysqladmin -u root -p$MYSQL_PASS --socket=$MYSQL_SOCK shutdown &
+    mysqladmin -u $MYSQL_USER --socket=$MYSQL_SOCK shutdown &
     wait $!
     echo "Making sure the MySQL socket file is removed..."
     local TIMEOUT=0;
@@ -432,7 +415,7 @@ db_prompt(){
     if [ "x$MYSQL_USER" != "x" ]; then
 	case "$2" in
 	  "wmagent")
-	      mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --database=${MYSQL_DATABASE_AG};;
+	      mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --database=${MYSQL_DATABASE_AG};;
 	  *)
 	      echo "Unknown arg to db_prompt: $2"
 	      echo "Should be one of unittest, wmagent"
@@ -569,7 +552,7 @@ init_wmagent(){
     init_rucio;
 
     if [ "x$MYSQL_USER" != "x" ]; then
-        local database_options="--mysql_url=mysql://$MYSQL_USER:$MYSQL_PASS@localhost/$MYSQL_DATABASE_AG \
+        local database_options="--mysql_url=mysql://$MYSQL_USER@localhost/$MYSQL_DATABASE_AG \
                           --mysql_socket=$MYSQL_SOCK "
     elif [ "x$ORACLE_USER" != "x" ]; then
         local database_options="--coredb_url=oracle://$ORACLE_USER:$ORACLE_PASS@$ORACLE_TNS "
@@ -658,8 +641,8 @@ clean_agent(){
         rm -f $INSTALL_AG/.init
 
         if [ "x$MYSQL_USER" != "x" ]; then
-            mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "drop database ${MYSQL_DATABASE_AG}"
-            mysql -u $MYSQL_USER -p$MYSQL_PASS --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "drop database ${MYSQL_DATABASE_AG}"
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
 	    fi
     fi
 }


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10926

MariaDB 10.4 changed the default authentication method to allow password-less connections via the local socket file. Details on the change can be found at https://mariadb.com/kb/en/authentication-from-mariadb-104/. 

This PR removes usage of MYSQL_PASS to authenticate to the database, as it is no longer necessary. It also removes the creation of the password for the root user.

More details here: https://github.com/dmwm/WMCore/issues/10837#issuecomment-996082271