### PR TITLE
Allow WMAgent MariaDB user creation when initializing the database

### DIFF
--- a/wmagent/manage
+++ b/wmagent/manage
@@ -338,6 +338,12 @@ init_mysql_db_post(){
 
     inited_mysql;
 
+    # create a user - different than root and current unix user - and grant privileges
+    if [ "$MYSQL_USER" != "$USER" ]; then
+        mysql -u root --socket=$MYSQL_SOCK --execute "CREATE USER '${MYSQL_USER}'@'localhost'"
+        mysql -u root --socket=$MYSQL_SOCK --execute "GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION"
+    fi
+
     # create databases for agent, wq
     if [ $USING_AG -eq 1 ]; then
         echo "Installing WMAgent Database: ${MYSQL_DATABASE_AG}"

--- a/wmagentpy3/manage
+++ b/wmagentpy3/manage
@@ -277,6 +277,12 @@ init_mysql_db_post(){
 
     inited_mysql;
 
+    # create a user - different than root and current unix user - and grant privileges
+    if [ "$MYSQL_USER" != "$USER" ]; then
+        mysql -u root --socket=$MYSQL_SOCK --execute "CREATE USER '${MYSQL_USER}'@'localhost'"
+        mysql -u root --socket=$MYSQL_SOCK --execute "GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION"
+    fi
+
     # create databases for agent
     if [ $USING_AG -eq 1 ]; then
         echo "Installing WMAgent Database: ${MYSQL_DATABASE_AG}"
@@ -314,15 +320,15 @@ status_of_mysql(){
 start_mysql(){
     load_secrets_file;
     if [ "x$MYSQL_USER" == "x" ]; then
-	echo "Not using MySQL..."
-	exit 1;
+	    echo "Not using MySQL..."
+	    exit 1;
     fi
 
     echo "Starting mysql..."
 
     if [ $MYSQL_INIT_DONE -eq 0 ]; then
-	echo "MySQL has not been initialised... running pre initialisation";
-	init_mysql_db_pre;
+	    echo "MySQL has not been initialised... running pre initialisation";
+	    init_mysql_db_pre;
     fi
 
     # Start mysqld to install the database schemas
@@ -341,8 +347,8 @@ start_mysql(){
       sleep 2;
       TIMEOUT=$(($TIMEOUT+2))
       if [ $TIMEOUT -ge 300 ]; then
-	  echo "ERROR: Timeout waiting for mysqld to start."
-	  exit 1;
+	    echo "ERROR: Timeout waiting for mysqld to start."
+	    exit 1;
       fi
     done
     echo "Socket file exists: $MYSQL_SOCK"
@@ -354,8 +360,8 @@ start_mysql(){
     echo "Checking Server connection..."
     mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
     if [ $? -ne 0 ]; then
-	echo "ERROR: checking mysql database is running, failed to execute SHOW GLOBAL STATUS"
-	exit 1
+	    echo "ERROR: checking mysql database is running, failed to execute SHOW GLOBAL STATUS"
+	    exit 1
     fi
    echo "Connection OK"
 }


### PR DESCRIPTION
This reverts some of the changes made in this PR: https://github.com/dmwm/deployment/pull/1117

Reason is, for WMAgent unit tests setup (docker), we still have to create a third user (different than root and current unix user, at the time agent was deployed).