### PR TITLE
Run mysql commands with local current unix user

### DIFF
--- a/wmagent/manage
+++ b/wmagent/manage
@@ -170,7 +170,7 @@ load_secrets_file(){
 
     # database settings (mysql or oracle)
     if [ "x$MATCH_ORACLE_USER" == "x" ]; then
-        MYSQL_USER=${MATCH_MYSQL_USER:-wmagentmysql};
+        MYSQL_USER=${MATCH_MYSQL_USER:-$USER};
     else
         ORACLE_USER=$MATCH_ORACLE_USER;
         ORACLE_PASS=$MATCH_ORACLE_PASS;
@@ -340,18 +340,18 @@ init_mysql_db_post(){
 
     # create a user - different than root and current unix user - and grant privileges
     if [ "$MYSQL_USER" != "$USER" ]; then
-        mysql -u root --socket=$MYSQL_SOCK --execute "CREATE USER '${MYSQL_USER}'@'localhost'"
-        mysql -u root --socket=$MYSQL_SOCK --execute "GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "CREATE USER '${MYSQL_USER}'@'localhost'"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION"
     fi
 
     # create databases for agent, wq
     if [ $USING_AG -eq 1 ]; then
         echo "Installing WMAgent Database: ${MYSQL_DATABASE_AG}"
-        mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
     fi
     if [ $USING_WQ -eq 1 ]; then
         echo "Installing WorkQueue Database: ${MYSQL_DATABASE_WQ}"
-        mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_WQ}"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_WQ}"
     fi
 }
 

--- a/wmagentpy3/manage
+++ b/wmagentpy3/manage
@@ -136,7 +136,7 @@ load_secrets_file(){
 
     # database settings (mysql or oracle)
     if [ "x$MATCH_ORACLE_USER" == "x" ]; then
-        MYSQL_USER=${MATCH_MYSQL_USER:-wmagentmysql};
+        MYSQL_USER=${MATCH_MYSQL_USER:-$USER};
     else
         ORACLE_USER=$MATCH_ORACLE_USER;
         ORACLE_PASS=$MATCH_ORACLE_PASS;
@@ -279,14 +279,14 @@ init_mysql_db_post(){
 
     # create a user - different than root and current unix user - and grant privileges
     if [ "$MYSQL_USER" != "$USER" ]; then
-        mysql -u root --socket=$MYSQL_SOCK --execute "CREATE USER '${MYSQL_USER}'@'localhost'"
-        mysql -u root --socket=$MYSQL_SOCK --execute "GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "CREATE USER '${MYSQL_USER}'@'localhost'"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION"
     fi
 
     # create databases for agent
     if [ $USING_AG -eq 1 ]; then
         echo "Installing WMAgent Database: ${MYSQL_DATABASE_AG}"
-        mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
     fi
 }
 
@@ -358,7 +358,7 @@ start_mysql(){
         init_mysql_db_post;
     fi
     echo "Checking Server connection..."
-    mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
+    mysql -u $USER --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
     if [ $? -ne 0 ]; then
 	    echo "ERROR: checking mysql database is running, failed to execute SHOW GLOBAL STATUS"
 	    exit 1


### PR DESCRIPTION
This fixes the use of root account to perform MariaDB commands (it is only allowed if we are logged in as root or run those commands as sudo). In addition to that, when installing the database, use the current unix user instead of what is provided in the environment file.

Complement to:
https://github.com/dmwm/deployment/pull/1117
and
https://github.com/dmwm/deployment/pull/1119

@goughes could you please have a look at it as well? This is going together with: https://github.com/dmwm/WMCore/pull/10934