### PR TITLE
remove crontab

### DIFF
--- a/crabserver/deploy
+++ b/crabserver/deploy
@@ -39,14 +39,9 @@ deploy_crabserver_sw()
 deploy_crabserver_post()
 {
   case $host in vocms013[89] | vocms073[89] | vocms0143 | vocms074[0123456] | vocms076[12345] | vocms0307 | vocms0318 ) disable ;; * ) enable ;; esac
-  (mkcrontab 
+  (mkcrontab
    sysboot
 
-   # Restart crab once every four days to release leaked memory
-   case $host in vocms0161 ) d=2;; vocms0163 ) d=3;; vocms0165 ) d=4;; * ) d=1;; esac
-   local cmd="$project_config/manage start 'I did read documentation'"
-   $nogroups || cmd="sudo -H -u _crabserver bashs -l -c \"${cmd}\""
-   echo "0 9 $d-31/4 * * $cmd &> /dev/null"
   ) | crontab -
 }
 


### PR DESCRIPTION
Remove cronjob that make CRABServer REST restart every 4 days.
Now, we are deploying CRABServer REST on k8s cluster, we can rely on its memory limit mechanism to kill app when limit are reached.
