### PR TITLE
Remove uGMT ZS plots from quick collection

### DIFF
--- a/dqmgui/layouts/l1t-layouts.py
+++ b/dqmgui/layouts/l1t-layouts.py
@@ -487,17 +487,6 @@ l1t_quickCollection(dqmitems, "54 - Input vs Output misMatch Ratios (clockwise f
     'description': "This should be empty at all times.",
     'draw': { 'withref': "no" }
   }])
-l1t_quickCollection(dqmitems, "55 - uGMT Zero Suppression misMatch Ratio (left: all events, right: fat events)",
-  [{
-    'path': "L1T/L1TStage2uGMT/zeroSuppression/AllEvts/mismatchRatio",
-    'description': "This should be empty at all times.",
-    'draw': { 'withref': "no" }
-  },
-  {
-    'path': "L1T/L1TStage2uGMT/zeroSuppression/FatEvts/mismatchRatio",
-    'description': "This should be empty at all times.",
-    'draw': { 'withref': "no" }
-  }])
 l1t_quickCollection(dqmitems, "56 - BMTF Zero Suppression misMatch Ratio (left: all events, right: fat events)",
   [{
     'path': "L1T/L1TStage2BMTF/zeroSuppression/AllEvts/mismatchRatio",

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -89,7 +89,6 @@ server.workspace('DQMContent', 10, 'Trigger', 'L1T', '^(L1T|L1T2016)/', '',
                  'L1T/Layouts/Stage2-QuickCollection/52 - uGT Muon Inputs Board 2-6 misMatch Ratios',
                  'L1T/Layouts/Stage2-QuickCollection/53 - uGMT Muon Copy 1-5 misMatch Ratios',
                  'L1T/Layouts/Stage2-QuickCollection/54 - Input vs Output misMatch Ratios (clockwise from top left: uGT vs. uGMT, uGT vs. caloL2, uGMT vs. EMTF, uGMT vs. OMTF, uGMT vs. BMTF)',
-                 'L1T/Layouts/Stage2-QuickCollection/55 - uGMT Zero Suppression misMatch Ratio (left: all events, right: fat events)',
                  'L1T/Layouts/Stage2-QuickCollection/56 - BMTF Zero Suppression misMatch Ratio (left: all events, right: fat events)',
                 )
 


### PR DESCRIPTION
These plots were removed from the DQM in https://github.com/cms-sw/cmssw/pull/38115 (main branch) and backported in https://github.com/cms-sw/cmssw/pull/38172 (12_3_X) as well as https://github.com/cms-sw/cmssw/pull/38174 (12_4_X).

attn @vukasinmilosevic