### PR TITLE
Customize ECAL GPU validation 2D histograms

### DIFF
--- a/dqmgui/style/EcalRenderPlugin.cc
+++ b/dqmgui/style/EcalRenderPlugin.cc
@@ -1333,6 +1333,7 @@ EcalRenderPlugin::postDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject,
      !fullpath.Contains("Cluster") &&
      !fullpath.Contains("StatusFlags") &&
      !fullpath.Contains("Integrity") &&
+     !fullpath.Contains("GpuTask") &&
      !fullpath.Contains("TT Flags vs Et")) return;
 
   TH1* obj(static_cast<TH1*>(dqmObject.object));
@@ -1423,6 +1424,13 @@ EcalRenderPlugin::postDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject,
     obj->GetXaxis()->SetTitle("DDCID");
     obj->GetYaxis()->SetNdivisions(4, false);
     obj->GetYaxis()->SetLabelSize(0.04);
+    applyDefaults = false;
+  }
+  else if(TPRegexp("E[BE]GpuTask/(.*)/E[BE]GT(.*)map2D").MatchB(fullpath)){
+    obj->GetXaxis()->SetNdivisions(510);
+    obj->GetYaxis()->SetNdivisions(510);
+    gPad->SetGrid(false, false);
+    gPad->SetLogz();
     applyDefaults = false;
   }
 }


### PR DESCRIPTION
Customize the draw options for the 2D histograms added to the ECAL DQM GPU validation module in the following CMSSW PRs:

-  [master] https://github.com/cms-sw/cmssw/pull/38427
- https://github.com/cms-sw/cmssw/pull/38428
- https://github.com/cms-sw/cmssw/pull/38429