### PR TITLE
Ensure default CouchDB installation can access the hmac ini file

### DIFF
--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -20,7 +20,6 @@ deploy_couchdb_sw()
   case $variant in
     default )
       deploy_pkg -l couchdb -a couchdb/hmackey.ini comp external+couchdb31
-      $authlink || setgroup ug+rx,o-rwx _config $project_auth/hmackey.ini
       ;;
     * )
       deploy_pkg -a couchdb/hmackey.ini comp external+couchdb
@@ -30,6 +29,7 @@ deploy_couchdb_sw()
   perl -p -i -e "s|{ROOT}|$root|g" $root/$cfgversion/config/$project/local.ini
 
   # BAD code for the hmackey that does not work when read from a separate file
+  $authlink || setgroup ug+rx,o-rwx _config $project_auth/hmackey.ini
   local hmacKey=`tail -n1 $project_auth/hmackey.ini`
   sed -i '/^validate_hmac=.*/a $hmacKey' $root/$cfgversion/config/$project/local.ini
 

--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -20,6 +20,7 @@ deploy_couchdb_sw()
   case $variant in
     default )
       deploy_pkg -l couchdb -a couchdb/hmackey.ini comp external+couchdb31
+      $authlink || setgroup ug+rx,o-rwx _config $project_auth/hmackey.ini
       ;;
     * )
       deploy_pkg -a couchdb/hmackey.ini comp external+couchdb
@@ -27,12 +28,6 @@ deploy_couchdb_sw()
   esac
 
   perl -p -i -e "s|{ROOT}|$root|g" $root/$cfgversion/config/$project/local.ini
-
-  # BAD code for the hmackey that does not work when read from a separate file
-  $authlink || setgroup ug+rx,o-rwx _config $project_auth/hmackey.ini
-  local hmacKey=`tail -n1 $project_auth/hmackey.ini`
-  sed -i '/^validate_hmac=.*/a $hmacKey' $root/$cfgversion/config/$project/local.ini
-
 }
 
 deploy_couchdb_post()
@@ -82,9 +77,4 @@ deploy_couchdb_auth()
   sed -i "s+;user = pass+$COUCH_USER = $COUCH_PASS+" $root/$cfgversion/config/$project/local.ini
   # Update the monitoring script as well
   sed -i "s+@@@USER:@@@PASS+$COUCH_USER:$COUCH_PASS+" $root/$cfgversion/config/$project/monitoring.ini
-
-  perl -e \
-    'undef $/; print "[couch_cms_auth]\n";
-     print "hmac_secret = ", unpack("h*", <STDIN>), "\n"' < \
-    $root/$cfgversion/auth/wmcore-auth/header-auth-key
 }


### PR DESCRIPTION
This is a complement for https://github.com/dmwm/deployment/pull/1088

As Imran reported, CouchDB deployment fails with:
```
++ perl -p -i -e 's|{ROOT}|/data/srv|g' /data/srv/beHG2207d/config/couchdb/local.ini
+++ tail -n1 /data/srv/beHG2207d/auth/couchdb/hmackey.ini
tail: cannot open ‘/data/srv/beHG2207d/auth/couchdb/hmackey.ini’ for reading: Permission denied
++++ err=1
++++ note 'ERROR: installation failed with exit code 1.'
++++ echo 'ERROR: installation failed with exit code 1.'
ERROR: installation failed with exit code 1.
++++ echo 'ERROR: installation failed with exit code 1.'
++++ exit 1
```