### PR TITLE
Layout and style customizations for PiZeroTask plots

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -475,6 +475,19 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/21 Cluster Energy vs Seed Energy',
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/22 di-Electron Mass',
 	   [{'path': 'HLT/ObjectMonitor/MainShifter/di-Electron_Mass', 'description': 'HLT di-electron mass [from HLT DQM].'}])
+
+#____________________ Layouts / 04 Energy / PiZero ____________________
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/00 Pi0 Invariant Mass',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Invariant Mass', 'description': 'Pi0 Invariant Mass in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/01 Pi0 Pt 1st most energetic photon',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Pt 1st most energetic photon', 'description': 'Pt 1st most energetic Pi0 photon in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/02 Pi0 Pt 2nd most energetic photon',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Pt 2nd most energetic photon', 'description': 'Pt 2nd most energetic Pi0 photon in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/03 Pi0 Pt',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Pt', 'description': 'Pi0 Pt in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/04 Pi0 Iso',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Iso', 'description': 'Pt 2nd most energetic Pi0 photon in EB'}])
+
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE
   for sign in ['-', '+']: # Loop over z-side

--- a/dqmgui/layouts/ecal_T0_layouts.py
+++ b/dqmgui/layouts/ecal_T0_layouts.py
@@ -473,6 +473,19 @@ ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/20 Super Cluster Size',
 ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/21 Cluster Energy vs Seed Energy',
 	   [{'path': 'EcalBarrel/EBClusterTask/EBCLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}],
 	   [{'path': 'EcalEndcap/EEClusterTask/EECLT SC energy vs seed crystal energy', 'description': 'Relation between super cluster energy and its seed crystal energy.'}])
+
+#____________________ Layouts / 04 Energy / PiZero ____________________
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/00 Pi0 Invariant Mass',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Invariant Mass', 'description': 'Pi0 Invariant Mass in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/01 Pi0 Pt 1st most energetic photon',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Pt 1st most energetic photon', 'description': 'Pt 1st most energetic Pi0 photon in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/02 Pi0 Pt 2nd most energetic photon',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Pt 2nd most energetic photon', 'description': 'Pt 2nd most energetic Pi0 photon in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/03 Pi0 Pt',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Pt', 'description': 'Pi0 Pt in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/04 Energy/PiZero/04 Pi0 Iso',
+	   [{'path': 'EcalBarrel/EBPiZeroTask/EBPZT Pi0 Iso', 'description': 'Pt 2nd most energetic Pi0 photon in EB'}])
+
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE
   for sign in ['-', '+']: # Loop over z-side

--- a/dqmgui/style/EcalRenderPlugin.cc
+++ b/dqmgui/style/EcalRenderPlugin.cc
@@ -1334,6 +1334,7 @@ EcalRenderPlugin::postDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject,
      !fullpath.Contains("StatusFlags") &&
      !fullpath.Contains("Integrity") &&
      !fullpath.Contains("GpuTask") &&
+     !fullpath.Contains("PiZeroTask") &&
      !fullpath.Contains("TT Flags vs Et")) return;
 
   TH1* obj(static_cast<TH1*>(dqmObject.object));
@@ -1432,6 +1433,9 @@ EcalRenderPlugin::postDrawByName(TCanvas* canvas, VisDQMObject const& dqmObject,
     gPad->SetGrid(false, false);
     gPad->SetLogz();
     applyDefaults = false;
+  }
+  else if(TPRegexp("E[BE]PiZeroTask/E[BE]PZT").MatchB(fullpath)){
+    gPad->SetLogy(0);
   }
 }
 


### PR DESCRIPTION
Complimentary PR to:
- https://github.com/cms-sw/cmssw/pull/38561

Move pi0 plots into `Layouts/04 Energy/PiZero` in the Ecal workspace to monitor both in online and offline DQM. Also, change pi0 plots from log scale (default) to linear to match the original plots and better see the pi0 peak.