### PR TITLE
Fix bind_address in central CouchDB

### DIFF
--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -27,7 +27,8 @@ deploy_couchdb_sw()
       ;;
   esac
 
-  perl -p -i -e "s|{ROOT}|$root|g" $root/$cfgversion/config/$project/local.ini
+  sed -i "s+{ROOT}+$root+" $root/$cfgversion/config/$project/local.ini
+  sed -i "s+bind_address = 127.0.0.1+bind_address = 0.0.0.0+" $root/$cfgversion/config/$project/local.ini
 }
 
 deploy_couchdb_post()


### PR DESCRIPTION
This fix the problem we had in testbed yesterday, where CouchDB service was listening only on localhost (which is fine for our private VM, but not cmsweb environment). It also replaces a perl command by sed.