### PR TITLE
Revert commenting out MSOutput and MSUnmerged

### DIFF
--- a/reqmgr2ms/manage
+++ b/reqmgr2ms/manage
@@ -53,8 +53,6 @@ else
   CFGFILERCLEAN=$CFGDIR/config-ruleCleaner.py
   CFGFILEUNMERGED=$CFGDIR/config-unmerged.py
 fi
-CFGFILEOUT=$CFGDIR # force ms-output to be disabled
-CFGFILEUNMERGED=$CFGDIR # force ms-unmerged to be disabled
 
 LOG_TRANS=ms-transferor
 LOG_MON=ms-monitor


### PR DESCRIPTION
This PR reverts a change provided in https://github.com/dmwm/deployment/pull/1088
which was meant to disable MSOutput and MSUnmerged in private VM setup, but it turns out it also affects services running in cmsweb{-testbed} kubernetes (unless overriden in services_config).