### PR TITLE
Update CouchDB configuration with default CouchDB 3.2.2 file

### DIFF
--- a/couchdb/default.ini
+++ b/couchdb/default.ini
@@ -8,8 +8,14 @@ database_dir = ./data
 view_index_dir = ./data
 ; util_driver_dir =
 ; plugin_dir =
-os_process_timeout = 5000 ; 5 seconds. for view servers.
-max_dbs_open = 500
+;os_process_timeout = 5000 ; 5 seconds. for view servers.
+
+; Maximum number of .couch files to open at once.
+; The actual limit may be slightly lower depending on how
+; many schedulers you have as the allowance is divided evenly
+; among them.
+;max_dbs_open = 500
+
 ; Method used to compress everything that is appended to database and view index files, except
 ; for attachments (see the attachments section). Available methods are:
 ;
@@ -17,17 +23,17 @@ max_dbs_open = 500
 ; snappy       - use google snappy, a very fast compressor/decompressor
 ; deflate_N    - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
 ;                lowest compression ratio) to 9 (slowest, highest compression ratio)
-file_compression = snappy
+;file_compression = snappy
 ; Higher values may give better read performance due to less read operations
 ; and/or more OS page cache hits, but they can also increase overall response
 ; time for writes when there are many attachment write requests in parallel.
-attachment_stream_buffer_size = 4096
+;attachment_stream_buffer_size = 4096
 ; Default security object for databases if not explicitly set
 ; everyone - same as couchdb 1.0, everyone can read/write
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_only
+;default_security = admin_only
 ; btree_chunk_size = 1279
 ; maintenance_mode = false
 ; stem_interactive_updates = true
@@ -35,28 +41,26 @@ default_security = admin_only
 ; The speed of processing the _changes feed with doc_ids filter can be
 ; influenced directly with this setting - increase for faster processing at the
 ; expense of more memory usage.
-changes_doc_ids_optimization_threshold = 100
+;changes_doc_ids_optimization_threshold = 100
 ; Maximum document ID length. Can be set to an integer or 'infinity'.
 ;max_document_id_length = infinity
 ;
 ; Limit maximum document size. Requests to create / update documents with a body
 ; size larger than this will fail with a 413 http error. This limit applies to
 ; requests which update a single document as well as individual documents from
-; a _bulk_docs request. Since there is no canonical size of json encoded data,
-; due to variabiliy in what is escaped or how floats are encoded, this limit is
-; applied conservatively. For example 1.0e+16 could be encoded as 1e16, so 4 used
-; for size calculation instead of 7.
-max_document_size = 8000000 ; bytes
+; a _bulk_docs request. The size limit is approximate due to the nature of JSON
+; encoding.
+;max_document_size = 8000000 ; bytes
 ;
 ; Maximum attachment size.
-; max_attachment_size = infinity
+; max_attachment_size = 1073741824 ; 1 gibibyte
 ;
 ; Do not update the least recently used DB cache on reads, only writes
 ;update_lru_on_read = false
 ;
 ; The default storage engine to use when creating databases
 ; is set as a key into the [couchdb_engines] section.
-default_engine = couch
+;default_engine = couch
 ;
 ; Enable this to only "soft-delete" databases when DELETE /{db} requests are
 ; made. This will place a .recovery directory in your data directory and
@@ -74,7 +78,7 @@ default_engine = couch
 ;single_node = false
 
 ; Allow edits on the _security object in the user db. By default, it's disabled.
-users_db_security_editable = false
+;users_db_security_editable = false
 
 [purge]
 ; Allowed maximum number of documents in one purge request
@@ -102,8 +106,8 @@ couch = couch_bt_engine
 ;couch_server = false
 
 [cluster]
-q=2
-n=3
+;q=2
+;n=3
 ; placement = metro-dc-a:2,metro-dc-b:1
 
 ; Supply a comma-delimited list of node names that this node should
@@ -117,18 +121,18 @@ n=3
 ; These settings affect the main, clustered port (5984 by default).
 port = 5984
 bind_address = 127.0.0.1
-backlog = 512
-socket_options = [{sndbuf, 262144}, {nodelay, true}]
-server_options = [{recbuf, undefined}]
-require_valid_user = false
+;backlog = 512
+;socket_options = [{sndbuf, 262144}, {nodelay, true}]
+;server_options = [{recbuf, undefined}]
+;require_valid_user = false
 ; require_valid_user_except_for_up = false
 ; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
 ; If Server header is left out, Mochiweb will add its own one in.
-prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
 ;
 ; Limit maximum number of databases when tying to get detailed information using
 ; _dbs_info in a request
-max_db_number_for_dbs_info_req = 100
+;max_db_number_for_dbs_info_req = 100
 
 ; set to true to delay the start of a response until the end has been calculated
 ;buffer_response = false
@@ -143,9 +147,35 @@ max_db_number_for_dbs_info_req = 100
 ; prevent non-admins from accessing /_all_dbs
 ; admin_only_all_dbs = true
 
+; These options are moved from [httpd]
+;secure_rewrites = true
+;allow_jsonp = false
+
+;enable_cors = false
+;enable_xframe_options = false
+
+; CouchDB can optionally enforce a maximum uri length;
+;max_uri_length = 8000
+
+;changes_timeout = 60000
+;config_whitelist =
+;rewrite_limit = 100
+;x_forwarded_host = X-Forwarded-Host
+;x_forwarded_proto = X-Forwarded-Proto
+;x_forwarded_ssl = X-Forwarded-Ssl
+
+; Maximum allowed http request size. Applies to both clustered and local port.
+;max_http_request_size = 4294967296 ; 4GB
+
+; Set to true to decode + to space in db and doc_id parts.
+; decode_plus_to_space = true
+
 ;[jwt_auth]
 ; List of claims to validate
-; required_claims =
+; can be the name of a claim like "exp" or a tuple if the claim requires
+; a parameter
+; required_claims = exp, {iss, "IssuerNameHere"}
+; roles_claim_name = https://example.com/roles
 ;
 ; [jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.
@@ -167,42 +197,33 @@ max_db_number_for_dbs_info_req = 100
 ; exists for each document in _users. These databases are writable only
 ; by the corresponding user. Databases are in the following form:
 ; userdb-{hex encoded username}
-enable = false
+;enable = false
 ; If set to true and a user is deleted, the respective database gets
 ; deleted as well.
-delete_dbs = false
+;delete_dbs = false
 ; Set a default q value for peruser-created databases that is different from
 ; cluster / q
 ;q = 1
 ; prefix for user databases. If you change this after user dbs have been
 ; created, the existing databases won't get deleted if the associated user
 ; gets deleted because of the then prefix mismatch.
-database_prefix = userdb-
+;database_prefix = userdb-
 
 [httpd]
 port = 5986
 bind_address = 127.0.0.1
-authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
-secure_rewrites = true
-allow_jsonp = false
+;authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+
 ; Options for the MochiWeb HTTP server.
 ;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
-socket_options = [{sndbuf, 262144}]
-enable_cors = false
-enable_xframe_options = false
-; CouchDB can optionally enforce a maximum uri length;
-; max_uri_length = 8000
-; changes_timeout = 60000
-; config_whitelist = 
-; max_uri_length = 
-; rewrite_limit = 100
-; x_forwarded_host = X-Forwarded-Host
-; x_forwarded_proto = X-Forwarded-Proto
-; x_forwarded_ssl = X-Forwarded-Ssl
-; Maximum allowed http request size. Applies to both clustered and local port.
-max_http_request_size = 4294967296 ; 4GB
+;socket_options = [{sndbuf, 262144}]
+
+; These settings were moved to [chttpd]
+; secure_rewrites, allow_jsonp, enable_cors, enable_xframe_options,
+; max_uri_length, changes_timeout, config_whitelist, rewrite_limit,
+; x_forwarded_host, x_forwarded_proto, x_forwarded_ssl, max_http_request_size
 
 ; [httpd_design_handlers]
 ; _view = 
@@ -212,10 +233,33 @@ max_http_request_size = 4294967296 ; 4GB
 ; ratio = 0.01
 
 [ssl]
-port = 6984
+;port = 6984
 
-; [chttpd_auth]
-; authentication_db = _users
+[chttpd_auth]
+;authentication_db = _users
+
+; These options are moved from [couch_httpd_auth]
+;authentication_redirect = /_utils/session.html
+;require_valid_user = false
+;timeout = 600 ; number of seconds before automatic logout
+;auth_cache_size = 50 ; size is number of cache entries
+;allow_persistent_cookies = true ; set to false to disallow persistent cookies
+;iterations = 10 ; iterations for password hashing
+;min_iterations = 1
+;max_iterations = 1000000000
+;password_scheme = pbkdf2
+; List of Erlang RegExp or tuples of RegExp and an optional error message.
+; Where a new password must match all RegExp.
+; Example: [{".{10,}", "Password min length is 10 characters."}, "\\d+"]
+;password_regexp = []
+;proxy_use_secret = false
+; comma-separated list of public fields, 404 if empty
+;public_fields =
+;secret =
+;users_db_public = false
+;cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+;same_site =
 
 ; [chttpd_auth_cache]
 ; max_lifetime = 600000
@@ -232,6 +276,7 @@ port = 6984
 ; all_docs_concurrency = 10
 ; changes_duration = 
 ; shard_timeout_factor = 2
+; shard_timeout_min_msec = 100
 ; uuid_prefix_len = 7
 ; request_timeout = 60000
 ; all_docs_timeout = 10000
@@ -263,35 +308,24 @@ port = 6984
 ; WARNING! This only affects the node-local port (5986 by default).
 ; You probably want the settings under [chttpd].
 authentication_db = _users
-authentication_redirect = /_utils/session.html
-require_valid_user = false
-timeout = 600 ; number of seconds before automatic logout
-auth_cache_size = 50 ; size is number of cache entries
-allow_persistent_cookies = true ; set to false to disallow persistent cookies
-iterations = 10 ; iterations for password hashing
-; min_iterations = 1
-; max_iterations = 1000000000
-; password_scheme = pbkdf2
-; proxy_use_secret = false
-; comma-separated list of public fields, 404 if empty
-; public_fields =
-; secret = 
-; users_db_public = false
-; cookie_domain = example.com
-; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
-; same_site =
+
+; These settings were moved to [chttpd_auth]
+; authentication_redirect, require_valid_user, timeout,
+; auth_cache_size, allow_persistent_cookies, iterations, min_iterations,
+; max_iterations, password_scheme, password_regexp, proxy_use_secret,
+; public_fields, secret, users_db_public, cookie_domain, same_site
 
 ; CSP (Content Security Policy) Support
 [csp]
 ;utils_enable = true
 ;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
-;attachments_enable = false
+;attachments_enable = true
 ;attachments_header_value = sandbox
-;showlist_enable = false
+;showlist_enable = true
 ;showlist_header_value = sandbox
 
 [cors]
-credentials = false
+;credentials = false
 ; List of origins separated by a comma, * means accept all
 ; Origins must include the scheme: http://example.com
 ; You can't set origins: * and credentials = true at the same time.
@@ -338,8 +372,8 @@ credentials = false
 ; please let us know on the mailing list so we can fine tune the heuristic.
 [query_server_config]
 ; commit_freq = 5
-reduce_limit = true
-os_process_limit = 100
+;reduce_limit = true
+;os_process_limit = 100
 ; os_process_idle_limit = 300
 ; os_process_soft_limit = 100
 ; Timeout for how long a response from a busy view group server can take.
@@ -381,42 +415,42 @@ partitioned||* = true
 ;     First 14 characters are the time in hex. Last 18 are random.
 ;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
 ;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
-algorithm = sequential
+;algorithm = sequential
 ; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
 ; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
-utc_id_suffix =
+;utc_id_suffix =
 # Maximum number of UUIDs retrievable from /_uuids in a single request
-max_count = 1000
+;max_count = 1000
 
 [attachments]
-compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
-compressible_types = text/*, application/javascript, application/json, application/xml
+;compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+;compressible_types = text/*, application/javascript, application/json, application/xml
 
 [replicator]
 ; Random jitter applied on replication job startup (milliseconds)
-startup_jitter = 5000
+;startup_jitter = 5000
 ; Number of actively running replications
-max_jobs = 500
+;max_jobs = 500
 ;Scheduling interval in milliseconds. During each reschedule cycle
-interval = 60000
+;interval = 60000
 ; Maximum number of replications to start and stop during rescheduling.
-max_churn = 20
+;max_churn = 20
 ; More worker processes can give higher network throughput but can also
 ; imply more disk and network IO.
-worker_processes = 4
+;worker_processes = 4
 ; With lower batch sizes checkpoints are done more frequently. Lower batch sizes
 ; also reduce the total amount of used RAM memory.
-worker_batch_size = 500
+;worker_batch_size = 500
 ; Maximum number of HTTP connections per replication.
-http_connections = 20
+;http_connections = 20
 ; HTTP connection timeout per replication.
 ; Even for very fast/reliable networks it might need to be increased if a remote
 ; database is too busy.
-connection_timeout = 30000
+;connection_timeout = 30000
 ; Request timeout
 ;request_timeout = infinity
 ; If a request fails, the replicator will retry it up to N times.
-retries_per_request = 5
+;retries_per_request = 5
 ; Use checkpoints
 ;use_checkpoints = true
 ; Checkpoint interval
@@ -427,7 +461,7 @@ retries_per_request = 5
 ;       {recbuf, integer()}
 ;       {priority, integer()}
 ; See the `inet` Erlang module's man page for the full list of options.
-socket_options = [{keepalive, true}, {nodelay, false}]
+;socket_options = [{keepalive, true}, {nodelay, false}]
 ; Path to a file containing the user's certificate.
 ;cert_file = /full/path/to/server_cert.pem
 ; Path to file containing user's private PEM encoded key.
@@ -435,11 +469,11 @@ socket_options = [{keepalive, true}, {nodelay, false}]
 ; String containing the user's password. Only used if the private keyfile is password protected.
 ;password = somepassword
 ; Set to true to validate peer certificates.
-verify_ssl_certificates = false
+;verify_ssl_certificates = false
 ; File containing a list of peer trusted certificates (in the PEM format).
 ;ssl_trusted_certificates_file = /etc/ssl/certs/ca-certificates.crt
 ; Maximum peer certificate depth (must be set even if certificate validation is off).
-ssl_certificate_max_depth = 3
+;ssl_certificate_max_depth = 3
 ; Maximum document ID length for replication.
 ;max_document_id_length = infinity
 ; How much time to wait before retrying after a missing doc exception. This
@@ -479,6 +513,32 @@ ssl_certificate_max_depth = 3
 ; or 403 response this setting is not needed.
 ;session_refresh_interval_sec = 550
 
+; Usage coefficient decays historic fair share usage every scheduling
+; cycle. The value must be between 0.0 and 1.0. Lower values will
+; ensure historic usage decays quicker and higher values means it will
+; be remembered longer.
+;usage_coeff = 0.5
+
+; Priority coefficient decays all the job priorities such that they slowly
+; drift towards the front of the run queue. This coefficient defines a maximum
+; time window over which this algorithm would operate. For example, if this
+; value is too small (0.1), after a few cycles quite a few jobs would end up at
+; priority 0, and would render this algorithm useless. The default value of
+; 0.98 is picked such that if a job ran for one scheduler cycle, then didn't
+; get to run for 7 hours, it would still have priority > 0. 7 hours was picked
+; as it was close enought to 8 hours which is the default maximum error backoff
+; interval.
+;priority_coeff = 0.98
+
+
+[replicator.shares]
+; Fair share configuration section. More shares result in a higher
+; chance that jobs from that db get to run. The default value is 100,
+; minimum is 1 and maximum is 1000. The configuration may be set even
+; if the database does not exit.
+;_replicator = 100
+
+
 [log]
 ; Possible log levels:
 ;  debug
@@ -491,13 +551,18 @@ ssl_certificate_max_depth = 3
 ;  emergency, emerg
 ;  none
 ;
-level = info
+;level = info
 ;
 ; Set the maximum log message length in bytes that will be
 ; passed through the writer
 ;
 ; max_message_size = 16000
 ;
+; Do not log last message received by terminated process
+; strip_last_msg = true
+;
+; List of fields to remove before logging the crash report
+; filter_fields = [pid, registered_name, error_info, messages]
 ;
 ; There are four different log writers that can be configured
 ; to write log messages. The default writes to stderr of the
@@ -509,7 +574,7 @@ level = info
 ; over the network, and a journald writer that's more suitable
 ; when using systemd journald.
 ;
-writer = stderr
+;writer = stderr
 ; Journald Writer notes:
 ;
 ; The journald writer doesn't have any options. It still writes
@@ -569,19 +634,19 @@ writer = stderr
 ;
 ;[smoosh.slack_dbs]
 ;priority = slack
-;min_priority = 16777216
+;min_priority = 536870912
 ;
 ;[smoosh.slack_views]
 ;priority = slack
-;min_priority = 16777216
+;min_priority = 536870912
 
 [ioq]
 ; The maximum number of concurrent in-flight IO requests that
-concurrency = 10
+;concurrency = 10
 
 ; The fraction of the time that a background IO request will be selected
 ; over an interactive IO request when both queues are non-empty
-ratio = 0.01
+;ratio = 0.01
 
 [ioq.bypass]
 ; System administrators can choose to submit specific classes of IO directly
@@ -591,23 +656,23 @@ ratio = 0.01
 ; classes are recognized with the following defaults:
 
 ; Messages on their way to an external process (e.g., couchjs) are bypassed
-os_process = true
+;os_process = true
 
 ; Disk IO fulfilling interactive read requests is bypassed
-read = true
+;read = true
 
 ; Disk IO required to update a database is bypassed
-write = true
+;write = true
 
 ; Disk IO required to update views and other secondary indexes is bypassed
-view_update = true
+;view_update = true
 
 ; Disk IO issued by the background replication processes that fix any
 ; inconsistencies between shard copies is queued
-shard_sync = false
+;shard_sync = false
 
 ; Disk IO issued by compaction jobs is queued
-compaction = false
+;compaction = false
 
 [dreyfus]
 ; The name and location of the Clouseau Java service required to
@@ -648,3 +713,8 @@ compaction = false
 ;source_close_timeout_sec = 600
 ;require_node_param = false
 ;require_range_param = false
+
+[prometheus]
+additional_port = false
+bind_address = 127.0.0.1
+port = 17986

--- a/couchdb/deploy
+++ b/couchdb/deploy
@@ -19,7 +19,7 @@ deploy_couchdb_sw()
 
   case $variant in
     default )
-      deploy_pkg -l couchdb -a couchdb/hmackey.ini -a couchdb/couch_creds comp external+couchdb31
+      deploy_pkg -l couchdb -a couchdb/hmackey.ini -a couchdb/couch_creds comp external+couchdb
       $authlink || setgroup ug+rx,o-rwx _config $project_auth/hmackey.ini
       $authlink || setgroup ug+rx,o-rwx _config $project_auth/couch_creds
       ;;

--- a/couchdb/local.ini
+++ b/couchdb/local.ini
@@ -26,6 +26,7 @@ os_process_timeout=240000
 single_node=true
 ; any user can perform read and writes to the databases
 default_security = everyone
+max_dbs_open = 500
 
 [compactions]
 _default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]

--- a/couchdb/manage
+++ b/couchdb/manage
@@ -227,8 +227,8 @@ start()
 stop()
 {
   echo "Stopping CouchDB service..."
-  # FIXME: grepping for couchdb31 is fragile!!!
-  for couch_pid in $(ps aux | grep couchdb31 | grep -v grep | awk '{print $2}'); do
+  # FIXME: grepping for couchdb is fragile!!!
+  for couch_pid in $(ps aux | grep couchdb | grep -v grep | awk '{print $2}'); do
     echo "  killing CouchDB process... ${pid}"
     kill -9 $couch_pid || true
   done

--- a/tier0/default.ini
+++ b/tier0/default.ini
@@ -8,8 +8,14 @@ database_dir = ./data
 view_index_dir = ./data
 ; util_driver_dir =
 ; plugin_dir =
-os_process_timeout = 5000 ; 5 seconds. for view servers.
-max_dbs_open = 500
+;os_process_timeout = 5000 ; 5 seconds. for view servers.
+
+; Maximum number of .couch files to open at once.
+; The actual limit may be slightly lower depending on how
+; many schedulers you have as the allowance is divided evenly
+; among them.
+;max_dbs_open = 500
+
 ; Method used to compress everything that is appended to database and view index files, except
 ; for attachments (see the attachments section). Available methods are:
 ;
@@ -17,17 +23,17 @@ max_dbs_open = 500
 ; snappy       - use google snappy, a very fast compressor/decompressor
 ; deflate_N    - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
 ;                lowest compression ratio) to 9 (slowest, highest compression ratio)
-file_compression = snappy
+;file_compression = snappy
 ; Higher values may give better read performance due to less read operations
 ; and/or more OS page cache hits, but they can also increase overall response
 ; time for writes when there are many attachment write requests in parallel.
-attachment_stream_buffer_size = 4096
+;attachment_stream_buffer_size = 4096
 ; Default security object for databases if not explicitly set
 ; everyone - same as couchdb 1.0, everyone can read/write
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_only
+;default_security = admin_only
 ; btree_chunk_size = 1279
 ; maintenance_mode = false
 ; stem_interactive_updates = true
@@ -35,28 +41,26 @@ default_security = admin_only
 ; The speed of processing the _changes feed with doc_ids filter can be
 ; influenced directly with this setting - increase for faster processing at the
 ; expense of more memory usage.
-changes_doc_ids_optimization_threshold = 100
+;changes_doc_ids_optimization_threshold = 100
 ; Maximum document ID length. Can be set to an integer or 'infinity'.
 ;max_document_id_length = infinity
 ;
 ; Limit maximum document size. Requests to create / update documents with a body
 ; size larger than this will fail with a 413 http error. This limit applies to
 ; requests which update a single document as well as individual documents from
-; a _bulk_docs request. Since there is no canonical size of json encoded data,
-; due to variabiliy in what is escaped or how floats are encoded, this limit is
-; applied conservatively. For example 1.0e+16 could be encoded as 1e16, so 4 used
-; for size calculation instead of 7.
-max_document_size = 8000000 ; bytes
+; a _bulk_docs request. The size limit is approximate due to the nature of JSON
+; encoding.
+;max_document_size = 8000000 ; bytes
 ;
 ; Maximum attachment size.
-; max_attachment_size = infinity
+; max_attachment_size = 1073741824 ; 1 gibibyte
 ;
 ; Do not update the least recently used DB cache on reads, only writes
 ;update_lru_on_read = false
 ;
 ; The default storage engine to use when creating databases
 ; is set as a key into the [couchdb_engines] section.
-default_engine = couch
+;default_engine = couch
 ;
 ; Enable this to only "soft-delete" databases when DELETE /{db} requests are
 ; made. This will place a .recovery directory in your data directory and
@@ -74,7 +78,7 @@ default_engine = couch
 ;single_node = false
 
 ; Allow edits on the _security object in the user db. By default, it's disabled.
-users_db_security_editable = false
+;users_db_security_editable = false
 
 [purge]
 ; Allowed maximum number of documents in one purge request
@@ -102,8 +106,8 @@ couch = couch_bt_engine
 ;couch_server = false
 
 [cluster]
-q=2
-n=3
+;q=2
+;n=3
 ; placement = metro-dc-a:2,metro-dc-b:1
 
 ; Supply a comma-delimited list of node names that this node should
@@ -117,18 +121,18 @@ n=3
 ; These settings affect the main, clustered port (5984 by default).
 port = 5984
 bind_address = 127.0.0.1
-backlog = 512
-socket_options = [{sndbuf, 262144}, {nodelay, true}]
-server_options = [{recbuf, undefined}]
-require_valid_user = false
+;backlog = 512
+;socket_options = [{sndbuf, 262144}, {nodelay, true}]
+;server_options = [{recbuf, undefined}]
+;require_valid_user = false
 ; require_valid_user_except_for_up = false
 ; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
 ; If Server header is left out, Mochiweb will add its own one in.
-prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
 ;
 ; Limit maximum number of databases when tying to get detailed information using
 ; _dbs_info in a request
-max_db_number_for_dbs_info_req = 100
+;max_db_number_for_dbs_info_req = 100
 
 ; set to true to delay the start of a response until the end has been calculated
 ;buffer_response = false
@@ -143,9 +147,35 @@ max_db_number_for_dbs_info_req = 100
 ; prevent non-admins from accessing /_all_dbs
 ; admin_only_all_dbs = true
 
+; These options are moved from [httpd]
+;secure_rewrites = true
+;allow_jsonp = false
+
+;enable_cors = false
+;enable_xframe_options = false
+
+; CouchDB can optionally enforce a maximum uri length;
+;max_uri_length = 8000
+
+;changes_timeout = 60000
+;config_whitelist =
+;rewrite_limit = 100
+;x_forwarded_host = X-Forwarded-Host
+;x_forwarded_proto = X-Forwarded-Proto
+;x_forwarded_ssl = X-Forwarded-Ssl
+
+; Maximum allowed http request size. Applies to both clustered and local port.
+;max_http_request_size = 4294967296 ; 4GB
+
+; Set to true to decode + to space in db and doc_id parts.
+; decode_plus_to_space = true
+
 ;[jwt_auth]
 ; List of claims to validate
-; required_claims =
+; can be the name of a claim like "exp" or a tuple if the claim requires
+; a parameter
+; required_claims = exp, {iss, "IssuerNameHere"}
+; roles_claim_name = https://example.com/roles
 ;
 ; [jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.
@@ -167,42 +197,33 @@ max_db_number_for_dbs_info_req = 100
 ; exists for each document in _users. These databases are writable only
 ; by the corresponding user. Databases are in the following form:
 ; userdb-{hex encoded username}
-enable = false
+;enable = false
 ; If set to true and a user is deleted, the respective database gets
 ; deleted as well.
-delete_dbs = false
+;delete_dbs = false
 ; Set a default q value for peruser-created databases that is different from
 ; cluster / q
 ;q = 1
 ; prefix for user databases. If you change this after user dbs have been
 ; created, the existing databases won't get deleted if the associated user
 ; gets deleted because of the then prefix mismatch.
-database_prefix = userdb-
+;database_prefix = userdb-
 
 [httpd]
 port = 5986
 bind_address = 127.0.0.1
-authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
-secure_rewrites = true
-allow_jsonp = false
+;authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+
 ; Options for the MochiWeb HTTP server.
 ;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
-socket_options = [{sndbuf, 262144}]
-enable_cors = false
-enable_xframe_options = false
-; CouchDB can optionally enforce a maximum uri length;
-; max_uri_length = 8000
-; changes_timeout = 60000
-; config_whitelist = 
-; max_uri_length = 
-; rewrite_limit = 100
-; x_forwarded_host = X-Forwarded-Host
-; x_forwarded_proto = X-Forwarded-Proto
-; x_forwarded_ssl = X-Forwarded-Ssl
-; Maximum allowed http request size. Applies to both clustered and local port.
-max_http_request_size = 4294967296 ; 4GB
+;socket_options = [{sndbuf, 262144}]
+
+; These settings were moved to [chttpd]
+; secure_rewrites, allow_jsonp, enable_cors, enable_xframe_options,
+; max_uri_length, changes_timeout, config_whitelist, rewrite_limit,
+; x_forwarded_host, x_forwarded_proto, x_forwarded_ssl, max_http_request_size
 
 ; [httpd_design_handlers]
 ; _view = 
@@ -212,10 +233,33 @@ max_http_request_size = 4294967296 ; 4GB
 ; ratio = 0.01
 
 [ssl]
-port = 6984
+;port = 6984
 
-; [chttpd_auth]
-; authentication_db = _users
+[chttpd_auth]
+;authentication_db = _users
+
+; These options are moved from [couch_httpd_auth]
+;authentication_redirect = /_utils/session.html
+;require_valid_user = false
+;timeout = 600 ; number of seconds before automatic logout
+;auth_cache_size = 50 ; size is number of cache entries
+;allow_persistent_cookies = true ; set to false to disallow persistent cookies
+;iterations = 10 ; iterations for password hashing
+;min_iterations = 1
+;max_iterations = 1000000000
+;password_scheme = pbkdf2
+; List of Erlang RegExp or tuples of RegExp and an optional error message.
+; Where a new password must match all RegExp.
+; Example: [{".{10,}", "Password min length is 10 characters."}, "\\d+"]
+;password_regexp = []
+;proxy_use_secret = false
+; comma-separated list of public fields, 404 if empty
+;public_fields =
+;secret =
+;users_db_public = false
+;cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+;same_site =
 
 ; [chttpd_auth_cache]
 ; max_lifetime = 600000
@@ -232,6 +276,7 @@ port = 6984
 ; all_docs_concurrency = 10
 ; changes_duration = 
 ; shard_timeout_factor = 2
+; shard_timeout_min_msec = 100
 ; uuid_prefix_len = 7
 ; request_timeout = 60000
 ; all_docs_timeout = 10000
@@ -263,35 +308,24 @@ port = 6984
 ; WARNING! This only affects the node-local port (5986 by default).
 ; You probably want the settings under [chttpd].
 authentication_db = _users
-authentication_redirect = /_utils/session.html
-require_valid_user = false
-timeout = 600 ; number of seconds before automatic logout
-auth_cache_size = 50 ; size is number of cache entries
-allow_persistent_cookies = true ; set to false to disallow persistent cookies
-iterations = 10 ; iterations for password hashing
-; min_iterations = 1
-; max_iterations = 1000000000
-; password_scheme = pbkdf2
-; proxy_use_secret = false
-; comma-separated list of public fields, 404 if empty
-; public_fields =
-; secret = 
-; users_db_public = false
-; cookie_domain = example.com
-; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
-; same_site =
+
+; These settings were moved to [chttpd_auth]
+; authentication_redirect, require_valid_user, timeout,
+; auth_cache_size, allow_persistent_cookies, iterations, min_iterations,
+; max_iterations, password_scheme, password_regexp, proxy_use_secret,
+; public_fields, secret, users_db_public, cookie_domain, same_site
 
 ; CSP (Content Security Policy) Support
 [csp]
 ;utils_enable = true
 ;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
-;attachments_enable = false
+;attachments_enable = true
 ;attachments_header_value = sandbox
-;showlist_enable = false
+;showlist_enable = true
 ;showlist_header_value = sandbox
 
 [cors]
-credentials = false
+;credentials = false
 ; List of origins separated by a comma, * means accept all
 ; Origins must include the scheme: http://example.com
 ; You can't set origins: * and credentials = true at the same time.
@@ -338,8 +372,8 @@ credentials = false
 ; please let us know on the mailing list so we can fine tune the heuristic.
 [query_server_config]
 ; commit_freq = 5
-reduce_limit = true
-os_process_limit = 100
+;reduce_limit = true
+;os_process_limit = 100
 ; os_process_idle_limit = 300
 ; os_process_soft_limit = 100
 ; Timeout for how long a response from a busy view group server can take.
@@ -381,42 +415,42 @@ partitioned||* = true
 ;     First 14 characters are the time in hex. Last 18 are random.
 ;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
 ;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
-algorithm = sequential
+;algorithm = sequential
 ; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
 ; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
-utc_id_suffix =
+;utc_id_suffix =
 # Maximum number of UUIDs retrievable from /_uuids in a single request
-max_count = 1000
+;max_count = 1000
 
 [attachments]
-compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
-compressible_types = text/*, application/javascript, application/json, application/xml
+;compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+;compressible_types = text/*, application/javascript, application/json, application/xml
 
 [replicator]
 ; Random jitter applied on replication job startup (milliseconds)
-startup_jitter = 5000
+;startup_jitter = 5000
 ; Number of actively running replications
-max_jobs = 500
+;max_jobs = 500
 ;Scheduling interval in milliseconds. During each reschedule cycle
-interval = 60000
+;interval = 60000
 ; Maximum number of replications to start and stop during rescheduling.
-max_churn = 20
+;max_churn = 20
 ; More worker processes can give higher network throughput but can also
 ; imply more disk and network IO.
-worker_processes = 4
+;worker_processes = 4
 ; With lower batch sizes checkpoints are done more frequently. Lower batch sizes
 ; also reduce the total amount of used RAM memory.
-worker_batch_size = 500
+;worker_batch_size = 500
 ; Maximum number of HTTP connections per replication.
-http_connections = 20
+;http_connections = 20
 ; HTTP connection timeout per replication.
 ; Even for very fast/reliable networks it might need to be increased if a remote
 ; database is too busy.
-connection_timeout = 30000
+;connection_timeout = 30000
 ; Request timeout
 ;request_timeout = infinity
 ; If a request fails, the replicator will retry it up to N times.
-retries_per_request = 5
+;retries_per_request = 5
 ; Use checkpoints
 ;use_checkpoints = true
 ; Checkpoint interval
@@ -427,7 +461,7 @@ retries_per_request = 5
 ;       {recbuf, integer()}
 ;       {priority, integer()}
 ; See the `inet` Erlang module's man page for the full list of options.
-socket_options = [{keepalive, true}, {nodelay, false}]
+;socket_options = [{keepalive, true}, {nodelay, false}]
 ; Path to a file containing the user's certificate.
 ;cert_file = /full/path/to/server_cert.pem
 ; Path to file containing user's private PEM encoded key.
@@ -435,11 +469,11 @@ socket_options = [{keepalive, true}, {nodelay, false}]
 ; String containing the user's password. Only used if the private keyfile is password protected.
 ;password = somepassword
 ; Set to true to validate peer certificates.
-verify_ssl_certificates = false
+;verify_ssl_certificates = false
 ; File containing a list of peer trusted certificates (in the PEM format).
 ;ssl_trusted_certificates_file = /etc/ssl/certs/ca-certificates.crt
 ; Maximum peer certificate depth (must be set even if certificate validation is off).
-ssl_certificate_max_depth = 3
+;ssl_certificate_max_depth = 3
 ; Maximum document ID length for replication.
 ;max_document_id_length = infinity
 ; How much time to wait before retrying after a missing doc exception. This
@@ -479,6 +513,32 @@ ssl_certificate_max_depth = 3
 ; or 403 response this setting is not needed.
 ;session_refresh_interval_sec = 550
 
+; Usage coefficient decays historic fair share usage every scheduling
+; cycle. The value must be between 0.0 and 1.0. Lower values will
+; ensure historic usage decays quicker and higher values means it will
+; be remembered longer.
+;usage_coeff = 0.5
+
+; Priority coefficient decays all the job priorities such that they slowly
+; drift towards the front of the run queue. This coefficient defines a maximum
+; time window over which this algorithm would operate. For example, if this
+; value is too small (0.1), after a few cycles quite a few jobs would end up at
+; priority 0, and would render this algorithm useless. The default value of
+; 0.98 is picked such that if a job ran for one scheduler cycle, then didn't
+; get to run for 7 hours, it would still have priority > 0. 7 hours was picked
+; as it was close enought to 8 hours which is the default maximum error backoff
+; interval.
+;priority_coeff = 0.98
+
+
+[replicator.shares]
+; Fair share configuration section. More shares result in a higher
+; chance that jobs from that db get to run. The default value is 100,
+; minimum is 1 and maximum is 1000. The configuration may be set even
+; if the database does not exit.
+;_replicator = 100
+
+
 [log]
 ; Possible log levels:
 ;  debug
@@ -491,13 +551,18 @@ ssl_certificate_max_depth = 3
 ;  emergency, emerg
 ;  none
 ;
-level = info
+;level = info
 ;
 ; Set the maximum log message length in bytes that will be
 ; passed through the writer
 ;
 ; max_message_size = 16000
 ;
+; Do not log last message received by terminated process
+; strip_last_msg = true
+;
+; List of fields to remove before logging the crash report
+; filter_fields = [pid, registered_name, error_info, messages]
 ;
 ; There are four different log writers that can be configured
 ; to write log messages. The default writes to stderr of the
@@ -509,7 +574,7 @@ level = info
 ; over the network, and a journald writer that's more suitable
 ; when using systemd journald.
 ;
-writer = stderr
+;writer = stderr
 ; Journald Writer notes:
 ;
 ; The journald writer doesn't have any options. It still writes
@@ -569,19 +634,19 @@ writer = stderr
 ;
 ;[smoosh.slack_dbs]
 ;priority = slack
-;min_priority = 16777216
+;min_priority = 536870912
 ;
 ;[smoosh.slack_views]
 ;priority = slack
-;min_priority = 16777216
+;min_priority = 536870912
 
 [ioq]
 ; The maximum number of concurrent in-flight IO requests that
-concurrency = 10
+;concurrency = 10
 
 ; The fraction of the time that a background IO request will be selected
 ; over an interactive IO request when both queues are non-empty
-ratio = 0.01
+;ratio = 0.01
 
 [ioq.bypass]
 ; System administrators can choose to submit specific classes of IO directly
@@ -591,23 +656,23 @@ ratio = 0.01
 ; classes are recognized with the following defaults:
 
 ; Messages on their way to an external process (e.g., couchjs) are bypassed
-os_process = true
+;os_process = true
 
 ; Disk IO fulfilling interactive read requests is bypassed
-read = true
+;read = true
 
 ; Disk IO required to update a database is bypassed
-write = true
+;write = true
 
 ; Disk IO required to update views and other secondary indexes is bypassed
-view_update = true
+;view_update = true
 
 ; Disk IO issued by the background replication processes that fix any
 ; inconsistencies between shard copies is queued
-shard_sync = false
+;shard_sync = false
 
 ; Disk IO issued by compaction jobs is queued
-compaction = false
+;compaction = false
 
 [dreyfus]
 ; The name and location of the Clouseau Java service required to
@@ -648,3 +713,8 @@ compaction = false
 ;source_close_timeout_sec = 600
 ;require_node_param = false
 ;require_range_param = false
+
+[prometheus]
+additional_port = false
+bind_address = 127.0.0.1
+port = 17986

--- a/tier0/local.ini
+++ b/tier0/local.ini
@@ -15,6 +15,7 @@ os_process_timeout = 1000000
 ; single node is only for test purposes, otherwise it will work just like CouchDB 1.x
 ; for now, define it in the default config such that _users, _replicator and _global_changes databases are automatically created
 single_node=true
+max_dbs_open = 500
 
 [log]
 level = info

--- a/wmagentpy3/default.ini
+++ b/wmagentpy3/default.ini
@@ -8,8 +8,14 @@ database_dir = ./data
 view_index_dir = ./data
 ; util_driver_dir =
 ; plugin_dir =
-os_process_timeout = 5000 ; 5 seconds. for view servers.
-max_dbs_open = 500
+;os_process_timeout = 5000 ; 5 seconds. for view servers.
+
+; Maximum number of .couch files to open at once.
+; The actual limit may be slightly lower depending on how
+; many schedulers you have as the allowance is divided evenly
+; among them.
+;max_dbs_open = 500
+
 ; Method used to compress everything that is appended to database and view index files, except
 ; for attachments (see the attachments section). Available methods are:
 ;
@@ -17,17 +23,17 @@ max_dbs_open = 500
 ; snappy       - use google snappy, a very fast compressor/decompressor
 ; deflate_N    - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
 ;                lowest compression ratio) to 9 (slowest, highest compression ratio)
-file_compression = snappy
+;file_compression = snappy
 ; Higher values may give better read performance due to less read operations
 ; and/or more OS page cache hits, but they can also increase overall response
 ; time for writes when there are many attachment write requests in parallel.
-attachment_stream_buffer_size = 4096
+;attachment_stream_buffer_size = 4096
 ; Default security object for databases if not explicitly set
 ; everyone - same as couchdb 1.0, everyone can read/write
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_only
+;default_security = admin_only
 ; btree_chunk_size = 1279
 ; maintenance_mode = false
 ; stem_interactive_updates = true
@@ -35,28 +41,26 @@ default_security = admin_only
 ; The speed of processing the _changes feed with doc_ids filter can be
 ; influenced directly with this setting - increase for faster processing at the
 ; expense of more memory usage.
-changes_doc_ids_optimization_threshold = 100
+;changes_doc_ids_optimization_threshold = 100
 ; Maximum document ID length. Can be set to an integer or 'infinity'.
 ;max_document_id_length = infinity
 ;
 ; Limit maximum document size. Requests to create / update documents with a body
 ; size larger than this will fail with a 413 http error. This limit applies to
 ; requests which update a single document as well as individual documents from
-; a _bulk_docs request. Since there is no canonical size of json encoded data,
-; due to variabiliy in what is escaped or how floats are encoded, this limit is
-; applied conservatively. For example 1.0e+16 could be encoded as 1e16, so 4 used
-; for size calculation instead of 7.
-max_document_size = 8000000 ; bytes
+; a _bulk_docs request. The size limit is approximate due to the nature of JSON
+; encoding.
+;max_document_size = 8000000 ; bytes
 ;
 ; Maximum attachment size.
-; max_attachment_size = infinity
+; max_attachment_size = 1073741824 ; 1 gibibyte
 ;
 ; Do not update the least recently used DB cache on reads, only writes
 ;update_lru_on_read = false
 ;
 ; The default storage engine to use when creating databases
 ; is set as a key into the [couchdb_engines] section.
-default_engine = couch
+;default_engine = couch
 ;
 ; Enable this to only "soft-delete" databases when DELETE /{db} requests are
 ; made. This will place a .recovery directory in your data directory and
@@ -74,7 +78,7 @@ default_engine = couch
 ;single_node = false
 
 ; Allow edits on the _security object in the user db. By default, it's disabled.
-users_db_security_editable = false
+;users_db_security_editable = false
 
 [purge]
 ; Allowed maximum number of documents in one purge request
@@ -102,8 +106,8 @@ couch = couch_bt_engine
 ;couch_server = false
 
 [cluster]
-q=2
-n=3
+;q=2
+;n=3
 ; placement = metro-dc-a:2,metro-dc-b:1
 
 ; Supply a comma-delimited list of node names that this node should
@@ -117,18 +121,18 @@ n=3
 ; These settings affect the main, clustered port (5984 by default).
 port = 5984
 bind_address = 127.0.0.1
-backlog = 512
-socket_options = [{sndbuf, 262144}, {nodelay, true}]
-server_options = [{recbuf, undefined}]
-require_valid_user = false
+;backlog = 512
+;socket_options = [{sndbuf, 262144}, {nodelay, true}]
+;server_options = [{recbuf, undefined}]
+;require_valid_user = false
 ; require_valid_user_except_for_up = false
 ; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
 ; If Server header is left out, Mochiweb will add its own one in.
-prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
 ;
 ; Limit maximum number of databases when tying to get detailed information using
 ; _dbs_info in a request
-max_db_number_for_dbs_info_req = 100
+;max_db_number_for_dbs_info_req = 100
 
 ; set to true to delay the start of a response until the end has been calculated
 ;buffer_response = false
@@ -143,9 +147,35 @@ max_db_number_for_dbs_info_req = 100
 ; prevent non-admins from accessing /_all_dbs
 ; admin_only_all_dbs = true
 
+; These options are moved from [httpd]
+;secure_rewrites = true
+;allow_jsonp = false
+
+;enable_cors = false
+;enable_xframe_options = false
+
+; CouchDB can optionally enforce a maximum uri length;
+;max_uri_length = 8000
+
+;changes_timeout = 60000
+;config_whitelist =
+;rewrite_limit = 100
+;x_forwarded_host = X-Forwarded-Host
+;x_forwarded_proto = X-Forwarded-Proto
+;x_forwarded_ssl = X-Forwarded-Ssl
+
+; Maximum allowed http request size. Applies to both clustered and local port.
+;max_http_request_size = 4294967296 ; 4GB
+
+; Set to true to decode + to space in db and doc_id parts.
+; decode_plus_to_space = true
+
 ;[jwt_auth]
 ; List of claims to validate
-; required_claims =
+; can be the name of a claim like "exp" or a tuple if the claim requires
+; a parameter
+; required_claims = exp, {iss, "IssuerNameHere"}
+; roles_claim_name = https://example.com/roles
 ;
 ; [jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.
@@ -167,42 +197,33 @@ max_db_number_for_dbs_info_req = 100
 ; exists for each document in _users. These databases are writable only
 ; by the corresponding user. Databases are in the following form:
 ; userdb-{hex encoded username}
-enable = false
+;enable = false
 ; If set to true and a user is deleted, the respective database gets
 ; deleted as well.
-delete_dbs = false
+;delete_dbs = false
 ; Set a default q value for peruser-created databases that is different from
 ; cluster / q
 ;q = 1
 ; prefix for user databases. If you change this after user dbs have been
 ; created, the existing databases won't get deleted if the associated user
 ; gets deleted because of the then prefix mismatch.
-database_prefix = userdb-
+;database_prefix = userdb-
 
 [httpd]
 port = 5986
 bind_address = 127.0.0.1
-authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
-secure_rewrites = true
-allow_jsonp = false
+;authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+
 ; Options for the MochiWeb HTTP server.
 ;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
-socket_options = [{sndbuf, 262144}]
-enable_cors = false
-enable_xframe_options = false
-; CouchDB can optionally enforce a maximum uri length;
-; max_uri_length = 8000
-; changes_timeout = 60000
-; config_whitelist = 
-; max_uri_length = 
-; rewrite_limit = 100
-; x_forwarded_host = X-Forwarded-Host
-; x_forwarded_proto = X-Forwarded-Proto
-; x_forwarded_ssl = X-Forwarded-Ssl
-; Maximum allowed http request size. Applies to both clustered and local port.
-max_http_request_size = 4294967296 ; 4GB
+;socket_options = [{sndbuf, 262144}]
+
+; These settings were moved to [chttpd]
+; secure_rewrites, allow_jsonp, enable_cors, enable_xframe_options,
+; max_uri_length, changes_timeout, config_whitelist, rewrite_limit,
+; x_forwarded_host, x_forwarded_proto, x_forwarded_ssl, max_http_request_size
 
 ; [httpd_design_handlers]
 ; _view = 
@@ -212,10 +233,33 @@ max_http_request_size = 4294967296 ; 4GB
 ; ratio = 0.01
 
 [ssl]
-port = 6984
+;port = 6984
 
-; [chttpd_auth]
-; authentication_db = _users
+[chttpd_auth]
+;authentication_db = _users
+
+; These options are moved from [couch_httpd_auth]
+;authentication_redirect = /_utils/session.html
+;require_valid_user = false
+;timeout = 600 ; number of seconds before automatic logout
+;auth_cache_size = 50 ; size is number of cache entries
+;allow_persistent_cookies = true ; set to false to disallow persistent cookies
+;iterations = 10 ; iterations for password hashing
+;min_iterations = 1
+;max_iterations = 1000000000
+;password_scheme = pbkdf2
+; List of Erlang RegExp or tuples of RegExp and an optional error message.
+; Where a new password must match all RegExp.
+; Example: [{".{10,}", "Password min length is 10 characters."}, "\\d+"]
+;password_regexp = []
+;proxy_use_secret = false
+; comma-separated list of public fields, 404 if empty
+;public_fields =
+;secret =
+;users_db_public = false
+;cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+;same_site =
 
 ; [chttpd_auth_cache]
 ; max_lifetime = 600000
@@ -232,6 +276,7 @@ port = 6984
 ; all_docs_concurrency = 10
 ; changes_duration = 
 ; shard_timeout_factor = 2
+; shard_timeout_min_msec = 100
 ; uuid_prefix_len = 7
 ; request_timeout = 60000
 ; all_docs_timeout = 10000
@@ -263,35 +308,24 @@ port = 6984
 ; WARNING! This only affects the node-local port (5986 by default).
 ; You probably want the settings under [chttpd].
 authentication_db = _users
-authentication_redirect = /_utils/session.html
-require_valid_user = false
-timeout = 600 ; number of seconds before automatic logout
-auth_cache_size = 50 ; size is number of cache entries
-allow_persistent_cookies = true ; set to false to disallow persistent cookies
-iterations = 10 ; iterations for password hashing
-; min_iterations = 1
-; max_iterations = 1000000000
-; password_scheme = pbkdf2
-; proxy_use_secret = false
-; comma-separated list of public fields, 404 if empty
-; public_fields =
-; secret = 
-; users_db_public = false
-; cookie_domain = example.com
-; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
-; same_site =
+
+; These settings were moved to [chttpd_auth]
+; authentication_redirect, require_valid_user, timeout,
+; auth_cache_size, allow_persistent_cookies, iterations, min_iterations,
+; max_iterations, password_scheme, password_regexp, proxy_use_secret,
+; public_fields, secret, users_db_public, cookie_domain, same_site
 
 ; CSP (Content Security Policy) Support
 [csp]
 ;utils_enable = true
 ;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
-;attachments_enable = false
+;attachments_enable = true
 ;attachments_header_value = sandbox
-;showlist_enable = false
+;showlist_enable = true
 ;showlist_header_value = sandbox
 
 [cors]
-credentials = false
+;credentials = false
 ; List of origins separated by a comma, * means accept all
 ; Origins must include the scheme: http://example.com
 ; You can't set origins: * and credentials = true at the same time.
@@ -338,8 +372,8 @@ credentials = false
 ; please let us know on the mailing list so we can fine tune the heuristic.
 [query_server_config]
 ; commit_freq = 5
-reduce_limit = true
-os_process_limit = 100
+;reduce_limit = true
+;os_process_limit = 100
 ; os_process_idle_limit = 300
 ; os_process_soft_limit = 100
 ; Timeout for how long a response from a busy view group server can take.
@@ -381,42 +415,42 @@ partitioned||* = true
 ;     First 14 characters are the time in hex. Last 18 are random.
 ;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
 ;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
-algorithm = sequential
+;algorithm = sequential
 ; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
 ; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
-utc_id_suffix =
+;utc_id_suffix =
 # Maximum number of UUIDs retrievable from /_uuids in a single request
-max_count = 1000
+;max_count = 1000
 
 [attachments]
-compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
-compressible_types = text/*, application/javascript, application/json, application/xml
+;compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+;compressible_types = text/*, application/javascript, application/json, application/xml
 
 [replicator]
 ; Random jitter applied on replication job startup (milliseconds)
-startup_jitter = 5000
+;startup_jitter = 5000
 ; Number of actively running replications
-max_jobs = 500
+;max_jobs = 500
 ;Scheduling interval in milliseconds. During each reschedule cycle
-interval = 60000
+;interval = 60000
 ; Maximum number of replications to start and stop during rescheduling.
-max_churn = 20
+;max_churn = 20
 ; More worker processes can give higher network throughput but can also
 ; imply more disk and network IO.
-worker_processes = 4
+;worker_processes = 4
 ; With lower batch sizes checkpoints are done more frequently. Lower batch sizes
 ; also reduce the total amount of used RAM memory.
-worker_batch_size = 500
+;worker_batch_size = 500
 ; Maximum number of HTTP connections per replication.
-http_connections = 20
+;http_connections = 20
 ; HTTP connection timeout per replication.
 ; Even for very fast/reliable networks it might need to be increased if a remote
 ; database is too busy.
-connection_timeout = 30000
+;connection_timeout = 30000
 ; Request timeout
 ;request_timeout = infinity
 ; If a request fails, the replicator will retry it up to N times.
-retries_per_request = 5
+;retries_per_request = 5
 ; Use checkpoints
 ;use_checkpoints = true
 ; Checkpoint interval
@@ -427,7 +461,7 @@ retries_per_request = 5
 ;       {recbuf, integer()}
 ;       {priority, integer()}
 ; See the `inet` Erlang module's man page for the full list of options.
-socket_options = [{keepalive, true}, {nodelay, false}]
+;socket_options = [{keepalive, true}, {nodelay, false}]
 ; Path to a file containing the user's certificate.
 ;cert_file = /full/path/to/server_cert.pem
 ; Path to file containing user's private PEM encoded key.
@@ -435,11 +469,11 @@ socket_options = [{keepalive, true}, {nodelay, false}]
 ; String containing the user's password. Only used if the private keyfile is password protected.
 ;password = somepassword
 ; Set to true to validate peer certificates.
-verify_ssl_certificates = false
+;verify_ssl_certificates = false
 ; File containing a list of peer trusted certificates (in the PEM format).
 ;ssl_trusted_certificates_file = /etc/ssl/certs/ca-certificates.crt
 ; Maximum peer certificate depth (must be set even if certificate validation is off).
-ssl_certificate_max_depth = 3
+;ssl_certificate_max_depth = 3
 ; Maximum document ID length for replication.
 ;max_document_id_length = infinity
 ; How much time to wait before retrying after a missing doc exception. This
@@ -479,6 +513,32 @@ ssl_certificate_max_depth = 3
 ; or 403 response this setting is not needed.
 ;session_refresh_interval_sec = 550
 
+; Usage coefficient decays historic fair share usage every scheduling
+; cycle. The value must be between 0.0 and 1.0. Lower values will
+; ensure historic usage decays quicker and higher values means it will
+; be remembered longer.
+;usage_coeff = 0.5
+
+; Priority coefficient decays all the job priorities such that they slowly
+; drift towards the front of the run queue. This coefficient defines a maximum
+; time window over which this algorithm would operate. For example, if this
+; value is too small (0.1), after a few cycles quite a few jobs would end up at
+; priority 0, and would render this algorithm useless. The default value of
+; 0.98 is picked such that if a job ran for one scheduler cycle, then didn't
+; get to run for 7 hours, it would still have priority > 0. 7 hours was picked
+; as it was close enought to 8 hours which is the default maximum error backoff
+; interval.
+;priority_coeff = 0.98
+
+
+[replicator.shares]
+; Fair share configuration section. More shares result in a higher
+; chance that jobs from that db get to run. The default value is 100,
+; minimum is 1 and maximum is 1000. The configuration may be set even
+; if the database does not exit.
+;_replicator = 100
+
+
 [log]
 ; Possible log levels:
 ;  debug
@@ -491,13 +551,18 @@ ssl_certificate_max_depth = 3
 ;  emergency, emerg
 ;  none
 ;
-level = info
+;level = info
 ;
 ; Set the maximum log message length in bytes that will be
 ; passed through the writer
 ;
 ; max_message_size = 16000
 ;
+; Do not log last message received by terminated process
+; strip_last_msg = true
+;
+; List of fields to remove before logging the crash report
+; filter_fields = [pid, registered_name, error_info, messages]
 ;
 ; There are four different log writers that can be configured
 ; to write log messages. The default writes to stderr of the
@@ -509,7 +574,7 @@ level = info
 ; over the network, and a journald writer that's more suitable
 ; when using systemd journald.
 ;
-writer = stderr
+;writer = stderr
 ; Journald Writer notes:
 ;
 ; The journald writer doesn't have any options. It still writes
@@ -569,19 +634,19 @@ writer = stderr
 ;
 ;[smoosh.slack_dbs]
 ;priority = slack
-;min_priority = 16777216
+;min_priority = 536870912
 ;
 ;[smoosh.slack_views]
 ;priority = slack
-;min_priority = 16777216
+;min_priority = 536870912
 
 [ioq]
 ; The maximum number of concurrent in-flight IO requests that
-concurrency = 10
+;concurrency = 10
 
 ; The fraction of the time that a background IO request will be selected
 ; over an interactive IO request when both queues are non-empty
-ratio = 0.01
+;ratio = 0.01
 
 [ioq.bypass]
 ; System administrators can choose to submit specific classes of IO directly
@@ -591,23 +656,23 @@ ratio = 0.01
 ; classes are recognized with the following defaults:
 
 ; Messages on their way to an external process (e.g., couchjs) are bypassed
-os_process = true
+;os_process = true
 
 ; Disk IO fulfilling interactive read requests is bypassed
-read = true
+;read = true
 
 ; Disk IO required to update a database is bypassed
-write = true
+;write = true
 
 ; Disk IO required to update views and other secondary indexes is bypassed
-view_update = true
+;view_update = true
 
 ; Disk IO issued by the background replication processes that fix any
 ; inconsistencies between shard copies is queued
-shard_sync = false
+;shard_sync = false
 
 ; Disk IO issued by compaction jobs is queued
-compaction = false
+;compaction = false
 
 [dreyfus]
 ; The name and location of the Clouseau Java service required to
@@ -648,3 +713,8 @@ compaction = false
 ;source_close_timeout_sec = 600
 ;require_node_param = false
 ;require_range_param = false
+
+[prometheus]
+additional_port = false
+bind_address = 127.0.0.1
+port = 17986

--- a/wmagentpy3/local.ini
+++ b/wmagentpy3/local.ini
@@ -15,6 +15,7 @@ os_process_timeout = 1000000
 ; single node is only for test purposes, otherwise it will work just like CouchDB 1.x
 ; for now, define it in the default config such that _users, _replicator and _global_changes databases are automatically created
 single_node=true
+max_dbs_open = 500
 
 [log]
 level = info


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11222

This updates the CouchDB local.ini file with an increased number of database file descriptors that can be opened at any given time (with the more aggressive database and view compaction, we have seen that the default 100 limit is not enough).

On what concerns the default.ini file, it simply updates it according to what is packaged with CouchDB 3.2.2

UPDATE: second commit updates the usage of `couchdb31`, which has been moved to `couchdb.spec` in the cmsdist repository.