### PR TITLE
Changes to the style of HG PCL Alignment plots

### DIFF
--- a/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
+++ b/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
@@ -173,13 +173,13 @@ private:
       if (fabs(obj->GetBinContent(i)) > maxMoveCut_[i-1]) obj->SetFillColor(kRed);
       else if (obj->GetBinContent(i) > cut_[i-1]){
 
-  if (obj->GetBinError(i) > maxErrorCut_[i-1]){
-    obj->SetFillColor(kRed);
-  }
-  else if (fabs(obj->GetBinContent(i))/obj->GetBinError(i) > sigCut_[i-1]){
+        if (obj->GetBinError(i) > maxErrorCut_[i-1]){
+          obj->SetFillColor(kRed);
+        }
+        else if (fabs(obj->GetBinContent(i))/obj->GetBinError(i) > sigCut_[i-1]){
 
-    obj->SetFillColor(kGreen+3);
-  }
+          obj->SetFillColor(kGreen+3);
+        }
       }
     }
 


### PR DESCRIPTION
#### Changes:

Changed the plotting style for HG PCL Alignment plots.
1. The 2D status plot  is now plotted in COLZ mode
2. The movement plots have thresholds drawn, and information is displayed if the observed movement would trigger an update and if not, why.
3. Some indentation fixes were (accidentally) performed because there was a mix of tabs and spaces in the file.

The changes are related to this PR in CMSSW: https://github.com/cms-sw/cmssw/pull/38815 

#### Validation:

The changes were found to correctly change the style of the targeted plots. It was also confirmed that this does not affect the plots of the LG PCL alignment.


