### PR TITLE
[DT CSC RPC] Adding setup for tag-and-probe plots

### DIFF
--- a/dqmgui/style/CSCRenderPlugin.cc
+++ b/dqmgui/style/CSCRenderPlugin.cc
@@ -22,6 +22,7 @@
 #include "CSCRenderPlugin_EventDisplay.h"
 #include "CSCRenderPlugin_EmuEventDisplay.h"
 #include "CSC_TPE_hAll.h"
+#include "utils.h"
 
 #include <math.h>
 #include <string>
@@ -2802,6 +2803,42 @@ public:
         obj->SetOption("colz");
         return;
       }
+    if (reMatch(".*Segment_TnP/Task/CSC_chamberEff_allCh$", o.name))
+      {
+        TH2* tmp = dynamic_cast<TH2*>(obj);
+        dqm::utils::reportSummaryMapPalette(tmp);
+        tmp->GetXaxis()->SetNdivisions(-9,true);
+        tmp->GetYaxis()->SetNdivisions(-4,true);
+        tmp->SetMinimum(0.);
+        tmp->GetXaxis()->CenterLabels();
+        tmp->GetYaxis()->CenterLabels();
+        tmp->SetOption("text,colz");
+        tmp->SetMarkerSize( 2 );
+        gStyle->SetPaintTextFormat("1.2f");
+        c->SetGrid(1,1);
+        return;
+      }
+    if (reMatch(".*CSC_nFailingProbe_allCh$", o.name) ||
+        reMatch(".*CSC_nPassingProbe_allCh$", o.name))
+      {
+        TH2* tmp = dynamic_cast<TH2*>(obj);
+        tmp->GetXaxis()->SetNdivisions(-9,true);
+        tmp->GetYaxis()->SetNdivisions(-4,true);
+        tmp->SetMinimum(0.);
+        tmp->GetXaxis()->CenterLabels();
+        tmp->GetYaxis()->CenterLabels();
+        tmp->SetOption("colz");
+        c->SetGrid(1,1);
+        return;
+      }
+
+    if (reMatch(".*CSC_chamberEff_allCh_1D$", o.name))
+      {
+        obj->SetMinimum(0.);
+        c->SetGrid(1,1);
+        return;
+      }
+
 
   }
 

--- a/dqmgui/style/DTRenderPlugin.cc
+++ b/dqmgui/style/DTRenderPlugin.cc
@@ -45,6 +45,7 @@ public:
          (o.name.find( "DT/B" ) != std::string::npos) ||
          (o.name.find( "DT/C" ) != std::string::npos) ||
          (o.name.find( "DT/L" ) != std::string::npos) ||
+	 (o.name.find( "DT/Segment_TnP" ) != std::string::npos) ||
          (o.name.find( "Everything/AlCaReco/DtCalibSynch/0" ) != std::string::npos))
         return true;
 
@@ -968,6 +969,21 @@ private:
         return;
       }
 
+      if( o.name.find( "DT_chamberEff_W" ) != std::string::npos )
+      {
+        dqm::utils::reportSummaryMapPalette(obj);
+        obj->GetXaxis()->SetNdivisions(-14,true);
+        obj->GetYaxis()->SetNdivisions(-4,true);
+        obj->SetMinimum(0.);
+        obj->GetXaxis()->CenterLabels();
+        obj->GetYaxis()->CenterLabels();
+        obj->SetOption("text,colz");
+        obj->SetMarkerSize( 2 );
+        gStyle->SetPaintTextFormat("1.2f");
+        c->SetGrid(1,1);
+        return;
+      }
+
       /*
         if(o.name.find("SetRange_2D") != std::string::npos)
         {
@@ -1252,6 +1268,14 @@ private:
         if(obj->Integral() != 0) c->SetLogy(1);
         return;
       }
+      
+      if(o.name.find("DT_chamberEff_allCh") != std::string::npos)
+      {
+        obj->SetMinimum(0.);
+        c->SetGrid(1,1);
+        return;
+      }
+
     }
 
   void postDrawTProfile2D( TCanvas *, const VisDQMObject & )

--- a/dqmgui/style/RPCRenderPlugin.cc
+++ b/dqmgui/style/RPCRenderPlugin.cc
@@ -28,6 +28,7 @@ public:
     if (o.name.find( "RPC/FEDIntegrity" ) != std::string::npos) return true;
     if (o.name.find("RPC/EventInfo") != std::string::npos) return true;
     if (o.name.find("RPC/AllHits") != std::string::npos) return true;
+    if (o.name.find( "RPC/Segment_TnP") != std::string::npos) return true;
     return false;
   }
 
@@ -55,6 +56,12 @@ private:
     if (o.name.find("BX") != std::string::npos) {
       obj->StatOverflows(false);
     }
+    if (o.name.find("RPC_chamberEff_Barrel_1D") != std::string::npos ||
+        o.name.find("RPC_chamberEff_Endcap_1D") != std::string::npos) {
+      obj->SetMinimum(0.);
+      c->SetGrid(1,1);
+    }
+
   }
 
   void preDrawTH2(TCanvas *c, const VisDQMObject &o) {
@@ -148,6 +155,34 @@ private:
       }
       return;
     }
+    if (o.name.find("RPC_chamberEff_Barrel_W") != std::string::npos) {
+        dqm::utils::reportSummaryMapPalette(obj);
+        obj->GetXaxis()->SetNdivisions(-21,true);
+        obj->GetYaxis()->SetNdivisions(-12,true);
+        obj->SetMinimum(0.);
+        obj->GetXaxis()->CenterLabels();
+        obj->GetYaxis()->CenterLabels();
+        obj->SetOption("text,colz");
+        obj->SetMarkerSize( 2 );
+        gStyle->SetPaintTextFormat("1.2f");
+        c->SetGrid(1,1);
+      return;
+    }
+
+    if (o.name.find("RPC_chamberEff_Endcap_Sta") != std::string::npos) {
+        dqm::utils::reportSummaryMapPalette(obj);
+        obj->GetXaxis()->SetNdivisions(-6,true);
+        obj->GetYaxis()->SetNdivisions(36,true);
+        obj->SetMinimum(0.);
+        obj->GetXaxis()->CenterLabels();
+        obj->GetYaxis()->CenterLabels();
+        obj->SetOption("text45,colz");
+        obj->SetMarkerSize( 2 );
+        gStyle->SetPaintTextFormat("1.2f");
+        c->SetGrid(1,1);
+      return;
+    }
+
   }
 
   void postDrawTH2(TCanvas *c __attribute__ ((unused)), const VisDQMObject &o) {

--- a/dqmgui/style/RPCRenderPlugin.cc
+++ b/dqmgui/style/RPCRenderPlugin.cc
@@ -57,7 +57,9 @@ private:
       obj->StatOverflows(false);
     }
     if (o.name.find("RPC_chamberEff_Barrel_1D") != std::string::npos ||
-        o.name.find("RPC_chamberEff_Endcap_1D") != std::string::npos) {
+        o.name.find("RPC_chamberEff_Barrel_allCh_1D") != std::string::npos ||
+        o.name.find("RPC_chamberEff_Endcap_1D") != std::string::npos ||
+        o.name.find("RPC_chamberEff_Endcap_allCh_1D") != std::string::npos) {
       obj->SetMinimum(0.);
       c->SetGrid(1,1);
     }


### PR DESCRIPTION
This PR includes the setup to draw tag-and-probe efficiency plots for DT, CSC and RPC, included in the `<subsystem>/Segment_TnP/Task` sub-directory. The code has been tested following the instruction in this twiki [1] and using this relVal sample [2].

[1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers
[2] /RelValZMM_14/CMSSW_12_4_0_pre4-124X_mcRun3_2021_realistic_v1-v1/DQMIO