### PR TITLE
Included HG PCL alignment veto logic in DQMGUI plots

### DIFF
--- a/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
+++ b/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
@@ -412,6 +412,7 @@ private:
       double error = obj->GetBinError(i);
   
       if (content == 0 && error == 0){
+        obj->SetBinContent(i, 0.00001);
         continue;
       }
   
@@ -442,36 +443,44 @@ private:
     t_text->SetBit(kCanDelete);
     t_text->SetNDC(true);
     
+    TString alignableType;
+    std::string axisTitle = obj->GetXaxis()->GetTitle();
+    if (axisTitle.find( "Panel" ) != std::string::npos){
+      alignableType = "panels";
+    }else{
+      alignableType = "ladders";
+    }
     
     if(vetoMaxMove){
       // Red, too large max error
       obj->SetMarkerColor(kRed);
       obj->SetLineColor(kRed);
-      t_text->DrawText(0.2,0.87, "Movements exceed max movement, veto");
+      t_text->DrawText(0.05,0.87, "Movements exceed max movement, veto");
     }else if(vetoMaxError){
       // Red, too large max error
       obj->SetMarkerColor(kRed);
       obj->SetLineColor(kRed);
-      t_text->DrawText(0.2,0.87, "Errors exceed max error, veto");
+      t_text->DrawText(0.05,0.87, "Errors exceed max error, veto");
     }else if(aboveSig){
       // Orange
       obj->SetMarkerColor(kOrange);
       obj->SetLineColor(kOrange);
-      t_text->DrawText(0.2,0.87, "Enough significant movements observed");
+      t_text->DrawText(0.13,0.87, "Significant movements above threshold");
+      t_text->DrawText(0.13,0.83, TString::Format("%.1f%% of %d aligned %s",100*((double)aboveSigCount / (double)alignableCount), alignableCount,alignableType.Data()));
 
     }else if(aboveCut){
       // Green, movements above threshold not significant
       obj->SetMarkerColor(kGreen+1);
       obj->SetLineColor(kGreen+1);
-      t_text->DrawText(0.2,0.87, "Movements above threshold not significant");
-      t_text->DrawText(0.2,0.83, TString::Format("Above significance: %.1f%%",100*((double)aboveSigCount / (double)alignableCount)));
+      t_text->DrawText(0.13,0.87, "Movements above threshold not significant");
+      t_text->DrawText(0.13,0.83, TString::Format("Above significance: %.1f%% of %d aligned %s",100*((double)aboveSigCount / (double)alignableCount), alignableCount,alignableType.Data()));
 
     }else{
       // Grey, movements not above threshold
-      obj->SetMarkerColor(kGray);
-      obj->SetLineColor(kGray);
-      t_text->DrawText(0.2,0.87, "Not enough movements above threshold");
-      t_text->DrawText(0.2,0.83, TString::Format("Above threshold: %.1f%%",100*((double)aboveCutCount / (double)alignableCount)));
+      obj->SetMarkerColor(kGray+2);
+      obj->SetLineColor(kGray+2);
+      t_text->DrawText(0.13,0.87, "Movements within threshold");
+      t_text->DrawText(0.13,0.83, TString::Format("Above threshold: %.1f%% of %d aligned %s",100*((double)aboveCutCount / (double)alignableCount), alignableCount,alignableType.Data()));
     }
 
 

--- a/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
+++ b/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
@@ -410,7 +410,11 @@ private:
     for (int i = 1; i <= nBins-5; i++){
       double content = obj->GetBinContent(i);
       double error = obj->GetBinError(i);
-
+  
+      if (content == 0 && error == 0){
+        continue;
+      }
+  
       alignableCount++;
       if(std::abs(content) > maxMove){
         aboveMaxMoveCount++;
@@ -419,12 +423,9 @@ private:
         aboveMaxErrorCount++;
       }
       
-      if(std::abs(content) > cutValue){
+      if(std::abs(content) >= cutValue){
         aboveCutCount++;
-        if(error==0){
-          continue;
-        }
-        if (std::abs(content/error) > significance){
+        if (std::abs(content/error) >= significance){
           aboveSigCount++;
         }
       }
@@ -463,14 +464,14 @@ private:
       obj->SetMarkerColor(kGreen+1);
       obj->SetLineColor(kGreen+1);
       t_text->DrawText(0.2,0.87, "Movements above threshold not significant");
-      t_text->DrawText(0.2,0.83, TString::Format("Above significance: %.0f%%",100*((double)aboveSigCount / (double)alignableCount)));
+      t_text->DrawText(0.2,0.83, TString::Format("Above significance: %.1f%%",100*((double)aboveSigCount / (double)alignableCount)));
 
     }else{
       // Grey, movements not above threshold
       obj->SetMarkerColor(kGray);
       obj->SetLineColor(kGray);
       t_text->DrawText(0.2,0.87, "Not enough movements above threshold");
-      t_text->DrawText(0.2,0.83, TString::Format("Above threshold: %.0f%%",100*((double)aboveCutCount / (double)alignableCount)));
+      t_text->DrawText(0.2,0.83, TString::Format("Above threshold: %.1f%%",100*((double)aboveCutCount / (double)alignableCount)));
     }
 
 


### PR DESCRIPTION
**Changes:**
Follow-up to #1171.

The high granularity PCL alignment has a simple veto logic, which was previously not used but will be in the near future. The plots now indicate if there was a movement that exceeded the maximum movement or error threshold, which would lead to a veto.

**Validation:**

Tested with a running dqm gui and a ROOT file whether the plots look as expected after the changes .