### PR TITLE
Add Tracker Alignment Workspace for RelVal

### DIFF
--- a/dqmgui/layouts/tkali_relval-layouts.py
+++ b/dqmgui/layouts/tkali_relval-layouts.py
@@ -1,0 +1,429 @@
+def alignmentvalidationlayout(i, p, *rows): i["DataLayouts/TkAli/" + p] = DQMItem(layout=rows)
+
+alignmentvalidationlayout(dqmitems, "00 - Vertex and vertex tracks quality",
+                   [{ 'path': "OfflinePV/Alignment/chi2ndf",
+                      'description': "Chi square of vertex tracks (pT>1GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/chi2prob",
+                      'description': "Chi square probability of vertex tracks (pT>1GeV)",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/sumpt",
+                      'description': "sum of transverse momentum squared of vertex tracks (pT>1GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/weight",
+                      'description': "weight of track in vertex fit",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/ntracks",
+                      'description': "number of tracks in vertex",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxy",
+                      'description': "transverse impact parameter",
+                      'draw': { 'withref': "no" }
+                      }])
+
+alignmentvalidationlayout(dqmitems, "01 - Impact parameters and errors",
+                   [{ 'path': "OfflinePV/Alignment/dxyzoom",
+                      'description': "transverse impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxyErr",
+                      'description': "error on transverse impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/dz",
+                      'description': "longitudinal impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dzErr",
+                      'description': "error on longitudinal impact parameter w.r.t vertex",
+                      'draw': { 'withref': "no" }
+                      }])
+
+alignmentvalidationlayout(dqmitems, "02 - Impact parameters projections (pT>1 GeV)",
+                   [{ 'path': "OfflinePV/Alignment/dxyVsPhi_pt1",
+                      'description': "transverse impact parameter vs track azimuth (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxyVsEta_pt1",
+                      'description': "transverse impact parameter vs track pseudorapitidy (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/dzVsPhi_pt1",
+                      'description': "longitudinal impact parameter vs track azimuth (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dzVsEta_pt1",
+                      'description': "longidutinal impact parameter vs track pseudorapidity (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      }])
+
+alignmentvalidationlayout(dqmitems, "03 - Impact parameters projections (pT>10 GeV)",
+                   [{ 'path': "OfflinePV/Alignment/dxyVsPhi_pt10",
+                      'description': "transverse impact parameter vs track azimuth (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxyVsEta_pt10",
+                      'description': "transverse impact parameter vs track pseudorapitidy (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/dzVsPhi_pt10",
+                      'description': "longitudinal impact parameter vs track azimuth (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dzVsEta_pt10",
+                      'description': "longidutinal impact parameter vs track pseudorapidity (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      }])
+
+alignmentvalidationlayout(dqmitems, "04 - 2D impact parameters projections",
+                   [{ 'path': "OfflinePV/Alignment/dxyVsEtaVsPhi_pt1",
+                      'description': "transverse impact parameter vs track pseudorapitidy vs track azimuth (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dxyVsEtaVsPhi_pt10",
+                      'description': "transverse impact parameter vs track pseudorapitidy vs track azimuth (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      }],
+                   [{ 'path': "OfflinePV/Alignment/dzVsEtaVsPhi_pt1",
+                      'description': "longidutinal impact parameter vs track pseudorapitidy vs track azimuth (track momentum > 1 GeV)",
+                      'draw': { 'withref': "no" }
+                      },
+                    { 'path': "OfflinePV/Alignment/dzVsEtaVsPhi_pt10",
+                      'description': "longidutinal impact parameter vs track pseudorapitidy vs track azimuth (track momentum > 10 GeV)",
+                      'draw': { 'withref': "no" }
+                      }])
+                      
+alignmentvalidationlayout(dqmitems, "38 - PixelPhase1 Residuals",
+   [{ 'path': "PixelPhase1/Tracks/residual_x_PXBarrel",
+      'description': "Track residuals x in PXBarrel",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/residual_x_PXForward",
+      'description': "Track residuals x in PXForward",
+      'draw': { 'withref': "no" }}],
+   [{ 'path': "PixelPhase1/Tracks/residual_y_PXBarrel",
+      'description': "Track residuals y in PXBarrel",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/residual_y_PXForward",
+      'description': "Track residuals y in PXForward",
+      'draw': { 'withref': "no" }}]
+   )
+
+alignmentvalidationlayout(dqmitems, "38aa - Residuals x per Layer",
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_PXLayer_1",
+      'description': "Track residuals x in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_PXLayer_2",
+      'description': "Track residuals x in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_PXLayer_3",
+      'description': "Track residuals x in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_PXLayer_4",
+      'description': "Track residuals x in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38ab - Residuals y per Layer",
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_PXLayer_1",
+      'description': "Track residuals y in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_PXLayer_2",
+      'description': "Track residuals y in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_PXLayer_3",
+      'description': "Track residuals y in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_PXLayer_4",
+      'description': "Track residuals y in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38ba - Profile Residuals x PXBarrel",
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_1",
+      'description': "Mean track residuals x in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_2",
+      'description': "Mean track residuals x in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_3",
+      'description': "Mean track residuals x in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_x_per_SignedModule_per_SignedLadder_PXLayer_4",
+      'description': "Mean track residuals x in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38bb - Profile Residuals y PXBarrel",
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_1",
+      'description': "Mean track residuals y in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_2",
+      'description': "Mean track residuals y in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_3",
+      'description': "Mean track residuals y in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXBarrel/residual_y_per_SignedModule_per_SignedLadder_PXLayer_4",
+      'description': "Mean track residuals y in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38ca - Mean Residuals x inner Modules per Layer",
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Inner_PXLayer_1",
+      'description': "Mean track residuals x for inner Modules in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Inner_PXLayer_2",
+      'description': "Mean track residuals x for inner Modules in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Inner_PXLayer_3",
+      'description': "Mean track residuals x for inner Modules in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Inner_PXLayer_4",
+      'description': "Mean track residuals x for inner Modules in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38cb - Mean Residuals x outer Modules per Layer",
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Outer_PXLayer_1",
+      'description': "Mean track residuals x for outer Modules in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Outer_PXLayer_2",
+      'description': "Mean track residuals x for outer Modules in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Outer_PXLayer_3",
+      'description': "Mean track residuals x for outer Modules in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_x_Outer_PXLayer_4",
+      'description': "Mean track residuals x for outer Modules in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38cc - Mean Residuals y inner Modules per Layer",
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Inner_PXLayer_1",
+      'description': "Mean track residuals y for inner Modules in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Inner_PXLayer_2",
+      'description': "Mean track residuals y for inner Modules in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Inner_PXLayer_3",
+      'description': "Mean track residuals y for inner Modules in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Inner_PXLayer_4",
+      'description': "Mean track residuals y for inner Modules in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38cd - Mean Residuals y outer Modules per Layer",
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Outer_PXLayer_1",
+      'description': "Mean track residuals y for outer Modules in PXBarrel Layer 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Outer_PXLayer_2",
+      'description': "Mean track residuals y for outer Modules in PXBarrel Layer 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Outer_PXLayer_3",
+      'description': "Mean track residuals y for outer Modules in PXBarrel Layer 3",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXBarrel/residual_mean_y_Outer_PXLayer_4",
+      'description': "Mean track residuals y for outer Modules in PXBarrel Layer 4",
+      'draw': { 'withref': "no" }},]
+   )
+   
+alignmentvalidationlayout(dqmitems, "38da - Residuals x per Disk",
+   [{ 'path': "PixelPhase1/Tracks/PXForward/residual_x_PXDisk_+1",
+      'description': "Track residuals x in PXForward Disk +1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_x_PXDisk_+2",
+      'description': "Track residuals x in PXForward Disk +2",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_x_PXDisk_+3",
+      'description': "Track residuals x in PXForward Disk +3",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/PXForward/residual_x_PXDisk_-1",
+      'description': "Track residuals x in PXForward Disk -1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_x_PXDisk_-2",
+      'description': "Track residuals x in PXForward Disk -2",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_x_PXDisk_-3",
+      'description': "Track residuals x in PXForward Disk -3",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38db - Residuals y per Disk",
+   [{ 'path': "PixelPhase1/Tracks/PXForward/residual_y_PXDisk_+1",
+      'description': "Track residuals y in PXForward Disk +1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_y_PXDisk_+2",
+      'description': "Track residuals y in PXForward Disk +2",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_y_PXDisk_+3",
+      'description': "Track residuals y in PXForward Disk +3",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/PXForward/residual_y_PXDisk_-1",
+      'description': "Track residuals y in PXForward Disk -1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_y_PXDisk_-2",
+      'description': "Track residuals y in PXForward Disk -2",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_y_PXDisk_-3",
+      'description': "Track residuals y in PXForward Disk -3",
+      'draw': { 'withref': "no" }},]
+   )
+   
+alignmentvalidationlayout(dqmitems, "38e - Profile Residuals PXFoward",
+   [{ 'path': "PixelPhase1/Tracks/PXForward/residual_x_per_PXDisk_per_SignedBladePanel_PXRing_1",
+      'description': "Mean track residuals x in PXFoward Ring 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_x_per_PXDisk_per_SignedBladePanel_PXRing_2",
+      'description': "Mean track residuals x in PXFoward Ring 2",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/PXForward/residual_y_per_PXDisk_per_SignedBladePanel_PXRing_1",
+      'description': "Mean track residuals y in PXFoward Ring 1",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/PXForward/residual_y_per_PXDisk_per_SignedBladePanel_PXRing_2",
+      'description': "Mean track residuals y in PXFoward Ring 2",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38fa - Mean Residuals InnerOuter Modules PXForward",
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_x_Inner",
+      'description': "Mean track residuals x for inner Modules in PXFoward",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_x_Outer",
+      'description': "Mean track residuals x for inner Modules in PXFoward",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_y_Inner",
+      'description': "Mean track residuals y for inner Modules in PXFoward",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_y_Outer",
+      'description': "Mean track residuals y for inner Modules in PXFoward",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "38fb - Mean Residuals pos.neg. Side PXForward",
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_x_pos",
+      'description': "Mean track residuals x for pos. Side in PXFoward",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_x_neg",
+      'description': "Mean track residuals x for neg. Side in PXFoward",
+      'draw': { 'withref': "no" }},],
+   [{ 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_y_pos",
+      'description': "Mean track residuals y for pos. Side in PXFoward",
+      'draw': { 'withref': "no" }},
+    { 'path': "PixelPhase1/Tracks/ResidualsExtra/PXForward/residual_mean_y_neg",
+      'description': "Mean track residuals y for neg. Side in PXFoward",
+      'draw': { 'withref': "no" }},]
+   )
+
+alignmentvalidationlayout(dqmitems, "42a - Barycenter coordinates",
+  [{ 'path': "PixelPhase1/Barycenter/barycenters_BPIX",
+     'description': "Barycenter coordinates derived from PXBarrel",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Barycenter/barycenters_FPIX_zm",
+     'description': "Barycenter coordinates derived from PXForward z-",
+     'draw': {'withref' : "no"}},
+     { 'path': "PixelPhase1/Barycenter/barycenters_FPIX_zp",
+     'description': "Barycenter coordinates derived from PXForward z-",
+     'draw': {'withref' : "no"}}],
+  )
+  
+alignmentvalidationlayout(dqmitems, "42b - Barycenter coordinates",
+  [{ 'path': "PixelPhase1/Barycenter/barycenters_BPIX_xm",
+     'description': "Barycenter coordinates derived from PXBarrel x-",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Barycenter/barycenters_BPIX_xp",
+     'description': "Barycenter coordinates derived from PXBarrel x+",
+     'draw': {'withref' : "no"}},
+     { 'path': "PixelPhase1/Barycenter/barycenters_FPIX_zm_xm",
+     'description': "Barycenter coordinates derived from PXForward z-,x-",
+     'draw': {'withref' : "no"}}],
+  [{ 'path': "PixelPhase1/Barycenter/barycenters_FPIX_zm_xp",
+     'description': "Barycenter coordinates derived from PXForward z-,x+",
+     'draw': {'withref' : "no"}},
+   { 'path': "PixelPhase1/Barycenter/barycenters_FPIX_zp_xm",
+     'description': "Barycenter coordinates derived from PXForward z+,x-",
+     'draw': {'withref' : "no"}},
+     { 'path': "PixelPhase1/Barycenter/barycenters_FPIX_zp_xp",
+     'description': "Barycenter coordinates derived from PXForward z+,x+",
+     'draw': {'withref' : "no"}}],
+  )
+  
+alignmentvalidationlayout(dqmitems, "21 - TIB Residuals",
+  [{ 'path': "SiStrip/MechanicalView/TIB/layer_1/HitResiduals_TIB__Layer__1",
+     'description': "Hit Residual in TIB Layer #1"},
+   { 'path': "SiStrip/MechanicalView/TIB/layer_2/HitResiduals_TIB__Layer__2",
+     'description': "Hit Residual in TIB Layer #2"}],
+  [{ 'path': "SiStrip/MechanicalView/TIB/layer_3/HitResiduals_TIB__Layer__3",
+     'description': "Hit Residual in TIB Layer #3"},
+   { 'path': "SiStrip/MechanicalView/TIB/layer_4/HitResiduals_TIB__Layer__4",
+     'description': "Hit Residual in TIB Layer #4"}])
+alignmentvalidationlayout(dqmitems, "22 - TOB Residuals",
+  [{ 'path': "SiStrip/MechanicalView/TOB/layer_1/HitResiduals_TOB__Layer__1",
+     'description': "Hit Residual in TOB Layer #1"},
+   { 'path': "SiStrip/MechanicalView/TOB/layer_2/HitResiduals_TOB__Layer__2",
+     'description': "Hit Residual in TOB Layer #2"},
+   { 'path': "SiStrip/MechanicalView/TOB/layer_3/HitResiduals_TOB__Layer__3",
+     'description': "Hit Residual in TOB Layer #3"}],
+  [{ 'path': "SiStrip/MechanicalView/TOB/layer_4/HitResiduals_TOB__Layer__4",
+     'description': "Hit Residual in TOB Layer #4"},
+   { 'path': "SiStrip/MechanicalView/TOB/layer_5/HitResiduals_TOB__Layer__5",
+     'description': "Hit Residual in TOB Layer #5"},
+   { 'path': "SiStrip/MechanicalView/TOB/layer_6/HitResiduals_TOB__Layer__6",
+     'description': "Hit Residual in TOB Layer #6"}])
+alignmentvalidationlayout(dqmitems, "23 - TID+ Residuals",
+  [{ 'path': "SiStrip/MechanicalView/TID/PLUS/wheel_1/HitResiduals_TID__wheel__1",
+     'description': "Hit Residuals in TID+ Wheel #1"},
+   { 'path': "SiStrip/MechanicalView/TID/PLUS/wheel_2/HitResiduals_TID__wheel__2",
+     'description': "Hit Residuals in TID+ Wheel #2"},
+   { 'path': "SiStrip/MechanicalView/TID/PLUS/wheel_3/HitResiduals_TID__wheel__3",
+     'description': "Hit Residuals in TID+ Wheel #3 "}])
+alignmentvalidationlayout(dqmitems, "24 - TID- Residuals",
+  [{ 'path': "SiStrip/MechanicalView/TID/MINUS/wheel_1/HitResiduals_TID__wheel__1",
+     'description': "Hit Residuals in TID- Wheel #1"},
+   { 'path': "SiStrip/MechanicalView/TID/MINUS/wheel_2/HitResiduals_TID__wheel__2",
+     'description': "Hit Residuals in TID- Wheel #2"},
+   { 'path': "SiStrip/MechanicalView/TID/MINUS/wheel_3/HitResiduals_TID__wheel__3",
+     'description': "Hit Residuals in TID- Wheel #3 "}])
+alignmentvalidationlayout(dqmitems, "25 - TEC+ Residual",
+  [{ 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_1/HitResiduals_TEC__wheel__1",
+     'description': "Hit Residual in TEC+ Wheel #1"},
+   { 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_2/HitResiduals_TEC__wheel__2",
+     'description': "Hit Residual in TEC+ Wheel #2"},
+   { 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_3/HitResiduals_TEC__wheel__3",
+     'description': "Hit Residual in TEC+ Wheel #3"}],
+  [{ 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_4/HitResiduals_TEC__wheel__4",
+     'description': "Hit Residual in TEC+ Wheel #4"},
+   { 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_5/HitResiduals_TEC__wheel__5",
+     'description': "Hit Residual in TEC+ Wheel #5"},
+   { 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_6/HitResiduals_TEC__wheel__6",
+     'description': "Hit Residual in TEC+ Wheel #6"}],
+  [{ 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_7/HitResiduals_TEC__wheel__7",
+     'description': "Hit Residual in TEC+ Wheel #7"},
+   { 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_8/HitResiduals_TEC__wheel__8",
+     'description': "Hit Residual in TEC+ Wheel #8"},
+   { 'path': "SiStrip/MechanicalView/TEC/PLUS/wheel_9/HitResiduals_TEC__wheel__9",
+     'description': "Hit Residual in TEC+ Wheel #9"}])
+alignmentvalidationlayout(dqmitems, "26 - TEC- Residual",
+  [{ 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_1/HitResiduals_TEC__wheel__1",
+     'description': "Hit Residual in TEC- Wheel #1"},
+   { 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_2/HitResiduals_TEC__wheel__2",
+     'description': "Hit Residual in TEC- Wheel #2"},
+   { 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_3/HitResiduals_TEC__wheel__3",
+     'description': "Hit Residual in TEC- Wheel #3"}],
+  [{ 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_4/HitResiduals_TEC__wheel__4",
+     'description': "Hit Residual in TEC- Wheel #4"},
+   { 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_5/HitResiduals_TEC__wheel__5",
+     'description': "Hit Residual in TEC- Wheel #5"},
+   { 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_6/HitResiduals_TEC__wheel__6",
+     'description': "Hit Residual in TEC- Wheel #6"}],
+  [{ 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_7/HitResiduals_TEC__wheel__7",
+     'description': "Hit Residual in TEC- Wheel #7"},
+   { 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_8/HitResiduals_TEC__wheel__8",
+     'description': "Hit Residual in TEC- Wheel #8"},
+   { 'path': "SiStrip/MechanicalView/TEC/MINUS/wheel_9/HitResiduals_TEC__wheel__9",
+     'description': "Hit Residual in TEC- Wheel #9"}])

--- a/dqmgui/server-conf-relval.py
+++ b/dqmgui/server-conf-relval.py
@@ -20,6 +20,8 @@ LAYOUTS += glob("%s/layouts/%s_relval-layouts.py" % (CONFIGDIR, "tk"))
 LAYOUTS += glob("%s/layouts/%s_relval-layouts.py" % (CONFIGDIR, "smp"))
 LAYOUTS += glob("%s/layouts/%s_relval-layouts.py" % (CONFIGDIR, "aliOfflinePV"))
 LAYOUTS += glob("%s/layouts/%s_relval-layouts.py" % (CONFIGDIR, "recotau"))
+LAYOUTS += glob("%s/layouts/%s_relval-layouts.py" % (CONFIGDIR, "tkali"))
+
 
 
 modules = ("Monitoring.DQM.GUI",)

--- a/dqmgui/workspaces-relval.py
+++ b/dqmgui/workspaces-relval.py
@@ -57,6 +57,35 @@ server.workspace('DQMContent', 24, 'Data', 'MET' , '^MET/', '')
 server.workspace('DQMContent', 25, 'Data', 'BTag' , '^BTag/', '')
 server.workspace('DQMContent', 26, 'Data', 'Tau' , '^Tau/', '')
 server.workspace('DQMContent', 27, 'Data', 'PFlow' , '^ParticleFlow/', '')
+server.workspace('DQMContent', 28, 'Data', 'TkAlignment', '', 'DataLayouts/TkAli',
+                 'DataLayouts/TkAli/00 - Vertex and vertex tracks quality',
+                 'DataLayouts/TkAli/01 - Impact parameters and errors',
+                 'DataLayouts/TkAli/02 - Impact parameters projections (pT>1 GeV)',
+                 'DataLayouts/TkAli/03 - Impact parameters projections (pT>10 GeV)',
+                 'DataLayouts/TkAli/04 - 2D impact parameters projections',
+                 'DataLayouts/TkAli/38 - PixelPhase1 Residuals',
+                 'DataLayouts/TkAli/38aa - Residuals x per Layer',
+                 'DataLayouts/TkAli/38ab - Residuals y per Layer',
+                 'DataLayouts/TkAli/38ba - Profile Residuals x PXBarrel',
+                 'DataLayouts/TkAli/38bb - Profile Residuals y PXBarrel',
+                 'DataLayouts/TkAli/38ca - Mean Residuals x inner Modules per Layer',
+                 'DataLayouts/TkAli/38cb - Mean Residuals x outer Modules per Layer',
+                 'DataLayouts/TkAli/38cc - Mean Residuals y inner Modules per Layer',
+                 'DataLayouts/TkAli/38cd - Mean Residuals y outer Modules per Layer',
+                 'DataLayouts/TkAli/38da - Residuals x per Disk',
+                 'DataLayouts/TkAli/38db - Residuals y per Disk',
+                 'DataLayouts/TkAli/38e - Profile Residuals PXFoward',
+                 'DataLayouts/TkAli/38fa - Mean Residuals InnerOuter Modules PXForward',
+                 'DataLayouts/TkAli/38fb - Mean Residuals pos.neg. Side PXForward',
+                 'DataLayouts/TkAli/42a - Barycenter coordinates',
+                 'DataLayouts/TkAli/42b - Barycenter coordinates',
+                 'DataLayouts/TkAli/21 - TIB Residuals',
+                 'DataLayouts/TkAli/22 - TOB Residuals',
+                 'DataLayouts/TkAli/23 - TID+ Residuals',
+                 'DataLayouts/TkAli/24 - TID- Residuals',
+                 'DataLayouts/TkAli/25 - TEC+ Residual',
+                 'DataLayouts/TkAli/26 - TEC- Residual',
+                )
 
 # Monte Carlo workspaces:
 server.workspace('DQMContent', 30, 'Monte Carlo', 'MC Tk' , '^(Tk/|TrackerDigisV|TrackerHitsV|TrackerRecHitsV|Pixel|SiStrip|Tracking)', 'MCLayouts/Tk',


### PR DESCRIPTION
This PR adds a tracker alignment workspace to the RelVal gui. The workspace is identical to the workspace already available in the offline gui. A screenshot of the TkAlignment workspace can be found below.

![RelVal_Gui](https://user-images.githubusercontent.com/32901048/186927204-5ef32f1a-f51b-46a8-84d1-e7d2a654f054.png)

For testing please have a look at my private gui, by using `ssh -NL 8081:localhost:8081 <username>@lxplus773.cern.ch` and following https://tinyurl.com/2k5rbz9k

cc: @mmusich, @arossi83, @sroychow
