### PR TITLE
Change schedd RewriteRule to any hostname (without dot)

### DIFF
--- a/frontend/app_schedd_ssl.conf
+++ b/frontend/app_schedd_ssl.conf
@@ -1,2 +1,2 @@
-RewriteRule ^(/scheddmon/[0-9]{1,4}(/.*)+)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
-RewriteRule ^/auth/complete/scheddmon/[0-9]{1,4}(/.*)+$ http://%{ENV:BACKEND}:80/mon${escape:$1} [QSA,P,L,NE]
+RewriteRule ^(/scheddmon/[a-z0-9][a-z0-9\-]*[a-z0-9](/.*)+)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:cert]
+RewriteRule ^/auth/complete/scheddmon/[a-z0-9][a-z0-9\-]*[a-z0-9](/.*)+$ http://%{ENV:BACKEND}:80/mon${escape:$1} [QSA,P,L,NE]


### PR DESCRIPTION
Fix previous PR https://github.com/dmwm/deployment/pull/1185

This PR make Frontend `RewirteRule` to schedd to accept more than number pattern, support a new schedd machine `crab-preprod-scd03.cern.ch`.
Changing from `[0-9]{1,4}` (accept any 1 to 4 numerical chars) to `[a-z0-9][a-z0-9\-]*[a-z0-9]` (accept any number of alphanumeric plus dash character that not start or end with dash character).

I have test in https://regex101.com/ with following testcase:
```
regex:
scheddmon\/[a-z0-9][a-z0-9\-]*[a-z0-9](\/.*)

testcase:
scheddmon/vocms059/
scheddmon/vocms/asdf
scheddmon/crab-preprod-scd03/asdfasdfasdf
scheddmon/crab-pre/prod-scd03/asdfasdfasdf
scheddmon/crab-preprod-scd03.cern.ch/asdfasdfasdf
scheddmon/random_string_here/asdfasdfasdf/asdfadsf
```
and it match correctly:
![Screenshot from 2022-09-06 15-25-55](https://user-images.githubusercontent.com/2346664/188653757-e6e2b3fb-6810-44c1-b7bc-dc02b4b02a50.png)

I have applied change in Frontend in testbed (only some pods) today and it working fine. CRABClient can fetch status_cache.pkl properly.

This the link I use to test:
- CMSWEB link: https://cmsweb-testbed.cern.ch:8443/scheddmon/crab-preprod-scd03/tseethon/220830_130156:tseethon_crab_20220830_150152/job_out.5.0.txt
  - Direct access (CERN network only): http://crab-preprod-scd03.cern.ch/mon/tseethon/220830_130156:tseethon_crab_20220830_150152/job_out.5.0.txt
- Current schedd (vocms069): https://cmsweb.cern.ch:8443/scheddmon/069/tseethon/220829_143142:tseethon_crab_20220829_163133/job_out.6.0.txt