### PR TITLE
`SiPixelLorentzAnglePCLRenderPlugin`: add reportMap style plot for fit quality ME

### DIFF
--- a/dqmgui/style/SiPixelLorentzAnglePCLRenderPlugin.cc
+++ b/dqmgui/style/SiPixelLorentzAnglePCLRenderPlugin.cc
@@ -103,6 +103,15 @@ private:
     TH2F* obj = dynamic_cast<TH2F*>( o.object );
     assert( obj );
 
+    if( o.name.find("h_bySectFitQuality") != std::string::npos){
+      gPad->SetGrid();
+      dqm::utils::reportSummaryMapPalette(obj);
+      obj->SetMarkerSize(1.5);
+      obj->SetStats( kFALSE );
+      obj->SetOption("colztext");
+      return;
+    }
+
     if( o.name.find("h_drift_depth")!= std::string::npos){
       obj->SetStats( kFALSE );
       gStyle->SetPalette(1,0);


### PR DESCRIPTION
Title says it all.
Example resulting histogram:

![Screenshot from 2022-10-01 19-37-31](https://user-images.githubusercontent.com/5082376/193421477-8edfa506-fa76-43df-abcd-2f903dd58372.png)

Tested in a private GUI, that is possible to visit by: `ssh -NL 8060:localhost:8060 <USER>@lxplus790.cern.ch` + https://tinyurl.com/2ovz3bpu
