### PR TITLE
Adjusted y-axis to accomodate new entry: render plugin or DQM application BeamPixel

### DIFF
--- a/dqmgui/style/BeamPixelRenderPlugin.cc
+++ b/dqmgui/style/BeamPixelRenderPlugin.cc
@@ -259,7 +259,7 @@ private:
       {
 	c->SetGrid(false, false);
 
-	ya->SetRangeUser(-5.5,5.5);
+	ya->SetRangeUser(-6.5,5.5);
 
 	gStyle->SetOptStat(10);
 	gStyle->SetEndErrorSize(0.);


### PR DESCRIPTION
I've adjusted the y-axis of the plot which is showing the fit status as a function of LS:
- since I've added in the `DQM` plugin `BemPixel` a new possible fit status, I had to adapt the y-axis of the render plugin