### PR TITLE
Add env variable for allowing obsolete OpenSSL.

### DIFF
--- a/reqmgr2ms/manage
+++ b/reqmgr2ms/manage
@@ -66,6 +66,7 @@ COLOR_NORMAL="\\033[0;39m"
 
 . $ROOT/apps/$ME/etc/profile.d/init.sh
 
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
 export PYTHONPATH=$ROOT/auth/$ME:$PYTHONPATH
 export WMCORE_ROOT=$REQMGR2MS_ROOT/lib/python*/site-packages
 export REQMGR_CACHE_DIR=$STATEDIR


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11378  

This PR is to allow obsolete OpenSSL library to be used as backends for `cryptography` v3.2.1. This is supposed to be a temporary solution since starting with v3.3 and later this workaround will no longer be an option.