### PR TITLE
Add start2() to run CRABREST with argument writing logs to named pipe

### DIFF
--- a/crabserver/manage
+++ b/crabserver/manage
@@ -54,6 +54,14 @@ start()
   LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/crabserver-%Y%m%d-`hostname -s`.log 86400" $CFGFILE
 }
 
+# Start the service but write logs to named pipe
+# Will replace the start() later when everything works.
+start2()
+{
+  echo "starting $ME"
+  LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -r -d $STATEDIR -l "$STATEDIR/crabserver/crabserver-fifo" $CFGFILE
+}
+
 # Stop the service.
 stop()
 {
@@ -88,6 +96,13 @@ case ${1:-status} in
     echo $2
     stop
     start
+    ;;
+
+  start2 | restart2 )
+    check "$2"
+    echo $2
+    stop
+    start2
     ;;
 
   status )

--- a/crabserver/manage
+++ b/crabserver/manage
@@ -59,7 +59,7 @@ start()
 start2()
 {
   echo "starting $ME"
-  LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -r -d $STATEDIR -l "$STATEDIR/crabserver/crabserver-fifo" $CFGFILE
+  LD_PRELOAD=$JEMALLOC_ROOT/lib/libjemalloc.so wmc-httpd -r -d $STATEDIR -l "$STATEDIR/crabserver-fifo" $CFGFILE
 }
 
 # Stop the service.


### PR DESCRIPTION
~~**PLEASE, DO NOT MERGE.**~~
~~Waiting until https://github.com/dmwm/WMCore/issues/11459 resolve.~~ 
*Above issue is fixed in wmcore 2.1.7rc3 release.*

Implement https://github.com/dmwm/CRABServer/issues/7463#issuecomment-1344306384, [CMSKUBERNETES-215](https://its.cern.ch/jira/browse/CMSKUBERNETES-215)
