### PR TITLE
PPS layouts with pixel error plots

### DIFF
--- a/dqmgui/layouts/ctpps-layouts.py
+++ b/dqmgui/layouts/ctpps-layouts.py
@@ -216,6 +216,7 @@ pixelstations = [ "station 210", "station 220" ]
 pixstationsf=["sector 45/station 210/","sector 45/station 220/","sector 56/station 210/","sector 56/station 220/"]
 pix_planes  = [ "0","1","2" ]
 pix_planes2 = [ "3","4","5" ]
+feds = [ "1462","1463" ]
 
 def CTPPSTrackingPixelLayout(i, p, *rows): i["CTPPS/TrackingPixel/Layouts/" + p] = DQMItem(layout=rows)
 
@@ -291,3 +292,18 @@ for plot in ["hits position"]:
       rows.append(row)
 
       CTPPSTrackingPixelLayout(dqmitems, plot+":" +sector+" "+station+" fr_hr", *rows)
+
+for fed in feds:
+  rows = list()
+  row = list()
+  row.append("CTPPS/TrackingPixel/Errors in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Message in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Type in FED"+fed)
+  rows.append(row)
+
+  CTPPSTrackingPixelLayout(dqmitems, "Errors in FED "+fed, *rows)
+

--- a/dqmgui/layouts/ctpps_T0_layouts.py
+++ b/dqmgui/layouts/ctpps_T0_layouts.py
@@ -216,6 +216,7 @@ pixelstations = [ "station 210", "station 220" ]
 pixstationsf=["sector 45/station 210/","sector 45/station 220/","sector 56/station 210/","sector 56/station 220/"]
 pix_planes  = [ "0","1","2" ]
 pix_planes2 = [ "3","4","5" ]
+feds = [ "1462","1463" ]
 
 def CTPPSTrackingPixelLayout(i, p, *rows): i["CTPPS/TrackingPixel/Layouts/" + p] = DQMItem(layout=rows)
 
@@ -291,3 +292,18 @@ for plot in ["hits position"]:
       rows.append(row)
 
       CTPPSTrackingPixelLayout(dqmitems, plot+":" +sector+" "+station+" fr_hr", *rows)
+
+for fed in feds:
+  rows = list()
+  row = list()
+  row.append("CTPPS/TrackingPixel/Errors in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Message in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Type in FED"+fed)
+  rows.append(row)
+
+  CTPPSTrackingPixelLayout(dqmitems, "Errors in FED "+fed, *rows)
+

--- a/dqmgui/layouts/shift_ctpps_T0_layout.py
+++ b/dqmgui/layouts/shift_ctpps_T0_layout.py
@@ -8,7 +8,7 @@ sectors = [ "sector 45", "sector 56" ]
 pixelstations = [ "station 210", "station 220" ]
 pix_planes  = [ "0","1","2" ]
 pix_planes2 = [ "3","4","5" ]
-
+pix_feds = [ "1462","1463" ]
 
 # layouts with no overlays
 for plot in [ "active planes", "vfats with any problem", "track XY profile" ]:
@@ -92,6 +92,20 @@ for plot in ["hits position"]:
       rows.append(row)
 
       CTPPSTrackingPixelLayout(dqmitems, plot+":" +sector+" "+station+" fr_hr", *rows)
+
+for fed in pix_feds:
+  rows = list()
+  row = list()
+  row.append("CTPPS/TrackingPixel/Errors in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Message in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Type in FED"+fed)
+  rows.append(row)
+
+  CTPPSTrackingPixelLayout(dqmitems, "Errors in FED "+fed, *rows)
 
 ####################################################################################################
 # Diamond layouts

--- a/dqmgui/layouts/shift_ctpps_layout.py
+++ b/dqmgui/layouts/shift_ctpps_layout.py
@@ -8,7 +8,7 @@ sectors = [ "sector 45", "sector 56" ]
 pixelstations = [ "station 210", "station 220" ]
 pix_planes  = [ "0","1","2" ]
 pix_planes2 = [ "3","4","5" ]
-
+pix_feds = [ "1462","1463" ]
 
 # layouts with no overlays
 for plot in [ "active planes", "vfats with any problem", "track XY profile" ]:
@@ -92,6 +92,20 @@ for plot in ["hits position"]:
       rows.append(row)
 
       CTPPSTrackingPixelLayout(dqmitems, plot+":" +sector+" "+station+" fr_hr", *rows)
+
+for fed in pix_feds:
+  rows = list()
+  row = list()
+  row.append("CTPPS/TrackingPixel/Errors in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Message in FED"+fed)
+  rows.append(row)
+  row = list()
+  row.append("CTPPS/TrackingPixel/TBM Type in FED"+fed)
+  rows.append(row)
+
+  CTPPSTrackingPixelLayout(dqmitems, "Errors in FED "+fed, *rows)
 
 ####################################################################################################
 # Diamond layouts


### PR DESCRIPTION
This PR introduces new layouts for PPS pixel error plots that have been implemented in CMSSW_13_0_0 by PR#40668.

The new layouts have been tested deploying private offline and dev GUIs. 