### PR TITLE
Check for nullpointer in postdraw of HGPCL

### DIFF
--- a/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
+++ b/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
@@ -69,46 +69,48 @@ public:
   {
     c->cd();
 
-    if( o.name.find("SiPixelAli")!= std::string::npos){
-      if(o.name.find("PedeExitCode") != std::string::npos){
-        // Clear the default string from the canvas
-        c->Clear();
-
-        TObjString* tos = dynamic_cast<TObjString*>( o.object );
-        auto exitCode = TString((tos->GetString())(0,6));
-        TText *t = new TText(.5, .5, tos->GetString());
-        t->SetTextFont(63);
-        t->SetTextAlign(22);
-        t->SetTextSize(18);
-        // from Pede manual: http://www.desy.de/~kleinwrt/MP2/doc/html/exit_code_page.html
-        // all exit codes <  10 are normal endings
-        // all exit codes >= 10 indicated an aborted measurement
-        if(exitCode.Atoi()>=10){
-          t->SetTextColor(kRed);
-        } else {
-          t->SetTextColor(kGreen+2);
+    if( dynamic_cast<TObjString*>( o.object ) ){
+      if( o.name.find("SiPixelAli")!= std::string::npos){
+        if(o.name.find("PedeExitCode") != std::string::npos){
+          // Clear the default string from the canvas
+          c->Clear();
+          
+          TObjString* tos = dynamic_cast<TObjString*>( o.object );
+          auto exitCode = TString((tos->GetString())(0,6));
+          TText *t = new TText(.5, .5, tos->GetString());
+          t->SetTextFont(63);
+          t->SetTextAlign(22);
+          t->SetTextSize(18);
+          // from Pede manual: http://www.desy.de/~kleinwrt/MP2/doc/html/exit_code_page.html
+          // all exit codes <  10 are normal endings
+          // all exit codes >= 10 indicated an aborted measurement
+          if(exitCode.Atoi()>=10){
+            t->SetTextColor(kRed);
+          } else {
+            t->SetTextColor(kGreen+2);
+          }
+          t->Draw();
         }
-        t->Draw();
-      }
-      if(o.name.find("IsVetoed") != std::string::npos){
-        // Clear the default string from the canvas
-        c->Clear();
+        if(o.name.find("IsVetoed") != std::string::npos){
+          // Clear the default string from the canvas
+          c->Clear();
 
-        TObjString* tos = dynamic_cast<TObjString*>( o.object );
-        auto strIsVetoed = TString((tos->GetString()));
-        TText *t = new TText(.5, .5, strIsVetoed);
-        t->SetTextFont(63);
-        t->SetTextAlign(22);
-        t->SetTextSize(50);
-        // Print the three different options (Veto,Update,N/A) in three different colors
-        if(strIsVetoed.Contains("Vetoed")){
-          t->SetTextColor(kRed);
-        } else if(strIsVetoed.Contains("Updated")){
-          t->SetTextColor(kGreen+2);
-        } else{
-          t->SetTextColor(kGray+1);
+          TObjString* tos = dynamic_cast<TObjString*>( o.object );
+          auto strIsVetoed = TString((tos->GetString()));
+          TText *t = new TText(.5, .5, strIsVetoed);
+          t->SetTextFont(63);
+          t->SetTextAlign(22);
+          t->SetTextSize(50);
+          // Print the three different options (Veto,Update,N/A) in three different colors
+          if(strIsVetoed.Contains("Vetoed")){
+            t->SetTextColor(kRed);
+          } else if(strIsVetoed.Contains("Updated")){
+            t->SetTextColor(kGreen+2);
+          } else{
+            t->SetTextColor(kGray+1);
+          }
+          t->Draw();
         }
-        t->Draw();
       }
     }
 


### PR DESCRIPTION
In the current code, no check for nullpointer is made for the strings isVetoed and PedeExitCode. This seems to have sometimes led to ROOT crashes, resulting in "Blacklisted for crashing ROOT" being displayed for these strings.

This PR adds a simple safety check to prevent this from happening.