### PR TITLE
Update BeamSpot shifter plots

### DIFF
--- a/dqmgui/layouts/shift_beam_layout.py
+++ b/dqmgui/layouts/shift_beam_layout.py
@@ -1,23 +1,27 @@
 def shiftbeamlayout(i, p, *rows): i["00 Shift/BeamMonitor/" + p] = DQMItem(layout=rows)
 
-shiftbeamlayout(dqmitems, "00 - BeamMonitor ReportSummary",
- [{ 'path': "BeamMonitor/EventInfo/reportSummaryMap",
+shiftbeamlayout(dqmitems, "00 - BeamMonitorHLT ReportSummary",
+ [{ 'path': "BeamMonitorHLT/EventInfo/reportSummaryMap",
     'description': "BeamSpot summary map"}])
 shiftbeamlayout(dqmitems, "01 - d0-phi0 of selected tracks",
- [{ 'path': "BeamMonitor/Fit/d0_phi0",
-    'description': "d0-phi0 correlation of selected tracks - <a href=https://twiki.cern.ch/twiki/bin/view/CMS/BeamMonitorOnlineDQMInstructions>BeamMonitorOnlineDQMInstructions</a> "}])
+ [{ 'path': "BeamMonitorHLT/Fit/d0_phi0",
+    'description': "d0-phi0 correlation of selected tracks - <a href=https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftBeamMonitor>BeamMonitorOnlineDQMInstructions</a> "}])
 shiftbeamlayout(dqmitems, "02 - z0 of selected tracks",
- [{ 'path': "BeamMonitor/Fit/trk_z0",
-    'description': "Z0 distribution of selected tracks  - <a href=https://twiki.cern.ch/twiki/bin/view/CMS/BeamMonitorOnlineDQMInstructions>BeamMonitorOnlineDQMInstructions</a> "}])
+ [{ 'path': "BeamMonitorHLT/Fit/trk_z0",
+    'description': "Z0 distribution of selected tracks  - <a href=https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftBeamMonitor>BeamMonitorOnlineDQMInstructions</a> "}])
 shiftbeamlayout(dqmitems, "03 - fit results beam spot",
- [{ 'path': "BeamMonitor/Fit/fitResults",
-    'description': "d_{0}-#phi correlation fit results of beam spot"}])
+ [{ 'path': "BeamMonitorHLT/Fit/fitResults",
+    'description': "d_{0}-#phi correlation fit results of beam spot",
+    'draw': { 'drawopts': "TEXT" } }])
 shiftbeamlayout(dqmitems, "04 - fitted x0, sigma(x0) vs LS",
- [{ 'path': "BeamMonitor/Fit/x0_lumi",'description': "x coordinate of beamspot vs LS"}],
- [{ 'path': "BeamMonitor/Fit/sigmaX0_lumi",'description': "sigma X of beamspot vs LS"}])
+ [{ 'path': "BeamMonitorHLT/Fit/x0_lumi",'description': "x coordinate of beamspot vs LS"}],
+ [{ 'path': "BeamMonitorHLT/Fit/sigmaX0_lumi",'description': "sigma X of beamspot vs LS"}])
 shiftbeamlayout(dqmitems, "05 - fitted y0, sigma(y0) vs LS",
- [{ 'path': "BeamMonitor/Fit/y0_lumi",'description': "y coordinate of beamspot vs LS"}],
- [{ 'path': "BeamMonitor/Fit/sigmaY0_lumi",'description': "sigma Y of beamspot vs LS"}])
+ [{ 'path': "BeamMonitorHLT/Fit/y0_lumi",'description': "y coordinate of beamspot vs LS"}],
+ [{ 'path': "BeamMonitorHLT/Fit/sigmaY0_lumi",'description': "sigma Y of beamspot vs LS"}])
 shiftbeamlayout(dqmitems, "06 - fitted z0, sigma(z0) vs LS",
- [{ 'path': "BeamMonitor/Fit/z0_lumi",'description': "z coordinate of beamspot vs LS"}],
- [{ 'path': "BeamMonitor/Fit/sigmaZ0_lumi",'description': "sigma Z of beamspot vs LS"}])
+ [{ 'path': "BeamMonitorHLT/Fit/z0_lumi",'description': "z coordinate of beamspot vs LS"}],
+ [{ 'path': "BeamMonitorHLT/Fit/sigmaZ0_lumi",'description': "sigma Z of beamspot vs LS"}])
+shiftbeamlayout(dqmitems, "07 - chosen beam spot fit",
+ [{ 'path': "OnlineBeamMonitor/Validation/bsChoice",
+    'description': "chosen beam spot between Legacy or HLT fit, or fake beam spot"}])

--- a/dqmgui/style/BeamRenderPlugin.cc
+++ b/dqmgui/style/BeamRenderPlugin.cc
@@ -23,7 +23,8 @@ class BeamRenderPlugin : public DQMRenderPlugin {
 
 public:
   virtual bool applies( const VisDQMObject &o, const VisDQMImgInfo & ) {
-    if ((o.name.find( "BeamMonitor/" )               == std::string::npos) &&
+    if ((o.name.find( "BeamMonitor/" )              == std::string::npos) &&
+	(o.name.find( "BeamMonitorHLT/" )            == std::string::npos) &&
 	(o.name.find( "BeamMonitor_PixelLess/" )     == std::string::npos) &&
 	(o.name.find( "TrackingHLTBeamspotStream/" ) == std::string::npos))
       return false;
@@ -107,12 +108,19 @@ private:
     xa->SetLabelSize(0.045);
     ya->SetLabelSize(0.045);
 
-    if ( o.name.find( "fitResults" )  != std::string::npos ||
-	 o.name.find( "pvResults" )  != std::string::npos ||
+    if ( o.name.find( "pvResults" )  != std::string::npos ||
 	 o.name.find( "_bx" )  != std::string::npos ) {
       c->SetGrid();
       obj->SetStats( kFALSE );
       obj->SetMarkerSize(2.);
+      return;
+    }
+
+    if ( o.name.find( "fitResults" )  != std::string::npos) {
+      c->SetGrid();
+      obj->SetStats( kFALSE );
+      obj->SetMarkerSize(2.);
+      obj->SetOption("text");
       return;
     }
 


### PR DESCRIPTION
### PR Description
Following the changes made to the BeamSpot folders in online DQM for Run3, it was requested by DQM experts (@syuvivida) to udpate the DQM Shifter folder as well.
In this PR we update the `00_Shift/BeamMonitor` folder to contain the following plots:
 - `X,Y,Z` positions and widths taken from the BeamMonitorHLT folder
 - `d0_phi0` and `trk_z0` from the BeamMonitorHLT folder
 - `reportSummaryMap` from the BeamMonitorHLT folder
 - `bsChoice` from the OnlineBeamMonitor folder
 
 ### Rendering
 The GUI has been tested in local and the output looks (as expected) as shown in this screenshot:
<img width="1440" alt="DQM_shifter_layout" src="https://github.com/dmwm/deployment/assets/7822641/51b40265-4b60-4037-91c6-1c90ef4be0ca">

### Next Updates 
 The Shifter twiki ([here](https://twiki.cern.ch/twiki/bin/view/CMS/DQMShiftBeamMonitor)) will be udpated soon.
 
 FYI @mmusich @gennai @dzuolo