### PR TITLE
Update rules for redirection of DQM^2 Mirror requests to new rubu machines

### DIFF
--- a/frontend/app_dqm_nossl.conf
+++ b/frontend/app_dqm_nossl.conf
@@ -8,6 +8,7 @@ RewriteRule ^(/dqm/online-test-new(/.*)?)$     https://%{SERVER_NAME}${escape:$1
 RewriteRule ^(/dqm/hcal-online(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square-origin(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/dqm-square-origin-rubu(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square-k8(/.*)?)$             https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 
 # Redirect rules for offline DQM, back to the https interface.

--- a/frontend/app_dqm_ssl.conf
+++ b/frontend/app_dqm_ssl.conf
@@ -1,5 +1,5 @@
 RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie;limited-proxy;cert;host]
-RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square|dqm-square-origin)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square|dqm-square-origin|dqm-square-origin-rubu)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/autodqm(/.*)?)$ http://%{ENV:BACKEND}:8083${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dqm-square-k8(/.*)?)$ http://%{ENV:BACKEND}:8084${escape:$1} [QSA,P,L,NE]

--- a/frontend/backends-k8s-preprod.txt
+++ b/frontend/backends-k8s-preprod.txt
@@ -2,7 +2,7 @@
 ^/auth/complete/reqmgr2(?:/|$) reqmgr2.dmwm.svc.cluster.local
 ^/auth/complete/phedex(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin|dqm-square-origin-rubu)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/offline(?:/|$) vocms0738.cern.ch

--- a/frontend/backends-k8s-prod.txt
+++ b/frontend/backends-k8s-prod.txt
@@ -1,6 +1,6 @@
 ^/auth/complete/phedex(?:/|$) vocms0136.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0136.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin|dqm-square-origin-rubu)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline-new)(?:/|$) cmsweb-srv.cern.ch

--- a/frontendx509/app_dqm_nossl.conf
+++ b/frontendx509/app_dqm_nossl.conf
@@ -8,6 +8,7 @@ RewriteRule ^(/dqm/online-test-new(/.*)?)$     https://%{SERVER_NAME}${escape:$1
 RewriteRule ^(/dqm/hcal-online(/.*)?)$     https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square-origin(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
+RewriteRule ^(/dqm/dqm-square-origin-rubu(/.*)?)$      https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 RewriteRule ^(/dqm/dqm-square-k8(/.*)?)$             https://%{SERVER_NAME}${escape:$1}%{env:CMS_QUERY} [R=301,NE,L]
 
 # Redirect rules for offline DQM, back to the https interface.

--- a/frontendx509/app_dqm_ssl.conf
+++ b/frontendx509/app_dqm_ssl.conf
@@ -1,5 +1,5 @@
 RewriteRule ^(/dqm(/.*)?)$ /auth/verify${escape:$1} [QSA,PT,E=AUTH_SPEC:aucookie;limited-proxy;cert;host]
-RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square|dqm-square-origin)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
+RewriteRule ^/auth/complete(/dqm/(online|online-playback|online-test|online-new|online-playback-new|online-test-new|hcal-online|dqm-square|dqm-square-origin|dqm-square-origin-rubu)(/.*)?)$ http://%{ENV:BACKEND}${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dev(/.*)?)$ http://%{ENV:BACKEND}:8060${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/autodqm(/.*)?)$ http://%{ENV:BACKEND}:8083${escape:$1} [QSA,P,L,NE]
 RewriteRule ^/auth/complete(/dqm/dqm-square-k8(/.*)?)$ http://%{ENV:BACKEND}:8084${escape:$1} [QSA,P,L,NE]

--- a/frontendx509/backends-k8s-preprod.txt
+++ b/frontendx509/backends-k8s-preprod.txt
@@ -2,7 +2,7 @@
 ^/auth/complete/reqmgr2(?:/|$) reqmgr2.dmwm.svc.cluster.local
 ^/auth/complete/phedex(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0132.cern.ch|vocms0731.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin|dqm-square-origin-rubu)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch

--- a/frontendx509/backends-k8s-prod.txt
+++ b/frontendx509/backends-k8s-prod.txt
@@ -1,6 +1,6 @@
 ^/auth/complete/phedex(?:/|$) vocms0136.cern.ch :affinity
 ^/auth/complete/phedex/datasvc(?:/|$) vocms0136.cern.ch :affinity
-^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin)(?:/|$) cmsdqm.cern.ch
+^/auth/complete/dqm/(?:online|online-playback|online-test|online-new|online-playback-new|online-test-new|dqm-square|dqm-square-origin|dqm-square-origin-rubu)(?:/|$) cmsdqm.cern.ch
 ^/auth/complete/dqm/hcal-online(?:/|$) cmshcaldqm.cern.ch
 ^/auth/complete/dqm/(?:dev|offline-test|offline-test-new|relval-test|relval-test-new)(?:/|$) vocms0731.cern.ch
 ^/auth/complete/dqm/(?:offline|offline-new)(?:/|$) vocms0738.cern.ch


### PR DESCRIPTION
We are in the process of migrating some services running at P5 machines which are going to be replaced by new ones, and we would like to have a (temporary) separate route for the new machines, until we have tested the new deployment. 

This PR was based on a [previous one](https://github.com/dmwm/deployment/pull/1104), which served the same purpose. Please let me know if anything is missing.  

Also tagging @syuvivida 

Thank you!