### PR TITLE
Update WMAgent deployment to parse MSPILEUP_URL - take2

### DIFF
--- a/wmagentpy3/manage
+++ b/wmagentpy3/manage
@@ -66,6 +66,8 @@ RUCIO_HOST=
 RUCIO_AUTH=
 RUCIO_ACCOUNT=
 
+MSPILEUP_URL=
+
 #
 # Init checks
 #
@@ -133,6 +135,7 @@ load_secrets_file(){
     local MATCH_RUCIO_HOST=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_HOST | sed s/RUCIO_HOST=//`
     local MATCH_RUCIO_AUTH=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_AUTH | sed s/RUCIO_AUTH=//`
     local MATCH_RUCIO_ACCOUNT=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_ACCOUNT | sed s/RUCIO_ACCOUNT=//`
+    local MATCH_MSPILEUP_URL=`cat $WMAGENT_SECRETS_LOCATION | grep MSPILEUP_URL | sed s/MSPILEUP_URL=//`
 
     # database settings (mysql or oracle)
     if [ "x$MATCH_ORACLE_USER" == "x" ]; then
@@ -194,6 +197,8 @@ load_secrets_file(){
     RUCIO_HOST=${MATCH_RUCIO_HOST:-$RUCIO_HOST}
     RUCIO_AUTH=${MATCH_RUCIO_AUTH:-$RUCIO_AUTH}
     RUCIO_ACCOUNT=${MATCH_RUCIO_ACCOUNT:-$RUCIO_ACCOUNT}
+
+    MSPILEUP_URL=${MATCH_MSPILEUP_URL:-$MSPILEUP_URL}
 }
 
 print_settings(){
@@ -228,6 +233,7 @@ print_settings(){
     echo "RUCIO_HOST=                $RUCIO_HOST                "
     echo "RUCIO_AUTH=                $RUCIO_AUTH                "
     echo "RUCIO_ACCOUNT=             $RUCIO_ACCOUNT             "
+    echo "MSPILEUP_URL=              $MSPILEUP_URL              "
 
 }
 
@@ -582,7 +588,8 @@ init_wmagent(){
 	                   --amq_credentials=$AMQ_CREDENTIALS \
 	                   --rucio_account=$RUCIO_ACCOUNT \
 	                   --rucio_host=$RUCIO_HOST \
-	                   --rucio_auth=$RUCIO_AUTH
+	                   --rucio_auth=$RUCIO_AUTH \
+	                   --mspileup_url=$MSPILEUP_URL
 
     wmcore-db-init --config $CONFIG_AG/config.py --create --modules=WMCore.WMBS,WMCore.Agent.Database,WMComponent.DBS3Buffer,WMCore.BossAir,WMCore.ResourceControl;
 


### PR DESCRIPTION
Deployment updates for WMAgent to go together with https://github.com/dmwm/WMCore/pull/11795

Please do not merge it yet.

@todor-ivanov we need to decide whether:
a) we enforce the new `mspileup_url` parameter, but then it's not backwards compatible.
b) we only pass the `mspileup_url` parameter if it's found in the secrets file, but then we might be deploying agents in the future without seeing that the MSPileup endpoint was not configured in the agent.

I opted for a) for the moment, but if you prefer, I can change it to b). Please let me know.