### PR TITLE
[DQM] Fix missed character escape in acrontab creation

### DIFF
--- a/dqmgui/deploy
+++ b/dqmgui/deploy
@@ -69,11 +69,11 @@ deploy_dqmgui_post() {
     (
       acrontab -l | { grep -E -v -e " $host.*$project_config/" || true; }
       # backup of the index
-      echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"dev DQM GUI Index Backup, exit code: \$ret\" -a $project_logs/dev/agent-castorindexbackup-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"dev DQM GUI Index Backup, exit code: \$ret\" -a $project_logs/dev/agent-castorindexbackup-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
       # backup of the zipped root files
-      echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"dev DQM GUI Zip Backup, exit code: \$ret\" -a $project_logs/dev/agent-castorzipbackup-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"dev DQM GUI Zip Backup, exit code: \$ret\" -a $project_logs/dev/agent-castorzipbackup-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
       # check/verification of the backup of the zipped root files
-      echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"dev DQM GUI Zip Backup Check, exit code: \$ret\" -a $project_logs/dev/agent-castorzipbackupcheck-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"dev DQM GUI Zip Backup Check, exit code: \$ret\" -a $project_logs/dev/agent-castorzipbackupcheck-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
     ) | acrontab
     ;;
   # Offline GUI
@@ -82,11 +82,11 @@ deploy_dqmgui_post() {
     (
       acrontab -l | { grep -E -v -e " $host.*$project_config/" || true; }
       # backup of the index
-      echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"Offline DQM GUI Index Backup, exit code: \$ret\" -a $project_logs/offline/agent-castorindexbackup-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"Offline DQM GUI Index Backup, exit code: \$ret\" -a $project_logs/offline/agent-castorindexbackup-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
       # backup of the zipped root files
-      echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup| mailx -s \"Offline DQM GUI Zip Backup, exit code: \$ret\" -a $project_logs/offline/agent-castorzipbackup-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup| mailx -s \"Offline DQM GUI Zip Backup, exit code: \$ret\" -a $project_logs/offline/agent-castorzipbackup-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
       # check/verification of the backup of the zipped root files
-      echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"Offline DQM GUI Zip Backup Check, exit code: \$ret\" -a $project_logs/offline/agent-castorzipbackupcheck-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"Offline DQM GUI Zip Backup Check, exit code: \$ret\" -a $project_logs/offline/agent-castorzipbackupcheck-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
     ) | acrontab
     ;;
   # RelVal GUI
@@ -95,11 +95,11 @@ deploy_dqmgui_post() {
     (
       acrontab -l | { grep -E -v -e " $host.*$project_config/" || true; }
       # backup of the index
-      echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"RelVal DQM GUI Index Backup, exit code: \$ret\" -a $project_logs/relval/agent-castorindexbackup-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "0 7 * * * $host $project_config/manage indexbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"RelVal DQM GUI Index Backup, exit code: \$ret\" -a $project_logs/relval/agent-castorindexbackup-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
       # backup of the zipped root files
-      echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup| mailx -s \"RelVal DQM GUI Zip Backup, exit code: \$ret\" -a $project_logs/relval/agent-castorzipbackup-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "*/15 * * * * $host $project_config/manage zipbackup 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup| mailx -s \"RelVal DQM GUI Zip Backup, exit code: \$ret\" -a $project_logs/relval/agent-castorzipbackup-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
       # check/verification of the backup of the zipped root files
-      echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"RelVal DQM GUI Zip Backup Check, exit code: \$ret\" -a $project_logs/relval/agent-castorzipbackupcheck-$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
+      echo "*/15 * * * * $host $project_config/manage zipbackupcheck 'I did read documentation'; ret=\$?; if [ \$ret -ne 3 ] && [ \$ret -ne 0 ] && [ \$ret -ne 4 ]; then echo Error during backup | mailx -s \"RelVal DQM GUI Zip Backup Check, exit code: \$ret\" -a $project_logs/relval/agent-castorzipbackupcheck-\$(printf '%(%Y%m%d)T' -1)-$host.log cmsweb-operator@cern.ch; fi"
     ) | acrontab
     ;;
   # Any other machine: do nothing


### PR DESCRIPTION
In continuation of https://github.com/dmwm/deployment/pull/1292, escape a `$` so that `printf` runs each time the cronjob is triggered and not only during acrontab creation.