### PR TITLE
Modernize DT DQM GUI layouts and add online DT DQM GUI customisation

### DIFF
--- a/dqmgui/layouts/dt-layouts.py
+++ b/dqmgui/layouts/dt-layouts.py
@@ -1,31 +1,31 @@
+
+DT_TWIKI = f"<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>"
+
 def dtlayout(i, p, *rows): i["DT/Layouts/" + p] = DQMItem(layout=rows)
 
 dtlayout(dqmitems, "00-Summary/00-DataIntegritySummary",
-  [{ 'path': "DT/00-DataIntegrity/DataIntegritySummary", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/00-DataIntegrity/DataIntegritySummary", 'description': DT_TWIKI }])
 
 dtlayout(dqmitems, "00-Summary/00-ROChannelSummary",
-  [{ 'path': "DT/00-ROChannels/ROChannelSummary", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/00-ROChannels/ROChannelSummary", 'description': DT_TWIKI }])
 
 dtlayout(dqmitems, "00-Summary/01-OccupancySummary",
-  [{ 'path': "DT/01-Digi/OccupancySummary", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/01-Digi/OccupancySummary", 'description': DT_TWIKI }])
 
 dtlayout(dqmitems, "00-Summary/02-SegmentSummary",
-  [{ 'path': "DT/02-Segments/segmentSummary", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/02-Segments/segmentSummary", 'description': DT_TWIKI }])
 
 dtlayout(dqmitems, "00-Summary/03-TM_TriggerCorrFractionSummaryIn",
-  [{ 'path': "DT/03-LocalTrigger-TM/TM_CorrFractionSummaryIn", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/03-LocalTrigger-TM/TM_CorrFractionSummaryIn", 'description': DT_TWIKI }])
 
 dtlayout(dqmitems, "00-Summary/04-TM_Trigger2ndFractionSummaryIn",
-  [{ 'path': "DT/03-LocalTrigger-TM/TM_2ndFractionSummaryIn", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/03-LocalTrigger-TM/TM_2ndFractionSummaryIn", 'description': DT_TWIKI }])
 
 dtlayout(dqmitems, "00-Summary/05-NoiseChannelsSummary",
-  [{ 'path': "DT/05-Noise/NoiseSummary", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/05-Noise/NoiseSummary", 'description': DT_TWIKI }])
 
 dtlayout(dqmitems, "00-Summary/06-SynchNoiseSummary",
-         [{ 'path': "DT/05-Noise/SynchNoise/SynchNoiseSummary", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
-
-#dtlayout(dqmitems, "00-Summary/09-TestPulseOccupancy",
-#         [{ 'path': "DT/10-TestPulses/OccupancySummary", 'description': "<a href=https://twiki.cern.ch/twiki/bin/view/CMS/DTDQMPlots>Description and Instructions</a>" }])
+  [{ 'path': "DT/05-Noise/SynchNoise/SynchNoiseSummary", 'description': DT_TWIKI }])
 
 #### OCCUPANCIES #################################################################################
 
@@ -34,9 +34,9 @@ for wheel in range(-2, 3):
         for sector in range (1, 15):
             if station != 4 and (sector == 13 or sector == 14):
                 continue
-            name = "01-Occupancy/Wheel" + str(wheel) + "/St" + str(station) + "_Sec" + str(sector)
-            histoname = "DT/01-Digi/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station" + str(station) +  "/OccupancyAllHits_perCh_W" + str(wheel) + "_St" + str(station) + "_Sec" +  str(sector)
-            dtlayout(dqmitems, name,[{ 'path': histoname}])
+            name = f"01-Occupancy/Wheel{wheel}/St{station}_Sec{sector}"
+            histo_name = f"DT/01-Digi/Wheel{wheel}/Sector{sector}/Station{station}/OccupancyAllHits_perCh_W{wheel}_St{station}_Sec{sector}"
+            dtlayout(dqmitems, name,[{ 'path': histo_name}])
 
 #### TIME BOXES #################################################################################
 
@@ -45,110 +45,119 @@ for wheel in range(-2, 3):
         for station in range (1, 5):
             if station != 4 and (sector == 13 or sector == 14):
                 continue
-            name = "02-TimeBoxes/Wheel" + str(wheel) + "/St" + str(station) + "_Sec" + str(sector)
-            histoname = "DT/01-Digi/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station" + str(station) +  "/TimeBox_W" + str(wheel) + "_St" + str(station) + "_Sec" +  str(sector)
-            histoname_SL1 = histoname + "_SL1"
-            histoname_SL2 = histoname + "_SL2"
-            histoname_SL3 = histoname + "_SL3"
+            name = f"02-TimeBoxes/Wheel{wheel}/St{station}_Sec{sector}"
+            histo_name = f"DT/01-Digi/Wheel{wheel}/Sector{sector}/Station{station}/TimeBox_W{wheel}_St{station}_Sec{sector}"
+            histo_name_SL1 = f"{histo_name}_SL1"
+            histo_name_SL2 = f"{histo_name}_SL2"
+            histo_name_SL3 = f"{histo_name}_SL3"
             if station != 4:
-                dtlayout(dqmitems, name,[{ 'path': histoname_SL1}],
-                         [{ 'path': histoname_SL2}],
-                         [{ 'path': histoname_SL3}])
+                dtlayout(dqmitems, name,[{ 'path': histo_name_SL1}],
+                                        [{ 'path': histo_name_SL2}],
+                                        [{ 'path': histo_name_SL3}])
             else:
-                dtlayout(dqmitems, name,[{ 'path': histoname_SL1}],
-                         [{ 'path': histoname_SL3}])
+                dtlayout(dqmitems, name,[{ 'path': histo_name_SL1}],
+                                        [{ 'path': histo_name_SL3}])
 
-#### EVENT SIZE #################################################################################
-for fed in range(770, 775):
-   name = name = "03-FEDEventSize/FED" + str(fed)
-   histoname = "DT/00-DataIntegrity/FED" + str(fed) + "/FED" + str(fed) + "_EventLenght"
-   dtlayout(dqmitems, name,[{ 'path': histoname}])
-   for rosid in range(1, 13):
-       ros = rosid
-       name = "04-ROSEventSize/FED" + str(fed) + "_ROS" + str(ros)
-       histoname = "DT/00-DataIntegrity/FED" + str(fed) + "/ROS" + str(ros) + "/FED" + str(fed) + "_ROS" + str(ros) + "_ROSEventLenght"
-       dtlayout(dqmitems, name,[{ 'path': histoname}])
+## EVENT SIZE #################################################################################
+
+for fed in range(1369, 1372):
+   name = f"03-FEDEventSize/FED{fed}"
+   histo_name = f"DT/00-DataIntegrity/FED{fed}/FED{fed}_EventLength"
+   dtlayout(dqmitems, name,[{ 'path': histo_name}])
+   for u_ros in range(1, 13):
+       name = f"04-ROSEventSize/FED{fed}_uROS{u_ros}"
+       histo_name = f"DT/00-DataIntegrity/FED{fed}/uROS{u_ros}/FED{fed}_uROS{u_ros}_EventLength"
+       dtlayout(dqmitems, name,[{ 'path': histo_name}])
 
 #### TRIGGER SYNCH ##############################################################################
 
 for wheel in range(-2, 3):
-    name = "05-TriggerSynch/01-CorrectBX_In_Wh" + str(wheel) + "_TM"
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_CorrectBXPhiIn_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
-    name = "05-TriggerSynch/Peak-Mean/01-Peak-Mean_In_Wh" + str(wheel) + "_TM"
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_ResidualBXPhiIn_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
-    name = "05-TriggerSynch/01-CorrectBX_Out_Wh" + str(wheel) + "_TM"
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_CorrectBXPhiOut_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
-    name = "05-TriggerSynch/Peak-Mean/01-Peak-Mean_Out_Wh" + str(wheel) + "_TM"
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_ResidualBXPhiOut_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
+    name = f"05-TriggerSynch/01-CorrectBX_In_Wh{wheel}_TM"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_CorrectBXPhiIn_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
+    name = f"05-TriggerSynch/Peak-Mean/01-Peak-Mean_In_Wh{wheel}_TM"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_ResidualBXPhiIn_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
+    name = f"05-TriggerSynch/01-CorrectBX_Out_Wh{wheel}_TM"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_CorrectBXPhiOut_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
+    name = f"05-TriggerSynch/Peak-Mean/01-Peak-Mean_Out_Wh{wheel}_TM"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_ResidualBXPhiOut_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
 
 #### TRIGGER BASICS ##############################################################################
 
 for wheel in range(-2, 3):
-    name = "06-TriggerBasics/01-CorrFraction_In_Wh" + str(wheel) + "_TM"
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_CorrFractionPhiIn_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
-    name = "06-TriggerBasics/03-2ndFractionPhi_In_Wh" + str(wheel)
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_2ndFractionPhiIn_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
-    name = "06-TriggerBasics/01-CorrFraction_Out_Wh" + str(wheel) + "_TM"
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_CorrFractionPhiOut_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
-    name = "06-TriggerBasics/03-2ndFractionPhi_Out_Wh" + str(wheel)
-    histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/TM_2ndFractionPhiOut_W" + str(wheel)
-    dtlayout(dqmitems, name,[{ 'path': histoname}])
+    name = f"06-TriggerBasics/01-CorrFraction_In_Wh{wheel}_TM"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_CorrFractionPhiIn_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
+    name = f"06-TriggerBasics/03-2ndFractionPhi_In_Wh{wheel}"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_2ndFractionPhiIn_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
+    name = f"06-TriggerBasics/01-CorrFraction_Out_Wh{wheel}_TM"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_CorrFractionPhiOut_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
+    name = f"06-TriggerBasics/03-2ndFractionPhi_Out_Wh{wheel}"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_2ndFractionPhiOut_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
 
-#### TRIGGER POS LUTs ###########################################################################
+## TRIGGER POS LUTs ###########################################################################
+
 for wheel in range(-2, 3):
     for sector in range (1, 13):
-        name = "07-TriggerPosLUTs/Wheel" + str(wheel) + "/Sec" + str(sector) + " In"
-        histoname1 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station1/Segment/TM_PhiResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St1"
-        histoname2 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station2/Segment/TM_PhiResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St2"
-        histoname3 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station3/Segment/TM_PhiResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St3"
-        histoname4 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station4/Segment/TM_PhiResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St4"
-        dtlayout(dqmitems, name,[{ 'path': histoname1},{ 'path': histoname2}],
-                 [{ 'path': histoname3},{ 'path': histoname4}])
-	name = "07-TriggerPosLUTs/Wheel" + str(wheel) + "/Sec" + str(sector) + " Out"
-        histoname5 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station1/Segment/TM_PhiResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St1"
-        histoname6 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station2/Segment/TM_PhiResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St2"
-        histoname7 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station3/Segment/TM_PhiResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St3"
-        histoname8 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station4/Segment/TM_PhiResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St4"
-	dtlayout(dqmitems, name,[{ 'path': histoname5},{ 'path': histoname6}],
-		 [{ 'path': histoname7},{ 'path': histoname8}])
+        name = f"07-TriggerPosLUTs/Wheel{wheel}/Sec{sector} In"
+        histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/Sector{sector}/Station{{station}}/Segment/TM_PhiResidualIn_W{wheel}_Sec{sector}_St{{station}}"
+        histo_name_1 = histo_name.format(station = 1)
+        histo_name_2 = histo_name.format(station = 2)
+        histo_name_3 = histo_name.format(station = 3)
+        histo_name_4 = histo_name.format(station = 4)
+        dtlayout(dqmitems, name,[{ 'path': histo_name_1},{ 'path': histo_name_2}],
+                                [{ 'path': histo_name_3},{ 'path': histo_name_4}])
+
+        name = f"07-TriggerPosLUTs/Wheel{wheel}/Sec{sector} Out"
+        histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/Sector{sector}/Station{{station}}/Segment/TM_PhiResidualOut_W{wheel}_Sec{sector}_St{{station}}"
+        histo_name_1 = histo_name.format(station = 1)
+        histo_name_2 = histo_name.format(station = 2)
+        histo_name_3 = histo_name.format(station = 3)
+        histo_name_4 = histo_name.format(station = 4)
+        dtlayout(dqmitems, name,[{ 'path': histo_name_1},{ 'path': histo_name_2}],
+                                [{ 'path': histo_name_3},{ 'path': histo_name_4}])
 
 #### TRIGGER DIR LUTs ###########################################################################
+
 for wheel in range(-2, 3):
     for sector in range (1, 13):
-        name = "08-TriggerDirLUTs/Wheel" + str(wheel) + "/Sec" + str(sector) + " In"
-        histoname1 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station1/Segment/TM_PhibResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St1"
-        histoname2 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station2/Segment/TM_PhibResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St2"
-        histoname3 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station3/Segment/TM_PhibResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St3"
-        histoname4 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station4/Segment/TM_PhibResidualIn_W" + str(wheel) + "_Sec" +  str(sector) + "_St4"
-        dtlayout(dqmitems, name,[{ 'path': histoname1},{ 'path': histoname2}],
-                  [{ 'path': histoname3},{ 'path': histoname4}])
-        name = "08-TriggerDirLUTs/Wheel" + str(wheel) + "/Sec" + str(sector) + " Out"
-        histoname5 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station1/Segment/TM_PhibResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St1"
-        histoname6 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station2/Segment/TM_PhibResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St2"
-        histoname7 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station3/Segment/TM_PhibResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St3"
-        histoname8 = "DT/03-LocalTrigger-TM/Wheel" + str(wheel) + "/Sector" + str(sector) + "/Station4/Segment/TM_PhibResidualOut_W" + str(wheel) + "_Sec" +  str(sector) + "_St4"
-        dtlayout(dqmitems, name,[{ 'path': histoname5},{ 'path': histoname6}],
-                  [{ 'path': histoname7},{ 'path': histoname8}])
+        name = f"08-TriggerDirLUTs/Wheel{wheel}/Sec{sector} In"
+        histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/Sector{sector}/Station{{station}}/Segment/TM_PhibResidualIn_W{wheel}_Sec{sector}_St{{station}}"
+        histo_name_1 = histo_name.format(station = 1)
+        histo_name_2 = histo_name.format(station = 2)
+        histo_name_3 = histo_name.format(station = 3)
+        histo_name_4 = histo_name.format(station = 4)
+        dtlayout(dqmitems, name,[{ 'path': histo_name_1},{ 'path': histo_name_2}],
+                                [{ 'path': histo_name_3},{ 'path': histo_name_4}])
 
+        name = f"08-TriggerDirLUTs/Wheel{wheel}/Sec{sector} Out"
+        histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/Sector{sector}/Station{{station}}/Segment/TM_PhibResidualOut_W{wheel}_Sec{sector}_St{{station}}"
+        histo_name_1 = histo_name.format(station = 1)
+        histo_name_2 = histo_name.format(station = 2)
+        histo_name_3 = histo_name.format(station = 3)
+        histo_name_4 = histo_name.format(station = 4)
+        dtlayout(dqmitems, name,[{ 'path': histo_name_1},{ 'path': histo_name_2}],
+                                [{ 'path': histo_name_3},{ 'path': histo_name_4}])
 
-#### HITS RESIDUALS ###########################################################################
+#### HITS PER SEGMENT ###########################################################################
+
 for wheel in range(-2, 3):
     for station in range (1, 5):
         for sector in range (1, 15):
             if station != 4 and (sector == 13 or sector == 14):
                continue
-            name = "09-Nhits/Wheel" + str(wheel) + "/Sector" + str(sector) + "_Station" + str(station)
-            histoname = "DT/02-Segments/Wheel" + str(wheel)+ "/Sector" + str(sector) + "/Station" + str(station) + "/h4DSegmNHits_W" + str(wheel) + "_St" + str(station) + "_Sec" + str(sector)
-            dtlayout(dqmitems, name,[{ 'path': histoname}])
+            name = f"09-Nhits/Wheel{wheel}/Sector{sector}_Station{station}"
+            histo_name = f"DT/02-Segments/Wheel{wheel}/Sector{sector}/Station{station}/h4DSegmNHits_W{wheel}_St{station}_Sec{sector}"
+            dtlayout(dqmitems, name,[{ 'path': histo_name}])
 
 #### SEGMENTS RESIDUALS #########################################################################
+
 for wheel in range(-2, 3):
     for station in range (1, 5):
         for sector in range (1, 15):
@@ -157,20 +166,15 @@ for wheel in range(-2, 3):
             for sl in range (1, 4):
                 if sl == 2 and (sector == 13 or sector == 14 or station == 4):
                    continue
-                name = "10-Segments/Wheel" + str(wheel) + "/Sector" + str(sector) + "_Station" + str(station) + "_SL" + str(sl)
-                histoname = "DT/02-Segments/Wheel" + str(wheel)+ "/Sector" + str(sector) + "/Station" + str(station) + "/hResDist_W" + str(wheel) + "_St" + str(station) + "_Sec" + str(sector) + "_SL" + str(sl)
-                dtlayout(dqmitems, name,[{ 'path': histoname}])
+                name = f"10-Segments/Wheel{wheel}/Sector{sector}_Station{station}_SL{sl}"
+                histo_name = f"DT/02-Segments/Wheel{wheel}/Sector{sector}/Station{station}/hResDist_W{wheel}_St{station}_Sec{sector}_SL{sl}"
+                dtlayout(dqmitems, name,[{ 'path': histo_name}])
 
 #### QUALITY vs PHI RAD ############################################################################
+
 for wheel in range(-2, 3):
     for station in range (1, 5):
         for sector in range (1, 13):
-            name = "11-QualityPhi/Wheel" + str(wheel) + "/Sector" + str(sector) + "_Station" + str(station)
-            histoname = "DT/03-LocalTrigger-TM/Wheel" + str(wheel)+ "/Sector" + str(sector) + "/Station" + str(station) + "/LocalTriggerPhiIn/TM_QualvsPhirad_In_W" + str(wheel) + "_Sec" + str(sector) + "_St" + str(station)
-            dtlayout(dqmitems, name,[{ 'path': histoname}])
-
-#
-#
-#
-#
-#
+            name = f"11-QualityPhi/Wheel{wheel}/Sector{sector}_Station{station}"
+            histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/Sector{sector}/Station{station}/LocalTriggerPhiIn/TM_QualvsPhirad_In_W{wheel}_Sec{sector}_St{station}"
+            dtlayout(dqmitems, name,[{ 'path': histo_name}])

--- a/dqmgui/server-conf-online.py
+++ b/dqmgui/server-conf-online.py
@@ -104,6 +104,13 @@ elif HOSTALIAS == "dqmfu-c2b02-46-01":  # ECAL/HCAL DQMFU
         SERVICENAME = "Online Ecal"
         BASEURL = "/dqm/ecal-online"
 
+elif HOSTALIAS == "dqmfu-c2b03-46-01":  # Muon DQMFU                                                                                              
+    if "dtdqm" in USERNAME:
+        COLLPORT = 9090
+        SERVERPORT = 9010
+        SERVICENAME = "Online DT"
+        BASEURL = "/dqm/dt-online"
+
 # Server configuration.
 modules = ("Monitoring.DQM.GUI",)
 


### PR DESCRIPTION
**PR** prepared as discussed over mattermost with DQM L2 convener (@syuvivida).

Includes the following updates to the DQM GUI:

- modifications to `dt-layouts.py` to make it work in the latest GUI version
- an update to `dqmgui/server-conf-online.py` that applies customisations targeting the deployment of a private DT DQM online GUI instance

Both were tested using a personal deployment of the DQM GUI at P5.
As I am not familiar with the rules for PR testing within this repository, I remain at disposal in case further work is needed on the DT community side.
