### PR TITLE
Replace the 2023 run number with 2024 run number when performing DQM file indexing

### DIFF
--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -456,7 +456,7 @@ start_agents_offline() {
       $DQM_DATA/agents/register \
       $DQM_DATA/data \
       $DQM_DATA/ix128 \
-      --min_run 365753 \
+      --min_run 376824 \
       --next $DQM_DATA/agents/qcontrol $DQM_DATA/agents/vcontrol \
       --rsync \
       --rsyncnext $DQM_DATA/agents/ixstageout \


### PR DESCRIPTION
In the visDQMImportDaemon, we give priority to files with run numbers greater than xxxxxx so that when the offline DQMGUI servers receive DQM root files from both PromptReco and ReReco, the PromptReco data (new incoming data) will be indexed before the ReReco data. 

The run number is now replaced with the first Cosmics24 run number: 376824.