### PR TITLE
Cast generic TH2 instead of TH2F

### DIFF
--- a/dqmgui/style/DTRenderPlugin.cc
+++ b/dqmgui/style/DTRenderPlugin.cc
@@ -215,7 +215,7 @@ private:
 
   void preDrawTH2( TCanvas *c, const VisDQMObject &o )
     {
-      TH2F* obj = dynamic_cast<TH2F*>( o.object );
+      TH2* obj = dynamic_cast<TH2*>( o.object );
       assert( obj );
 
       // This applies to all


### PR DESCRIPTION
Tested in playback version of Online DQM, it prevents from crashing TH2D histograms which were blacklisted up to now
Thanks @nothingface0 for spotting this and provide a solution!