### PR TITLE
Make the display of sqrt(s) energy flexible in the report summar map of DQMGUI

### DIFF
--- a/dqmgui/style/DQMInfoRenderPlugin.cc
+++ b/dqmgui/style/DQMInfoRenderPlugin.cc
@@ -215,7 +215,8 @@ class DQMInfoRenderPlugin : public DQMRenderPlugin {
       for (int binYOrig = 1; binYOrig <= maxBinY; binYOrig++) {
         std::string current_label(source.GetYaxis()->GetBinLabel(binYOrig));
         boost::trim(current_label);
-        if (current_label == wanted_label) {
+        if (current_label == wanted_label
+	    || ((current_label.find("eV") != std::string::npos) && (wanted_label.find("eV") !=std::string::npos))) {
           binYNew++;
           for (int binX = 1; binX < maxBinX; binX++) {
             // We go to 1 less than maxBinX, because, remember that we added


### PR DESCRIPTION
Previously the code has a hard-wired number of sqrt(s)=13 TeV which is not applicable to the Run 3 energy any more. Change the code so that it is flexible regarding the displayed energy in the y-axis label. The updated code would display the energy label saved in the histograms (which is determined in [DQMProvInfo.cc](https://github.com/cms-sw/cmssw/blob/master/DQMServices/Components/plugins/DQMProvInfo.cc), currently 13 TeV, will be updated to 13.6 TeV once this PR is merged.) .

The code has been tested with various output (pp reference run 373710, HI run 375252, and 900 GeV run 378239).