### PR TITLE
Add local trigger information (theta view) to DT layouts and fix  a minor issue in the Private DT DQM GUI customisation

### DIFF
--- a/dqmgui/layouts/dt-layouts.py
+++ b/dqmgui/layouts/dt-layouts.py
@@ -84,6 +84,10 @@ for wheel in range(-2, 3):
     name = f"05-TriggerSynch/Peak-Mean/01-Peak-Mean_Out_Wh{wheel}_TM"
     histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_ResidualBXPhiOut_W{wheel}"
     dtlayout(dqmitems, name,[{ 'path': histo_name}])
+    name = f"05-TriggerSynch/01-CorrectBX_Theta_Wh{wheel}_TM"
+    histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/TM_CorrectBXTheta_W{wheel}"
+    dtlayout(dqmitems, name,[{ 'path': histo_name}])
+
 
 #### TRIGGER BASICS ##############################################################################
 
@@ -175,6 +179,15 @@ for wheel in range(-2, 3):
 for wheel in range(-2, 3):
     for station in range (1, 5):
         for sector in range (1, 13):
-            name = f"11-QualityPhi/Wheel{wheel}/Sector{sector}_Station{station}"
+            name = f"11-TriggerQualityVsPhi/Wheel{wheel}/Sector{sector}_Station{station}"
             histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/Sector{sector}/Station{station}/LocalTriggerPhiIn/TM_QualvsPhirad_In_W{wheel}_Sec{sector}_St{station}"
+            dtlayout(dqmitems, name,[{ 'path': histo_name}])
+
+#### TRIGGER THETA #################################################################################
+
+for wheel in range(-2, 3):
+    for station in range (1, 4):
+        for sector in range (1, 13):
+            name = f"12-TriggerTheta/Wheel{wheel}/Sector{sector}_Station{station}"
+            histo_name = f"DT/03-LocalTrigger-TM/Wheel{wheel}/Sector{sector}/Station{station}/LocalTriggerTheta/TM_PositionvsQual_W{wheel}_Sec{sector}_St{station}"
             dtlayout(dqmitems, name,[{ 'path': histo_name}])

--- a/dqmgui/server-conf-online.py
+++ b/dqmgui/server-conf-online.py
@@ -104,13 +104,13 @@ elif HOSTALIAS == "dqmfu-c2b02-46-01":  # ECAL/HCAL DQMFU
         SERVICENAME = "Online Ecal"
         BASEURL = "/dqm/ecal-online"
 
-elif HOSTALIAS == "dqmfu-c2b03-46-01":  # Muon DQMFU                                                                                              
+elif HOSTALIAS == "dqmfu-c2b03-46-01":  # Muon DQMFU
     if "dtdqm" in USERNAME:
-        COLLPORT = 9090
+        COLLPORT = 9190
         SERVERPORT = 9010
         SERVICENAME = "Online DT"
         BASEURL = "/dqm/dt-online"
-
+    
 # Server configuration.
 modules = ("Monitoring.DQM.GUI",)
 


### PR DESCRIPTION
Following the workflow applied for PR #1302, here is an additional **PR** that:

- adds to `dt-layouts.py` more plots, upon request of the DT P5 experts 
- fix a small bug to `dqmgui/server-conf-online.py` making it consistent with the actual private DT DQM online GUI depoloyed in `dqmfu-c2b03-46-01`

Both were tested using the private deployment of the DQM GUI at P5.
I remain at disposal in case further work is needed on the DT community side.
