### PR TITLE
Add PF Clusters monitoring to DQMGUI

### DIFF
--- a/dqmgui/layouts/pfClusters-layouts.py
+++ b/dqmgui/layouts/pfClusters-layouts.py
@@ -1,0 +1,44 @@
+def pfClusterlayout(
+    i, p, *rows): i["ParticleFlow/Layouts/" + p] = DQMItem(layout=rows)
+
+
+pfClusterlayout(dqmitems, "000 - Compare PFCluster Depths",
+   [{'path':  "ParticleFlow/pfCaloGPUCompDir/pfCluster_Depth_HostvsDevice",
+      'description': "PFCluster depth GPU vs CPU",
+      'draw': {'withref': "no", 'drawopts': "COLZ"}}]
+   )
+
+pfClusterlayout(dqmitems, "001 - Compare PFCluster Duplicates",
+   [{'path':  "ParticleFlow/pfCaloGPUCompDir/pfCluster_Duplicates_HostvsDevice",
+      'description': "PFCluster duplicates GPU vs CPU",
+      'draw': {'withref': "no"}}]
+   )
+
+pfClusterlayout(dqmitems, "002 - Compare PFCluster Energy",
+   [{'path':  "ParticleFlow/pfCaloGPUCompDir/pfCluster_Energy_HostvsDevice",
+      'description': "PFCluster Energy [Gev] GPU vs CPU",
+      'draw': {'withref': "no", 'drawopts': "COLZ"}}]
+   )
+
+pfClusterlayout(dqmitems, "003 - Compare PFCluster eta",
+   [{'path':  "ParticleFlow/pfCaloGPUCompDir/pfCluster_Eta_HostvsDevice",
+      'description': "PFCluster eta GPU vs CPU",
+      'draw': {'withref': "no", 'drawopts': "COLZ"}}]
+
+pfClusterlayout(dqmitems, "004 - Compare PFCluster phi",
+   [{'path':  "ParticleFlow/pfCaloGPUCompDir/pfCluster_Phi_HostvsDevice",
+      'description': "PFCluster Phi GPU vs CPU",
+      'draw': {'withref': "no", 'drawopts': "COLZ"}}]
+   )
+
+pfClusterlayout(dqmitems, "005 - Compare Number of PFCluster",
+   [{'path':  "ParticleFlow/pfCaloGPUCompDir/pfCluster_Multiplicity_HostvsDevice",
+      'description': "Number of PFCluster GPU vs CPU",
+      'draw': {'withref': "no", 'drawopts': "COLZ"}}]
+   )
+
+pfClusterlayout(dqmitems, "006 - Compare PFCluster Rechit multiplicity",
+   [{'path':  "ParticleFlow/pfCaloGPUCompDir/pfCluster_RecHitMultiplicity_HostvsDevice",
+      'description': "RecHit multiplicity in PFClusters GPU vs CPU",
+      'draw': {'withref': "no", 'drawopts': "COLZ"}}]
+   )

--- a/dqmgui/workspaces-dev.py
+++ b/dqmgui/workspaces-dev.py
@@ -46,6 +46,7 @@ server.workspace('DQMContent', 33, 'Trigger/Lumi', 'HLT', '^HLT/', '')
 server.workspace('DQMContent', 41, 'POG', 'Muons', '^Muons/', '')
 server.workspace('DQMContent', 42, 'POG', 'JetMet', '^JetMET/', '')
 server.workspace('DQMContent', 43, 'POG', 'EGamma', '^Egamma/', '')
+server.workspace('DQMContent', 44, 'POG', 'ParticleFlow', '^ParticleFlow/', '')
 
 # CTPPS workspaces:
 server.workspace('DQMContent', 50, 'CTPPS', 'TrackingStrip', '^CTPPS/', 'CTPPS/TrackingStrip/Layouts')

--- a/dqmgui/workspaces-online.py
+++ b/dqmgui/workspaces-online.py
@@ -397,6 +397,8 @@ server.workspace('DQMContent', 43, 'Muons', 'GEM', '^GEM/', '',
                  'GEM/Layouts/Common/56 GE11-P-L1 GEM-CSC segment efficiency', 
                  'GEM/Layouts/Common/57 GE11-P-L2 GEM-CSC segment efficiency',
                 )
+# ParticleFlow workspaces
+server.workspace('DQMContent', 44, 'ParticleFlow', 'ParticleFlow', '^ParticleFlow/', '')
 
 # CTPPS workspaces:
 server.workspace('DQMContent', 50, 'CTPPS', 'TrackingStrip', '^CTPPS/(TrackingStrip|common)/', 'CTPPS/TrackingStrip/Layouts')


### PR DESCRIPTION
This PR adds the layout for displaying PFCluster monitoring in the DQMGUI.

Tested on VM (dev-flavour)

![image](https://github.com/dmwm/deployment/assets/39335169/aa665dd4-20e9-4d00-9c39-4f62d5030ad5)
