### PR TITLE
Recotau layout modified for relval

### DIFF
--- a/dqmgui/layouts/recotau_relval-layouts.py
+++ b/dqmgui/layouts/recotau_relval-layouts.py
@@ -4,29 +4,39 @@ paths = ["DoubleElectron","DoubleMuon","JETHT","QCD","ZEE","ZMM","ZTT"]
 for j in paths:
     recotaulayout(dqmitems, j+"/00_Summary",
             [
-                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/summaryPlot",
-                'description':"none"},
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/summaryPlotDen",
                 'description':"none"},
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/summaryPlotNum",
+                'description':"none"},
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/summaryPlot",
                 'description':"none"},
             ])
     recotaulayout(dqmitems, j+"/01_TauObjects",
             [
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_pt",
                 'description':"none",
-                'draw':{'xmax':'500'}},
+                'draw':{'xmax':'1500'}},
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_eta",
                 'description':"none"},
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_phi",
+                'description':"none"},
+            ],[
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_pu",
                 'description':"none",
                 'draw':{'xmax':'50'}},
-            ],[
-                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_phi",
-                'description':"none"},
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_mass",
                 'description':"none",
                 'draw':{'xmax':'2.0'}},
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_leadTrkPt",
+                'description':"none",
+                'draw':{'xmax':'1000'}},
+            ],[
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_hadrEoP",
+                'description':"none"},
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_hcFraction",
+                'description':"none"},
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_emFraction",
+                'description':"none"},
             ])
     recotaulayout(dqmitems, j+"/02_DecayModes",
             [
@@ -36,7 +46,7 @@ for j in paths:
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/dmMigration",
                 'description':"none",
                 'draw': {"drawopts" : "colz"}},
-                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_decayMode",
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_decayMode_reco",
                 'description':"none"},
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_decayModeFinding",
                 'description':"none"},
@@ -44,7 +54,7 @@ for j in paths:
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/pTOverProng_dm0",
                 'description':"none",
                 'draw': {"drawopts" : "colz","xmax" : "500"}},
-                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/pTOverProng_dm1",
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/pTOverProng_dm1p2",
                 'description':"none",
                 'draw': {"drawopts" : "colz","xmax" : "500"}},
                 {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/pTOverProng_dm10",
@@ -54,22 +64,22 @@ for j in paths:
                 'description':"none",
                 'draw': {"drawopts" : "colz","xmax" : "500"}},
             ])
-    recotaulayout(dqmitems, j+"/03_DeepTau2017v2p1Raw",
+    recotaulayout(dqmitems, j+"/03_DeepTau2018v2p5Raw",
             [
-                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_byDeepTau2017v2p1VSeraw",
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_byDeepTau2018v2p5VSeraw",
                 'description':"none",'draw':{'ytype':'log'}},
-                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_byDeepTau2017v2p1VSjetraw",
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_byDeepTau2018v2p5VSjetraw",
                 'description':"none",'draw':{'ytype':'log'}},
-                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_byDeepTau2017v2p1VSmuraw",
+                {'path':"RecoTauV/miniAODValidation/"+j+"/Summary/tau_byDeepTau2018v2p5VSmuraw",
                 'description':"none",'draw':{'ytype':'log'}},
             ])
 
-    if j == "QCD" or j == "ZTT":
+    if j == "QCD" or j == "ZTT" or j == "JETHT":
         recotaulayout(dqmitems, j+"/04_vsJet",
                 [
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/loose/tau_loosevsJet_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/loose/tau_loosevsJet_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/loose/tau_loosevsJet_phi",
@@ -83,7 +93,7 @@ for j in paths:
                 ],[
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/medium/tau_mediumvsJet_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/medium/tau_mediumvsJet_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/medium/tau_mediumvsJet_phi",
@@ -97,7 +107,7 @@ for j in paths:
                 ],[
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/tight/tau_tightvsJet_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/tight/tau_tightvsJet_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsJet/tight/tau_tightvsJet_phi",
@@ -109,12 +119,12 @@ for j in paths:
                     'description':"none",
                     'draw':{'xmax':'50'}},
                ])
-    if j == "ZEE" or j == "ZTT":
+    if j == "ZEE" or j == "ZTT" or j == "DoubleElectron":
         recotaulayout(dqmitems, j+"/04_vsElectron",
                 [
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/loose/tau_loosevsEle_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/loose/tau_loosevsEle_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/loose/tau_loosevsEle_phi",
@@ -128,7 +138,7 @@ for j in paths:
                 ],[
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/medium/tau_mediumvsEle_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/medium/tau_mediumvsEle_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/medium/tau_mediumvsEle_phi",
@@ -142,7 +152,7 @@ for j in paths:
                 ],[
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/tight/tau_tightvsEle_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/tight/tau_tightvsEle_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsEle/tight/tau_tightvsEle_phi",
@@ -154,12 +164,12 @@ for j in paths:
                     'description':"none",
                     'draw':{'xmax':'50'}},
                ])
-    if j == "ZMM" or j == "ZTT":
+    if j == "ZMM" or j == "ZTT" or j == "DoubleMuon":
         recotaulayout(dqmitems, j+"/04_vsMuon",
                 [
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/loose/tau_loosevsMuo_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/loose/tau_loosevsMuo_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/loose/tau_loosevsMuo_phi",
@@ -173,7 +183,7 @@ for j in paths:
                 ],[
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/medium/tau_mediumvsMuo_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/medium/tau_mediumvsMuo_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/medium/tau_mediumvsMuo_phi",
@@ -187,7 +197,7 @@ for j in paths:
                 ],[
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/tight/tau_tightvsMuo_pt",
                     'description':"none",
-                    'draw':{'xmax':'200'}},
+                    'draw':{'xmax':'1000'}},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/tight/tau_tightvsMuo_eta",
                     'description':"none"},
                     {'path':"RecoTauV/miniAODValidation/"+j+"/vsMuo/tight/tau_tightvsMuo_phi",

--- a/dqmgui/style/RecoTauVRenderPlugin.cc
+++ b/dqmgui/style/RecoTauVRenderPlugin.cc
@@ -73,8 +73,9 @@ class RecoTauVRenderPlugin : public DQMRenderPlugin {
             // checks that object indeed exists
             if(o.name.find("_pt") != std::string::npos){
                 obj->GetXaxis()->SetTitle("pt (GeV)");
-                Double_t bins[12] = {-20,0,20,40,60,80,100,120,140,160,180,200};
-                TH1F* newobj = (TH1F*) obj->Rebin(11,"rebinned",bins);
+                //Double_t bins[12] = {-20,0,20,40,60,80,100,120,140,160,180,200};
+                //TH1F* newobj = (TH1F*) obj->Rebin(11,"rebinned",bins);
+		TH1F* newobj = (TH1F*) obj->Rebin(2);
                 newobj->SetMaximum(newobj->GetMaximum()*1.2);
                 newobj->Draw();
                 c->Modified();
@@ -116,7 +117,7 @@ class RecoTauVRenderPlugin : public DQMRenderPlugin {
                     obj->GetXaxis()->SetTitle("Decay Mode");
                 }
             }
-            if(o.name.find("DeepTau2017v2p1VS") != std::string::npos){
+            if(o.name.find("DeepTau2018v2p5VS") != std::string::npos){
                 if(o.name.find("VSeraw") != std::string::npos){
                     obj->GetXaxis()->SetTitle("raw DeepTauvsElectron");
                 }else if(o.name.find("VSjetraw") != std::string::npos){
@@ -124,7 +125,7 @@ class RecoTauVRenderPlugin : public DQMRenderPlugin {
                 }else if(o.name.find("VSmuraw") != std::string::npos){
                     obj->GetXaxis()->SetTitle("raw DeepTauvsMuon");
                 }
-                TH1F* newobj = (TH1F*) obj->Rebin(10);
+                TH1F* newobj = (TH1F*) obj->Rebin(2);
                 newobj->Draw();
                 c->Modified();
                 return;

--- a/dqmgui/workspaces-relval.py
+++ b/dqmgui/workspaces-relval.py
@@ -55,7 +55,7 @@ server.workspace('DQMContent', 22, 'Data', 'Muon' , '^Muon/', '')
 server.workspace('DQMContent', 23, 'Data', 'Jet' , '^Jet/', '')
 server.workspace('DQMContent', 24, 'Data', 'MET' , '^MET/', '')
 server.workspace('DQMContent', 25, 'Data', 'BTag' , '^BTag/', '')
-server.workspace('DQMContent', 26, 'Data', 'Tau' , '^Tau/', '')
+server.workspace('DQMContent', 26, 'Data', 'Tau' , '^.*Tau.*/', 'RecoTauV/Layouts')
 server.workspace('DQMContent', 27, 'Data', 'PFlow' , '^ParticleFlow/', '')
 server.workspace('DQMContent', 28, 'Data', 'TkAlignment', '', 'DataLayouts/TkAli',
                  'DataLayouts/TkAli/00 - Vertex and vertex tracks quality',


### PR DESCRIPTION
This PR contains a few changes in the relval layout of recotau.

- added a few plots in the layout following the PR [44029](https://github.com/cms-sw/cmssw/pull/44029)
- changed the render plugin for recotau

<img width="1437" alt="Screenshot 2024-06-23 at 16 59 16" src="https://github.com/dmwm/deployment/assets/31443792/a6a7664d-8dc8-4725-ba32-9cbc734fadd0">
<img width="1435" alt="Screenshot 2024-06-23 at 16 59 00" src="https://github.com/dmwm/deployment/assets/31443792/7cafb7d8-4063-4463-85a7-8fd38c8cd534">

