### PR TITLE
[DQM] Add configuration for Offline and RelVal RHEL8 machine names

### DIFF
--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -813,7 +813,9 @@ compile() {
 indexmonitor() {
   refuseproc "index monitoring" "visDQMIndexMonitoring"
   for D in $CONFIGS; do
-    visDQMIndexMonitoring FLAVOR="$D" INSTALLATION_DIR="$TOP"
+    DQM_DATA=$STATEDIR/$D
+    LOGSTEM=$D/agent-indexmonitor
+    visDQMIndexMonitoring FLAVOR="$D" INSTALLATION_DIR="$TOP" ALERT_THRESHOLD="0.95" >>"$LOGDIR/$LOGSTEM-$(hostname -s).log" 2>&1
   done
 }
 
@@ -865,7 +867,7 @@ indexbackup() {
         $DQM_DATA/ix128 \
         $CASTORDIR \
         cms-dqm-coreTeam@cern.ch \
-        </dev/null 2>&1 >>$LOGDIR/$LOGSTEM-$(hostname -s).log
+        </dev/null 2>&1 >>"$LOGDIR/$LOGSTEM-$(hostname -s).log"
       ;;
     esac
   done
@@ -915,7 +917,7 @@ zipbackup() {
         $DQM_DATA/zipped \
         $CASTORDIR \
         $DQM_DATA/agents/verify \
-        </dev/null 2>&1 >>$LOGDIR/$LOGSTEM-$(hostname -s).log
+        </dev/null 2>&1 >>"$LOGDIR/$LOGSTEM-$(hostname -s).log"
       ;;
     esac
   done
@@ -970,7 +972,7 @@ zipbackupcheck() {
         $CASTORDIR \
         24 \
         $DQM_DATA/agents/clean \
-        </dev/null 2>&1 >$LOGDIR/$LOGSTEM-$(printf '%(%Y%m%d)T' -1)-$(hostname -s).log
+        </dev/null 2>&1 >>"$LOGDIR/$LOGSTEM-$(hostname -s).log"
       ;;
     esac
   done

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -101,11 +101,11 @@ vocms0730:*)
   FLAVOR=offline-relval-testing
   _kerberos_init
   ;;
-vocmsNEWOFFLINE:*)
+vocms0736:*)
   FLAVOR=offline
   _kerberos_init
   ;;
-vocmsNEWRELVAL:*)
+vocms0737:*)
   FLAVOR=relval
   _kerberos_init
   ;;
@@ -331,7 +331,7 @@ start_agents() {
   #   online to offline
   # note that the agents to copy zip to castor, verify zip from castor and
   # copy index to castor run as tasks under acron.
-  vocms0738:*agents* | vocmsNEWOFFLINE:*agents*)
+  vocms0738:*agents* | vocms0736:*agents*)
     start_agents_offline
     ;;
   ##### OFFLINE: relval server vocms0739 (CC7)
@@ -341,7 +341,7 @@ start_agents() {
   # - the zip and zipfreeze daemons
   # Note that the agents to copy zip to Castor, verify zip from Castor and
   # copy index to Castor run as tasks under acron.
-  vocms0739:*agents* | vocmsNEWRELVAL:*agents*)
+  vocms0739:*agents* | vocms0737:*agents*)
     start_agents_relval
     ;;
   ##### OFFLINE: test server vocms0731, vocms0730
@@ -445,7 +445,7 @@ start_agents_dqm_test() {
     $STATEDIR/online/ix128
 }
 
-# vocms0738, vocmsNEWOFFLINE
+# vocms0738, vocms0736
 start_agents_offline() {
   refuseproc "file agents" "visDQMIndex|[^/]zip +|OnlineSync|visDQMCreateInfo" "refusing to restart"
   for D in $CONFIGS; do
@@ -510,7 +510,7 @@ start_agents_offline() {
   done
 }
 
-# vocms0739, vocmsNEWRELVAL
+# vocms0739, vocms0737
 start_agents_relval() {
   refuseproc "file agents" "visDQMIndex|[^/]zip +" "refusing to restart"
   for D in $CONFIGS; do
@@ -827,7 +827,7 @@ indexbackup() {
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
     case $HOST:$D in
-    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocmsNEWOFFLINE:offline | vocmsNEWRELVAL:relval)
+    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocms0736:offline | vocms0737:relval)
       CASTORDIR=/eos/cms/store/group/comm_dqm/DQMGUI_Backup/ixbackup/$D
       ;;
     *)
@@ -880,7 +880,7 @@ zipbackup() {
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
     case $HOST:$D in
-    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocmsNEWOFFLINE:offline | vocmsNEWRELVAL:relval)
+    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocms0736:offline | vocms0737:relval)
       CASTORDIR=/eos/cms/store/group/comm_dqm/DQMGUI_Backup/data/$D
       ;;
     *)
@@ -930,7 +930,7 @@ zipbackupcheck() {
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
     case $HOST:$D in
-    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocmsNEWOFFLINE:offline | vocmsNEWRELVAL:relval)
+    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocms0736:offline | vocms0737:relval)
       CASTORDIR=/eos/cms/store/group/comm_dqm/DQMGUI_Backup/data/$D
       ;;
     *)

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -101,6 +101,14 @@ vocms0730:*)
   FLAVOR=offline-relval-testing
   _kerberos_init
   ;;
+vocmsNEWOFFLINE:*)
+  FLAVOR=offline
+  _kerberos_init
+  ;;
+vocmsNEWRELVAL:*)
+  FLAVOR=relval
+  _kerberos_init
+  ;;
 # Private instances get the dev flavor, unless specified differently
 *:cern.ch) FLAVOR=dev ;;
 esac
@@ -323,7 +331,7 @@ start_agents() {
   #   online to offline
   # note that the agents to copy zip to castor, verify zip from castor and
   # copy index to castor run as tasks under acron.
-  vocms0738:*agents*)
+  vocms0738:*agents* | vocmsNEWOFFLINE:*agents*)
     start_agents_offline
     ;;
   ##### OFFLINE: relval server vocms0739 (CC7)
@@ -333,7 +341,7 @@ start_agents() {
   # - the zip and zipfreeze daemons
   # Note that the agents to copy zip to Castor, verify zip from Castor and
   # copy index to Castor run as tasks under acron.
-  vocms0739:*agents*)
+  vocms0739:*agents* | vocmsNEWRELVAL:*agents*)
     start_agents_relval
     ;;
   ##### OFFLINE: test server vocms0731, vocms0730
@@ -437,7 +445,7 @@ start_agents_dqm_test() {
     $STATEDIR/online/ix128
 }
 
-# vocms0738
+# vocms0738, vocmsNEWOFFLINE
 start_agents_offline() {
   refuseproc "file agents" "visDQMIndex|[^/]zip +|OnlineSync|visDQMCreateInfo" "refusing to restart"
   for D in $CONFIGS; do
@@ -502,7 +510,7 @@ start_agents_offline() {
   done
 }
 
-# vocms0739
+# vocms0739, vocmsNEWRELVAL
 start_agents_relval() {
   refuseproc "file agents" "visDQMIndex|[^/]zip +" "refusing to restart"
   for D in $CONFIGS; do
@@ -819,7 +827,7 @@ indexbackup() {
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
     case $HOST:$D in
-    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval)
+    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocmsNEWOFFLINE:offline | vocmsNEWRELVAL:relval)
       CASTORDIR=/eos/cms/store/group/comm_dqm/DQMGUI_Backup/ixbackup/$D
       ;;
     *)
@@ -857,7 +865,7 @@ indexbackup() {
         $DQM_DATA/ix128 \
         $CASTORDIR \
         cms-dqm-coreTeam@cern.ch \
-        </dev/null 2>&1 >$LOGDIR/$LOGSTEM-$(printf '%(%Y%m%d)T' -1)-$(hostname -s).log
+        </dev/null 2>&1 >>$LOGDIR/$LOGSTEM-$(hostname -s).log
       ;;
     esac
   done
@@ -872,7 +880,7 @@ zipbackup() {
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
     case $HOST:$D in
-    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval)
+    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocmsNEWOFFLINE:offline | vocmsNEWRELVAL:relval)
       CASTORDIR=/eos/cms/store/group/comm_dqm/DQMGUI_Backup/data/$D
       ;;
     *)
@@ -907,7 +915,7 @@ zipbackup() {
         $DQM_DATA/zipped \
         $CASTORDIR \
         $DQM_DATA/agents/verify \
-        </dev/null 2>&1 >$LOGDIR/$LOGSTEM-$(printf '%(%Y%m%d)T' -1)-$(hostname -s).log
+        </dev/null 2>&1 >>$LOGDIR/$LOGSTEM-$(hostname -s).log
       ;;
     esac
   done
@@ -922,7 +930,7 @@ zipbackupcheck() {
     # Set default CASTOR directory to a testing area. Only the production
     # servers (Offline and Relval and Dev) get the real thing.
     case $HOST:$D in
-    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval)
+    vocms0731:dev | vocms0730:dev | vocms0738:offline | vocms0739:relval | vocmsNEWOFFLINE:offline | vocmsNEWRELVAL:relval)
       CASTORDIR=/eos/cms/store/group/comm_dqm/DQMGUI_Backup/data/$D
       ;;
     *)

--- a/dqmgui/server-conf-dev.py
+++ b/dqmgui/server-conf-dev.py
@@ -48,8 +48,9 @@ server.extend(
     STATEDIR,
     [
         "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=rovere/CN=653292/CN=Marco Rovere",
-        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=batinkov/CN=739757/CN=Atanas Ivanov Batinkov",
-        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bvanbesi/CN=759373/CN=Broen van Besien",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dpapagia/CN=857294/CN=Dimitrios Papagiannis",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dpapagia/CN=857294/CN=Dimitris Papagiannis",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=gamoreir/CN=844403/CN=Gabriel Moreira Da Silva Campos",
     ],
 )
 server.source("DQMUnknown")

--- a/dqmgui/server-conf-offline.py
+++ b/dqmgui/server-conf-offline.py
@@ -31,7 +31,7 @@ server.logFile = (
 server.title = "CMS data quality"
 
 # Offline production servers
-if hostname == "vocms0738":
+if hostname == "vocms0738" or hostname == "vocmsNEWOFFLINE":
     server.serviceName = "Offline"
     server.baseUrl = "/dqm/offline"
 # Relval test server

--- a/dqmgui/server-conf-offline.py
+++ b/dqmgui/server-conf-offline.py
@@ -58,8 +58,9 @@ server.extend(
     STATEDIR,
     [
         "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=rovere/CN=653292/CN=Marco Rovere",
-        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=batinkov/CN=739757/CN=Atanas Ivanov Batinkov",
-        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bvanbesi/CN=759373/CN=Broen van Besien",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dpapagia/CN=857294/CN=Dimitrios Papagiannis",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dpapagia/CN=857294/CN=Dimitris Papagiannis",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=gamoreir/CN=844403/CN=Gabriel Moreira Da Silva Campos",
     ],
 )
 server.source("DQMUnknown")

--- a/dqmgui/server-conf-offline.py
+++ b/dqmgui/server-conf-offline.py
@@ -31,7 +31,7 @@ server.logFile = (
 server.title = "CMS data quality"
 
 # Offline production servers
-if hostname == "vocms0738" or hostname == "vocmsNEWOFFLINE":
+if hostname == "vocms0738" or hostname == "vocms0736":
     server.serviceName = "Offline"
     server.baseUrl = "/dqm/offline"
 # Relval test server

--- a/dqmgui/server-conf-relval.py
+++ b/dqmgui/server-conf-relval.py
@@ -43,7 +43,7 @@ server.logFile = (
     else "%s/weblog.log" % LOGDIR
 )
 # Relval production servers
-if hostname == "vocms0739" or hostname == "vocmsNEWRELVAL":
+if hostname == "vocms0739" or hostname == "vocms0737":
     server.serviceName = "RelVal"
     server.baseUrl = "/dqm/relval"
 # Relval test server

--- a/dqmgui/server-conf-relval.py
+++ b/dqmgui/server-conf-relval.py
@@ -43,7 +43,7 @@ server.logFile = (
     else "%s/weblog.log" % LOGDIR
 )
 # Relval production servers
-if hostname == "vocms0739":
+if hostname == "vocms0739" or hostname == "vocmsNEWRELVAL":
     server.serviceName = "RelVal"
     server.baseUrl = "/dqm/relval"
 # Relval test server

--- a/dqmgui/server-conf-relval.py
+++ b/dqmgui/server-conf-relval.py
@@ -70,8 +70,9 @@ server.extend(
     STATEDIR,
     [
         "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=rovere/CN=653292/CN=Marco Rovere",
-        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=batinkov/CN=739757/CN=Atanas Ivanov Batinkov",
-        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bvanbesi/CN=759373/CN=Broen van Besien",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dpapagia/CN=857294/CN=Dimitrios Papagiannis",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dpapagia/CN=857294/CN=Dimitris Papagiannis",
+        "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=gamoreir/CN=844403/CN=Gabriel Moreira Da Silva Campos",
     ],
 )
 server.source("DQMUnknown")


### PR DESCRIPTION
Part of the ongoing CentOS7 to RHEL8 migration, this PR adds customization for the `vocms0736` (`offline`) and `vocms0737` (`relval`) machines. 