### PR TITLE
[DQM] Fix order of script output redirections + kerberos ticket management

### DIFF
--- a/dqmgui/kinit.sh
+++ b/dqmgui/kinit.sh
@@ -5,6 +5,7 @@ export keytab=""
 
 # Skip the .service principals
 principal=$(klist -k "$keytab" | grep -v '.service' | tail -1 | grep -oE '[[:alnum:]_-]+@CERN\.CH')
+kdestroy -A >/dev/null 2>&1
 kinit $principal -k -t "$keytab" 2>&1 1>&/dev/null
 if [ $? = 1 ]; then
     echo "Unable to perform kinit for ${principal}."

--- a/dqmgui/kinit.sh
+++ b/dqmgui/kinit.sh
@@ -6,8 +6,7 @@ export keytab=""
 # Skip the .service principals
 principal=$(klist -k "$keytab" | grep -v '.service' | tail -1 | grep -oE '[[:alnum:]_-]+@CERN\.CH')
 kdestroy -A >/dev/null 2>&1
-kinit $principal -k -t "$keytab" 2>&1 1>&/dev/null
-if [ $? = 1 ]; then
+if ! kinit $principal -k -t "$keytab" 2>&1 1>&/dev/null; then
     echo "Unable to perform kinit for ${principal}."
     echo "If you are installing a DQM GUI on lxplus or any other private machine, please comment lines from this block and proceed as usual"
     exit 1

--- a/dqmgui/kinit.sh
+++ b/dqmgui/kinit.sh
@@ -6,7 +6,19 @@ export keytab=""
 # Skip the .service principals
 principal=$(klist -k "$keytab" | grep -v '.service' | tail -1 | grep -oE '[[:alnum:]_-]+@CERN\.CH')
 kdestroy -A >/dev/null 2>&1
-if ! kinit $principal -k -t "$keytab" 2>&1 1>&/dev/null; then
+
+# Try up to # tries times to run kinit.
+tries=${1:-1}
+while [ $tries -gt 0 ]; do
+    if ! kinit $principal -k -t "$keytab" 2>&1 1>&/dev/null; then
+        tries=$((tries - 1))
+        sleep 4
+    else
+        break
+    fi
+done
+
+if [ $tries -eq 0 ]; then
     echo "Unable to perform kinit for ${principal}."
     echo "If you are installing a DQM GUI on lxplus or any other private machine, please comment lines from this block and proceed as usual"
     exit 1

--- a/dqmgui/kinit.sh
+++ b/dqmgui/kinit.sh
@@ -8,7 +8,7 @@ principal=$(klist -k "$keytab" | grep -v '.service' | tail -1 | grep -oE '[[:aln
 kdestroy -A >/dev/null 2>&1
 
 # Try up to # tries times to run kinit.
-tries=${1:-1}
+tries=${1:-2}
 while [ $tries -gt 0 ]; do
     if ! kinit $principal -k -t "$keytab" 2>&1 1>&/dev/null; then
         tries=$((tries - 1))

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -867,7 +867,7 @@ indexbackup() {
         $DQM_DATA/ix128 \
         $CASTORDIR \
         cms-dqm-coreTeam@cern.ch \
-        </dev/null 2>&1 >>"$LOGDIR/$LOGSTEM-$(hostname -s).log"
+        </dev/null >>"$LOGDIR/$LOGSTEM-$(hostname -s).log" 2>&1
       ;;
     esac
   done
@@ -917,7 +917,7 @@ zipbackup() {
         $DQM_DATA/zipped \
         $CASTORDIR \
         $DQM_DATA/agents/verify \
-        </dev/null 2>&1 >>"$LOGDIR/$LOGSTEM-$(hostname -s).log"
+        </dev/null >>"$LOGDIR/$LOGSTEM-$(hostname -s).log" 2>&1
       ;;
     esac
   done
@@ -972,7 +972,7 @@ zipbackupcheck() {
         $CASTORDIR \
         24 \
         $DQM_DATA/agents/clean \
-        </dev/null 2>&1 >>"$LOGDIR/$LOGSTEM-$(hostname -s).log"
+        </dev/null >>"$LOGDIR/$LOGSTEM-$(hostname -s).log" 2>&1
       ;;
     esac
   done

--- a/dqmgui/manage
+++ b/dqmgui/manage
@@ -74,7 +74,9 @@ export STAGE_SVCCLASS=archive
 # when trying to load any DQM GUI instance
 # commenting them works perfectly fine since users alrady have a kerberos token by default
 _kerberos_init() {
-  bash "$TOP/current/config/dqmgui/kinit.sh"
+  # Use source here so that the exit command works and
+  # can terminate execution when needed.
+  source "$TOP/current/config/dqmgui/kinit.sh"
 }
 # Set Flavor for HOST:DOMAIN
 case $HOST:$DOMAIN in


### PR DESCRIPTION
This PR fixes wrong redirection of scripts' output to files, and adds some modifications to kerberos ticket management.

Now, the `kinit.sh` script accepts a single argument, which configures the number of tries that the script will attempt to execute `kinit`. Default, if no argument is present, is `2`. This was added due to spurious failures of the script, which didn't seem to have any obvious reason for failing. Adding a second try fixes that. A 4-second delay has also been added between tries.