### PR TITLE
New HCAL DQM histogram for bad quality events

### DIFF
--- a/dqmgui/layouts/shift_error_layout.py
+++ b/dqmgui/layouts/shift_error_layout.py
@@ -55,3 +55,6 @@ errorlayout(dqmitems, "12 - HCAL LED Misfires",
 errorlayout(dqmitems, "13 - HCAL Bad CapID rotation",
   [{'path':"Hcal/DigiTask/CapID/CapID_BadvsLSmod60", 'description': "Bad CapID values vs FED vs LSmod60", 'draw': { 'withref': "no" }}
   ])
+errorlayout(dqmitems, "14 - HCAL Bad Quality Events",
+  [{'path':"Hcal/RawTask/BadQ_FEDvsLSmod60/BadQ_FEDvsLSmod60", 'description': "Bad Quality Events values vs FED vs LSmod60", 'draw': { 'withref': "no" }}
+  ])

--- a/dqmgui/layouts/shift_error_layout.py
+++ b/dqmgui/layouts/shift_error_layout.py
@@ -53,8 +53,8 @@ errorlayout(dqmitems, "12 - HCAL LED Misfires",
   ])
 
 errorlayout(dqmitems, "13 - HCAL Bad CapID rotation",
-  [{'path':"Hcal/DigiTask/CapID/CapID_BadvsLSmod60", 'description': "Bad CapID values vs FED vs LSmod60", 'draw': { 'withref': "no" }}
+  [{'path':"Hcal/DigiTask/CapID/CapID_BadvsLSmod10", 'description': "Bad CapID values vs FED vs LSmod10", 'draw': { 'withref': "no" }}
   ])
 errorlayout(dqmitems, "14 - HCAL Bad Quality Events",
-  [{'path':"Hcal/RawTask/BadQ_FEDvsLSmod60/BadQ_FEDvsLSmod60", 'description': "Bad Quality Events values vs FED vs LSmod60", 'draw': { 'withref': "no" }}
+  [{'path':"Hcal/RawTask/BadQ_FEDvsLSmod10/BadQ_FEDvsLSmod10", 'description': "Bad Quality Events values vs FED vs LSmod10", 'draw': { 'withref': "no" }}
   ])


### PR DESCRIPTION
A new Online HCAL DQM histogram for bad quality events is added in shift_error_layout.py.
The following lines are added in shift_error_layout.py.

HCAL Bad Quality Events",
  [{'path':"Hcal/RawTask/BadQ_FEDvsLSmod60/BadQ_FEDvsLSmod60", 'description': "Bad Quality Events values vs FED vs LSmod60", 'draw': { 'withref': "no" }}
  ])

