### PR TITLE
Add the section for ES ByLS DQM in GUI

### DIFF
--- a/dqmgui/style/ESRenderPlugin.cc
+++ b/dqmgui/style/ESRenderPlugin.cc
@@ -81,6 +81,8 @@ bool ESRenderPlugin::applies( const VisDQMObject &o, const VisDQMImgInfo & ) {
       return true;
     if ( o.name.find( "EventInfo" ) != std::string::npos )
       return true;
+    if ( o.name.find( "ByLumiSection" ) != std::string::npos )
+      return true;
   }
 
   return false;


### PR DESCRIPTION
This PR handles the styling of the EcalPreshower (ES) DQM plots in the DQM GUI, for the new added ES DQM category of "ByLumiSection" from CMSSW PR [#[46348](https://github.com/cms-sw/cmssw/pull/46348)] and [#[46349](https://github.com/cms-sw/cmssw/pull/46349)].