### PR TITLE
Adding SiPixelAliHLTHG to HG workflow check in DQM GUI rendering

### DIFF
--- a/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
+++ b/dqmgui/style/PCLPixelAlignmentRenderPlugin.cc
@@ -40,7 +40,7 @@ public:
     c->cd();
 
     // Check if HG alignment is used
-    bool isHG = (o.name.find( "SiPixelAliHG" ) != std::string::npos);
+    bool isHG = ((o.name.find( "SiPixelAliHG" ) != std::string::npos) || (o.name.find( "SiPixelAliHLTHG" ) != std::string::npos));
 
 
     if( dynamic_cast<TH1F*>( o.object ) )
@@ -115,7 +115,7 @@ public:
     }
 
     // Check if HG alignment is used
-    bool isHG = (o.name.find( "SiPixelAliHG" ) != std::string::npos);
+    bool isHG = ((o.name.find( "SiPixelAliHG" ) != std::string::npos) || (o.name.find( "SiPixelAliHLTHG" ) != std::string::npos));
 
     if( dynamic_cast<TH1F*>( o.object ) )
     {


### PR DESCRIPTION
This PR adds `"SiPixelAliHLTHG"` to the HG check in the DQM GUI rendering plugin.
This is necessary, since the new HLT-based Pixel Alignments have a new naming scheme starting with `SiPixelAliHLT`, as implemented in CMSSW PR https://github.com/cms-sw/cmssw/pull/46888. 
@mmusich 