### PR TITLE
Add ECAL spike-killer monitoring plots

### DIFF
--- a/dqmgui/layouts/ecal-layouts.py
+++ b/dqmgui/layouts/ecal-layouts.py
@@ -707,6 +707,13 @@ ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/21 noniso_bx_ieta_first
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/First_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_firstbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_FirstCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_FirstCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the first bunch in a bunch train.'}])
 ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/22 noniso_bx_ieta_lastbunch',
            [{'path': 'L1T/L1TObjects/L1TEGamma/timing/Last_bunch/ptmin_20p0_gev/egamma_noniso_bx_ieta_lastbunch_ptmin20p0', 'description': 'L1T EGamma object BX relative to the BX of the L1_LastCollisionInTrain algorithm vs. L1T EGamma object iEta, for events where the L1_LastCollisionInTrain algorithm has fired within +/-2 BX around L1A BX 0. L1T EGamma objects must have pT >= 20 GeV. BX 0 in the histogram marks the last bunch in a bunch train.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/23 Rate of TP vs Et Threshold',
+           [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT Rate of TP with Et above threshold vs Et threshold', 'description': 'Number of TPs above Et threshold in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/24 Rate of TP (Spike-matched) vs Et Threshold',
+           [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT Rate of TP with Et above threshold (spike matched) vs Et threshold', 'description': 'Number of spike-matched TPs above Et threshold in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/25 Efficiency of spike-matching',
+           [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT Efficiency of spike killer matching', 'description': 'Efficiency of spike-matching'}])
+
 
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE
@@ -1092,6 +1099,12 @@ ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/12 DCC-SRP Desync Trend',
          {'path': 'Ecal/Trends/RawDataTask number of EBRDT L1A SRP errors', 'description': 'Trend of the number of L1A value mismatches between DCC and SRP in EB'}],
         [{'path': 'Ecal/Trends/RawDataTask number of EERDT bunch crossing SRP errors', 'description': 'Trend of the number of bunch crossing value mismatches between DCC and SRP in EE.'},
          {'path': 'Ecal/Trends/RawDataTask number of EERDT L1A SRP errors', 'description': 'Trend of the number of L1A value mismatches between DCC and SRP in EE'}])
+ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/13 Trend of Et sum of TPs with Et > 30 GeV',
+        [{'path': 'Ecal/Trends/TriggerTowerTask Et sum of TPs above threshold', 'description': 'Trend of Et sum of TPs with Et > 30 GeV.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/14 Trend of Et sum of Spike-matched TPs with Et > 30 GeV',
+ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/15 PU Trend',
+        [{'path': 'Ecal/Trends/PU per Lumisection', 'description': 'Trend of PU per LS.'}])
+
 
 #____________________ Layouts / 12 By SuperModule ____________________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE

--- a/dqmgui/layouts/ecal_T0_layouts.py
+++ b/dqmgui/layouts/ecal_T0_layouts.py
@@ -668,6 +668,13 @@ ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/12 TT Masking Status',
      [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT TT Masking Status',      'description': 'Trigger tower masking status: a TT or strip is red if it is masked.'}],
      [{'path': 'EcalEndcap/EETriggerTowerTask/EETTT TT Masking Status EE -', 'description': 'Trigger tower masking status: a TT or strip is red if it is masked.'},
       {'path': 'EcalEndcap/EETriggerTowerTask/EETTT TT Masking Status EE +', 'description': 'Trigger tower masking status: a TT or strip is red if it is masked.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/13 Rate of TP vs Et Threshold',
+           [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT Rate of TP with Et above threshold vs Et threshold', 'description': 'Number of TPs above Et threshold in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/14 Rate of TP (Spike-matched) vs Et Threshold',
+           [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT Rate of TP with Et above threshold (spike matched) vs Et threshold', 'description': 'Number of spike-matched TPs above Et threshold in EB'}])
+ecallayout(dqmitems, 'Ecal/Layouts/06 Trigger Primitives/15 Efficiency of spike-matching',
+           [{'path': 'EcalBarrel/EBTriggerTowerTask/EBTTT Efficiency of spike killer matching', 'description': 'Efficiency of spike-matching'}])
+
 
 # By SuperModule _______________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE
@@ -1030,7 +1037,9 @@ ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/11 DCC-SRP Desync Trend',
          {'path': 'Ecal/Trends/RawDataTask number of EBRDT L1A SRP errors', 'description': 'Trend of the number of L1A value mismatches between DCC and SRP in EB'}],
         [{'path': 'Ecal/Trends/RawDataTask number of EERDT bunch crossing SRP errors', 'description': 'Trend of the number of bunch crossing value mismatches between DCC and SRP in EE.'},
          {'path': 'Ecal/Trends/RawDataTask number of EERDT L1A SRP errors', 'description': 'Trend of the number of L1A value mismatches between DCC and SRP in EE'}])
-
+ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/12 Trend of Et sum of TPs with Et > 30 GeV',
+        [{'path': 'Ecal/Trends/TriggerTowerTask Et sum of TPs above threshold', 'description': 'Trend of Et sum of TPs with Et > 30 GeV.'}])
+ecallayout(dqmitems, 'Ecal/Layouts/11 Trend/13 Trend of Et sum of Spike-matched TPs with Et > 30 GeV',
 
 #____________________ Layouts / 12 By SuperModule ____________________
 for (detector, label, maxchannel) in [('Endcap', 'EE', 9), ('Barrel', 'EB', 18)]: # Loop over EB,EE


### PR DESCRIPTION
This PR adds spike-killer monitoring plots for both online and offline ECAL DQM. PRs to CMSSW are made in PR #48278 [[master]](https://github.com/cms-sw/cmssw/pull/48278) and #48277 [[15_0_X]](https://github.com/cms-sw/cmssw/pull/48277). 