### PR TITLE
[DQM] Silence logrotate when called from daily

### DIFF
--- a/dqmgui/daily
+++ b/dqmgui/daily
@@ -59,4 +59,4 @@ done
 
 ######################################################################
 # Rotate logs
-/usr/sbin/logrotate "$TOP/current/apps/dqmgui/128/etc/logrotate.conf" --state "$TOP/state/dqmgui/logrotate.state" --verbose --log "$TOP/logs/dqmgui/logrotate.log"
+/usr/sbin/logrotate "$TOP/current/apps/dqmgui/128/etc/logrotate.conf" --state "$TOP/state/dqmgui/logrotate.state" --verbose --log "$TOP/logs/dqmgui/logrotate.log" &>/dev/null


### PR DESCRIPTION
Since the `daily` script is called from `cron`, and
`logrotate` already puts its logs to the proper
log file through the `--log` argument, there's no
need to keep its output on stdout, as it
gets caught by `cron` and it keeps sending emails.